### PR TITLE
Add unit tests for core module (mostly EasySpeak class)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ warn_unreachable = true
 warn_unused_ignores = true
 
 [tool.ruff.lint]
-# extend-select = ["ALL"]
+extend-select = ["I"]  # "ALL" one day
 extend-ignore = ["D", "E722"]
 
 [tool.setuptools.package-dir]

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -150,6 +150,16 @@ class EasySpeak:
 
     # --- Audio ---
 
+    def flush_stream(self):
+        """Flush any remaining audio data from the stream buffer."""
+        try:
+            self.stream.read(
+                self.stream.get_read_available(),
+                exception_on_overflow=False,
+            )
+        except:  # noqa: E722 - Intentionally catch all to prevent cleanup failures
+            pass
+
     def is_silence(self, audio_chunk):
         return np.abs(audio_chunk).mean() < SILENCE_THRESHOLD
 
@@ -257,13 +267,7 @@ class EasySpeak:
                     # Reset everything
                     self.wakeword.reset()
                     audio_buffer = []
-                    try:
-                        self.stream.read(
-                            self.stream.get_read_available(),
-                            exception_on_overflow=False,
-                        )
-                    except:
-                        pass
+                    self.flush_stream()
 
                     # Audio feedback first
                     subprocess.run(
@@ -272,13 +276,7 @@ class EasySpeak:
                     )
 
                     # Flush any audio captured during beep
-                    try:
-                        self.stream.read(
-                            self.stream.get_read_available(),
-                            exception_on_overflow=False,
-                        )
-                    except:
-                        pass
+                    self.flush_stream()
 
                     # Wait for user to start speaking (up to 5 seconds)
                     first = self.wait_for_speech(timeout=5)
@@ -292,13 +290,7 @@ class EasySpeak:
                             if not self.route_command(cmd.lower().strip(".,!? ")):
                                 break
                             self.wakeword.reset()
-                            try:
-                                self.stream.read(
-                                    self.stream.get_read_available(),
-                                    exception_on_overflow=False,
-                                )
-                            except:
-                                pass
+                            self.flush_stream()
                     else:
                         self.speak("I didn't hear anything.")
 

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -6,16 +6,17 @@ Loads plugins from plugins/ folder automatically.
 Uses OpenWakeWord for fast wake detection.
 """
 
-import subprocess
-import tempfile
-import os
-import sys
 import importlib
+import os
+import subprocess
+import sys
+import tempfile
 import time
-import numpy as np
-import pyaudio
 import wave
 from pathlib import Path
+
+import numpy as np
+import pyaudio
 from faster_whisper import WhisperModel
 from openwakeword.model import Model as WakeWordModel
 
@@ -157,8 +158,8 @@ class EasySpeak:
                 self.stream.get_read_available(),
                 exception_on_overflow=False,
             )
-        except:  # noqa: E722 - Intentionally catch all to prevent cleanup failures
-            pass
+        except:
+            pass  # intentionally catch all to prevent cleanup failures
 
     def is_silence(self, audio_chunk):
         return np.abs(audio_chunk).mean() < SILENCE_THRESHOLD

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,81 @@
+"""Pytest fixtures for core module tests."""
+
+import pytest
+from unittest.mock import Mock
+
+
+def create_mock_plugin(name="TestPlugin", **kwargs) -> Mock:
+    """
+    Factory function to create mock plugin objects.
+
+    Args:
+        name: Plugin name (default: "TestPlugin")
+        **kwargs: Additional attributes to set on the plugin
+            - commands: List of commands to set as COMMANDS attribute
+            - handle_side_effect: Side effect for handle method
+            - handle_return: Return value for handle method
+            - Any other attributes will be set directly on the plugin
+    """
+    plugin = Mock()
+    plugin.NAME = name
+
+    if "commands" in kwargs:
+        plugin.COMMANDS = kwargs.pop("commands")
+
+    plugin.handle = (
+        Mock(side_effect=kwargs.pop("handle_side_effect"))
+        if "handle_side_effect" in kwargs
+        else Mock(return_value=kwargs.pop("handle_return"))
+        if "handle_return" in kwargs
+        else Mock()
+    )
+
+    for key, val in kwargs.items():
+        setattr(plugin, key, val)
+
+    return plugin
+
+
+@pytest.fixture
+def mock_test_plugin():
+    """Create a mock plugin with name 'TestPlugin' that handles commands."""
+    return create_mock_plugin(handle_return=True)
+
+
+@pytest.fixture
+def mock_test_plugin_with_setup():
+    """Create a mock plugin with name 'TestPlugin' that has a setup method."""
+    return create_mock_plugin(setup=Mock())
+
+
+@pytest.fixture
+def mock_test_plugin_no_handle():
+    """Create a mock plugin that doesn't handle commands (returns None)."""
+    return create_mock_plugin(handle_return=None)
+
+
+@pytest.fixture
+def mock_test_plugin_exit():
+    """Create a mock plugin that signals exit (returns False)."""
+    return create_mock_plugin(handle_return=False)
+
+
+@pytest.fixture
+def mock_test_plugin_with_commands():
+    """Create a mock plugin with COMMANDS attribute."""
+    return create_mock_plugin(commands=["cmd1", "cmd2"], handle_return=True)
+
+
+@pytest.fixture
+def mock_multiple_plugins():
+    """Create multiple mock plugins for testing plugin routing."""
+    return [
+        create_mock_plugin(name="Plugin1", handle_return=None),
+        create_mock_plugin(name="Plugin2", handle_return=True),
+    ]
+
+
+@pytest.fixture
+def mock_plugin_with_error():
+    """Create a mock plugin that raises an exception."""
+    return create_mock_plugin(handle_side_effect=ValueError("Test error"))

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -38,33 +38,45 @@ def create_mock_plugin(name="TestPlugin", **kwargs) -> Mock:
 
 
 @pytest.fixture
-def mock_test_plugin():
+def mock_plugin():
     """Create a mock plugin with name 'TestPlugin' that handles commands."""
     return create_mock_plugin(handle_return=True)
 
 
 @pytest.fixture
-def mock_test_plugin_with_setup():
+def mock_plugin_with_setup():
     """Create a mock plugin with name 'TestPlugin' that has a setup method."""
     return create_mock_plugin(setup=Mock())
 
 
 @pytest.fixture
-def mock_test_plugin_no_handle():
+def mock_plugin_no_handle():
     """Create a mock plugin that doesn't handle commands (returns None)."""
     return create_mock_plugin(handle_return=None)
 
 
 @pytest.fixture
-def mock_test_plugin_exit():
+def mock_plugin_exit():
     """Create a mock plugin that signals exit (returns False)."""
     return create_mock_plugin(handle_return=False)
 
 
 @pytest.fixture
-def mock_test_plugin_with_commands():
-    """Create a mock plugin with COMMANDS attribute."""
+def mock_plugin_with_commands_12():
+    """Create a mock plugin with COMMANDS attribute containing cmd1 and cmd2."""
     return create_mock_plugin(commands=["cmd1", "cmd2"], handle_return=True)
+
+
+@pytest.fixture
+def mock_plugin_with_commands_34():
+    """Create a mock plugin with COMMANDS attribute containing cmd3 and cmd4."""
+    return create_mock_plugin(commands=["cmd3", "cmd4"], handle_return=True)
+
+
+@pytest.fixture
+def mock_plugin_without_commands():
+    """Create a mock plugin without COMMANDS attribute."""
+    return Mock(spec=[])
 
 
 @pytest.fixture

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,7 +1,8 @@
 """Pytest fixtures for core module tests."""
 
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 
 def create_mock_plugin(name="TestPlugin", **kwargs) -> Mock:

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -1,9 +1,10 @@
 """Tests for the core main module."""
 
-import sys
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
+
 import numpy as np
 
 # Mock all external dependencies before importing the module

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -1,13 +1,944 @@
 """Tests for the core main module."""
 
-import pytest
+import sys
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+import numpy as np
+
+# Mock all external dependencies before importing the module
+sys.modules["pyaudio"] = MagicMock()
+sys.modules["openwakeword"] = MagicMock()
+sys.modules["openwakeword.model"] = MagicMock()
+sys.modules["faster_whisper"] = MagicMock()
+
+from easyspeak.core.main import EasySpeak  # noqa: E402
 
 
-def test_main():
-    """Importing the main mudule will fail by default."""
-    expected_error = "No module named 'pyaudio'"
+class TestEasySpeakInit:
+    """Tests for EasySpeak initialization."""
 
-    with pytest.raises(ModuleNotFoundError, match=expected_error):
-        from easyspeak.core import main
+    def test_init(self):
+        """Test that EasySpeak initializes with correct default values."""
+        easy = EasySpeak()
 
-        assert "EasySpeak" in dir(main)
+        assert easy.plugins == []
+        assert easy.whisper is None
+        assert easy.wakeword is None
+        assert easy.audio is None
+        assert easy.stream is None
+        assert easy.last_wake_time == 0
+
+
+class TestEasySpeakUtilities:
+    """Tests for EasySpeak utility methods."""
+
+    @patch("subprocess.run")
+    def test_host_run_foreground(self, mock_run):
+        """Test host_run method in foreground mode."""
+        easy = EasySpeak()
+        mock_result = Mock(returncode=0, stdout="output", stderr="")
+        mock_run.return_value = mock_result
+
+        result = easy.host_run(["echo", "test"], background=False)
+
+        mock_run.assert_called_once_with(
+            ["echo", "test"], capture_output=True, text=True
+        )
+        assert result == mock_result
+
+    @patch("subprocess.Popen")
+    def test_host_run_background(self, mock_popen):
+        """Test host_run method in background mode."""
+        easy = EasySpeak()
+        mock_process = Mock()
+        mock_popen.return_value = mock_process
+
+        result = easy.host_run(["echo", "test"], background=True)
+
+        mock_popen.assert_called_once()
+        call_args = mock_popen.call_args
+        assert call_args[0][0] == ["echo", "test"]
+        assert call_args[1]["stdout"] == subprocess.DEVNULL
+        assert call_args[1]["stderr"] == subprocess.DEVNULL
+        assert result == mock_process
+
+    @patch("subprocess.run")
+    @patch("subprocess.Popen")
+    @patch("os.remove")
+    @patch("tempfile.NamedTemporaryFile")
+    def test_speak(self, mock_tempfile, mock_remove, mock_popen, mock_run, capsys):
+        """Test speak method."""
+        easy = EasySpeak()
+
+        # Mock temporary file
+        mock_file = Mock()
+        mock_file.name = "/tmp/test.wav"
+        mock_tempfile.return_value.__enter__.return_value = mock_file
+
+        # Mock piper process
+        mock_piper = Mock()
+        mock_piper.communicate.return_value = (b"", b"")
+        mock_popen.return_value = mock_piper
+
+        easy.speak("Hello world")
+
+        # Check that text was printed
+        captured = capsys.readouterr()
+        assert "💬 Hello world" in captured.out
+
+        # Check that piper was called
+        mock_popen.assert_called_once()
+        assert mock_piper.communicate.called
+
+        # Check that ffplay was called
+        mock_run.assert_called_once()
+
+        # Check that temp file was removed
+        mock_remove.assert_called_once_with("/tmp/test.wav")
+
+
+class TestEasySpeakPlugins:
+    """Tests for EasySpeak plugin management."""
+
+    @patch("importlib.import_module")
+    @patch("sys.path")
+    def test_load_plugins_no_directory(self, mock_syspath, mock_import, capsys):
+        """Test load_plugins when plugins directory doesn't exist."""
+        easy = EasySpeak()
+
+        # Mock plugins directory to not exist
+        with patch.object(Path, "exists", return_value=False):
+            easy.load_plugins()
+
+        captured = capsys.readouterr()
+        assert "No plugins directory found" in captured.out
+        assert easy.plugins == []
+
+    @patch("importlib.import_module")
+    @patch("sys.path")
+    def test_load_plugins_valid_plugin(
+        self, mock_syspath, mock_import, mock_test_plugin_with_setup, capsys
+    ):
+        """Test load_plugins with a valid plugin."""
+        easy = EasySpeak()
+
+        mock_import.return_value = mock_test_plugin_with_setup
+
+        # Mock plugins directory
+        mock_file = Mock()
+        mock_file.name = "test_plugin.py"
+        mock_file.stem = "test_plugin"
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "glob", return_value=[mock_file]),
+        ):
+            easy.load_plugins()
+
+        # Check that plugin was loaded
+        assert len(easy.plugins) == 1
+        assert easy.plugins[0] == mock_test_plugin_with_setup
+        mock_test_plugin_with_setup.setup.assert_called_once_with(easy)
+
+        captured = capsys.readouterr()
+        assert "✓ Loaded: TestPlugin" in captured.out
+
+    @patch("importlib.import_module")
+    @patch("sys.path")
+    def test_load_plugins_skip_underscore_files(
+        self, mock_syspath, mock_import, capsys
+    ):
+        """Test that files starting with underscore are skipped."""
+        easy = EasySpeak()
+
+        # Mock plugins directory with underscore file
+        mock_file = Mock()
+        mock_file.name = "_test_plugin.py"
+        mock_file.stem = "_test_plugin"
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "glob", return_value=[mock_file]),
+        ):
+            easy.load_plugins()
+
+        # Check that no plugins were loaded
+        assert easy.plugins == []
+        mock_import.assert_not_called()
+
+    @patch("importlib.import_module")
+    @patch("sys.path")
+    def test_load_plugins_invalid_plugin(self, mock_syspath, mock_import, capsys):
+        """Test load_plugins with an invalid plugin (missing NAME or handle)."""
+        easy = EasySpeak()
+
+        # Mock plugin module without NAME or handle
+        mock_plugin = Mock(spec=[])
+        mock_import.return_value = mock_plugin
+
+        # Mock plugins directory
+        mock_file = Mock()
+        mock_file.name = "invalid_plugin.py"
+        mock_file.stem = "invalid_plugin"
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "glob", return_value=[mock_file]),
+        ):
+            easy.load_plugins()
+
+        # Check that plugin was not loaded
+        assert easy.plugins == []
+
+        captured = capsys.readouterr()
+        assert "Invalid plugin: invalid_plugin.py" in captured.out
+
+    @patch("importlib.import_module")
+    @patch("sys.path")
+    def test_load_plugins_import_error(self, mock_syspath, mock_import, capsys):
+        """Test load_plugins when import fails."""
+        easy = EasySpeak()
+
+        # Mock import to raise an exception
+        mock_import.side_effect = ImportError("Test error")
+
+        # Mock plugins directory
+        mock_file = Mock()
+        mock_file.name = "broken_plugin.py"
+        mock_file.stem = "broken_plugin"
+
+        with (
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "glob", return_value=[mock_file]),
+        ):
+            easy.load_plugins()
+
+        # Check that plugin was not loaded
+        assert easy.plugins == []
+
+        captured = capsys.readouterr()
+        assert "Failed to load broken_plugin.py" in captured.out
+
+    def test_get_all_commands_empty(self):
+        """Test get_all_commands with no plugins."""
+        easy = EasySpeak()
+
+        commands = easy.get_all_commands()
+
+        assert commands == []
+
+    def test_get_all_commands_with_plugins(self, mock_test_plugin_with_commands):
+        """Test get_all_commands with plugins that have commands."""
+        easy = EasySpeak()
+
+        # Create additional plugin with commands
+        plugin2 = Mock()
+        plugin2.COMMANDS = ["cmd3", "cmd4"]
+
+        plugin3 = Mock(spec=[])  # Plugin without COMMANDS
+
+        easy.plugins = [mock_test_plugin_with_commands, plugin2, plugin3]
+
+        commands = easy.get_all_commands()
+
+        assert commands == ["cmd1", "cmd2", "cmd3", "cmd4"]
+
+
+class TestEasySpeakRouteCommand:
+    """Tests for EasySpeak command routing."""
+
+    def test_route_command_empty(self):
+        """Test route_command with empty command."""
+        easy = EasySpeak()
+
+        result = easy.route_command("")
+
+        assert result is True
+
+    def test_route_command_strip_wake_words(self, mock_test_plugin):
+        """Test that route_command strips wake words."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Test various wake word formats
+        easy.route_command("hey jarvis test command")
+        mock_test_plugin.handle.assert_called_with("test command", easy)
+
+        easy.route_command("hey, jarvis, test command")
+        mock_test_plugin.handle.assert_called_with("test command", easy)
+
+        easy.route_command("jarvis test command")
+        mock_test_plugin.handle.assert_called_with("test command", easy)
+
+    def test_route_command_strip_punctuation(self, mock_test_plugin):
+        """Test that route_command strips punctuation."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        easy.route_command("test command...")
+        mock_test_plugin.handle.assert_called_with("test command", easy)
+
+    def test_route_command_plugin_handles_true(self, mock_test_plugin):
+        """Test route_command when plugin handles command and returns True."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        result = easy.route_command("test command")
+
+        assert result is True
+        mock_test_plugin.handle.assert_called_once()
+
+    def test_route_command_plugin_handles_false(self, mock_test_plugin_exit):
+        """Test route_command when plugin handles command and returns False (exit)."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin_exit]
+
+        result = easy.route_command("exit")
+
+        assert result is False
+        mock_test_plugin_exit.handle.assert_called_once()
+
+    @patch.object(EasySpeak, "speak")
+    def test_route_command_no_matching_plugin(
+        self, mock_speak, mock_test_plugin_no_handle
+    ):
+        """Test route_command when no plugin handles the command."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin_no_handle]
+
+        result = easy.route_command("unknown command")
+
+        assert result is True
+        mock_speak.assert_called_once_with(
+            "I didn't understand. Say help for commands."
+        )
+
+    @patch.object(EasySpeak, "speak")
+    def test_route_command_plugin_error(
+        self, mock_speak, mock_plugin_with_error, capsys
+    ):
+        """Test route_command when plugin raises an exception."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin_with_error]
+
+        result = easy.route_command("test command")
+
+        captured = capsys.readouterr()
+        assert "Plugin error (TestPlugin)" in captured.out
+        assert result is True
+        mock_speak.assert_called_once()
+
+    def test_route_command_multiple_plugins(self, mock_multiple_plugins):
+        """Test route_command with multiple plugins."""
+        easy = EasySpeak()
+        easy.plugins = mock_multiple_plugins
+        result = easy.route_command("test command")
+
+        assert result is True
+        mock_multiple_plugins[0].handle.assert_called_once()
+        mock_multiple_plugins[1].handle.assert_called_once()
+
+
+class TestEasySpeakAudio:
+    """Tests for EasySpeak audio methods."""
+
+    def test_flush_stream_success(self):
+        """Test flush_stream successfully flushes audio buffer."""
+        easy = EasySpeak()
+
+        # Mock stream
+        easy.stream = Mock()
+        easy.stream.get_read_available.return_value = 1280
+        easy.stream.read.return_value = b"\x00\x00" * 1280
+
+        easy.flush_stream()
+
+        # Verify stream was read
+        easy.stream.get_read_available.assert_called_once()
+        easy.stream.read.assert_called_once_with(1280, exception_on_overflow=False)
+
+    def test_flush_stream_exception(self):
+        """Test flush_stream handles exceptions gracefully."""
+        easy = EasySpeak()
+
+        # Mock stream that raises exception
+        easy.stream = Mock()
+        easy.stream.get_read_available.return_value = 1280
+        easy.stream.read.side_effect = Exception("Stream error")
+
+        # Should not raise exception
+        easy.flush_stream()
+
+        # Verify read was attempted
+        easy.stream.read.assert_called_once()
+
+    def test_is_silence_true(self):
+        """Test is_silence returns True for quiet audio."""
+        easy = EasySpeak()
+
+        # Create quiet audio chunk
+        audio_chunk = np.array([10, -10, 5, -5], dtype=np.int16)
+
+        result = easy.is_silence(audio_chunk)
+
+        # Use == instead of is because numpy returns np.bool_ type
+        assert result == True  # noqa: E712
+
+    def test_is_silence_false(self):
+        """Test is_silence returns False for loud audio."""
+        easy = EasySpeak()
+
+        # Create loud audio chunk
+        audio_chunk = np.array([1000, -1000, 500, -500], dtype=np.int16)
+
+        result = easy.is_silence(audio_chunk)
+
+        # Use == instead of is because numpy returns np.bool_ type
+        assert result == False  # noqa: E712
+
+    def test_record_until_silence(self):
+        """Test record_until_silence method."""
+        easy = EasySpeak()
+
+        # Mock stream
+        easy.stream = Mock()
+
+        # Create audio data - first few chunks are loud, then silent
+        loud_audio = np.array([1000] * 1600, dtype=np.int16).tobytes()
+        silent_audio = np.array([10] * 1600, dtype=np.int16).tobytes()
+
+        # Return loud audio for first 10 chunks, then silent
+        audio_sequence = [loud_audio] * 10 + [silent_audio] * 10
+        easy.stream.read = Mock(side_effect=audio_sequence)
+
+        result = easy.record_until_silence()
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_wait_for_speech_found(self):
+        """Test wait_for_speech when speech is detected."""
+        easy = EasySpeak()
+
+        # Mock stream
+        easy.stream = Mock()
+
+        # First chunk is silent, second is loud
+        silent_audio = np.array([10] * 1600, dtype=np.int16).tobytes()
+        loud_audio = np.array([1000] * 1600, dtype=np.int16).tobytes()
+
+        easy.stream.read = Mock(side_effect=[silent_audio, loud_audio])
+
+        result = easy.wait_for_speech(timeout=5)
+
+        assert result == loud_audio
+
+    def test_wait_for_speech_timeout(self):
+        """Test wait_for_speech when no speech is detected (timeout)."""
+        easy = EasySpeak()
+
+        # Mock stream
+        easy.stream = Mock()
+
+        # All chunks are silent
+        silent_audio = np.array([10] * 1600, dtype=np.int16).tobytes()
+        easy.stream.read = Mock(return_value=silent_audio)
+
+        result = easy.wait_for_speech(timeout=0.1)  # Short timeout for testing
+
+        assert result is None
+
+    @patch("wave.open")
+    @patch("os.remove")
+    @patch("tempfile.NamedTemporaryFile")
+    def test_transcribe(self, mock_tempfile, mock_remove, mock_wave):
+        """Test transcribe method."""
+        easy = EasySpeak()
+
+        # Mock whisper model
+        easy.whisper = Mock()
+        mock_segment = Mock()
+        mock_segment.text = "Hello world"
+        easy.whisper.transcribe = Mock(return_value=([mock_segment], None))
+
+        # Mock temporary file
+        mock_file = Mock()
+        mock_file.name = "/tmp/test.wav"
+        mock_tempfile.return_value.__enter__.return_value = mock_file
+
+        # Mock wave file
+        mock_wf = Mock()
+        mock_wave.return_value.__enter__.return_value = mock_wf
+
+        # Test transcription
+        audio_data = b"test audio data"
+        result = easy.transcribe(audio_data)
+
+        assert result == "Hello world"
+        mock_remove.assert_called_once_with("/tmp/test.wav")
+
+    @patch("wave.open")
+    @patch("os.remove")
+    @patch("tempfile.NamedTemporaryFile")
+    def test_transcribe_with_custom_prompt(self, mock_tempfile, mock_remove, mock_wave):
+        """Test transcribe method with custom prompt."""
+        easy = EasySpeak()
+
+        # Mock whisper model
+        easy.whisper = Mock()
+        mock_segment = Mock()
+        mock_segment.text = "Custom prompt test"
+        easy.whisper.transcribe = Mock(return_value=([mock_segment], None))
+
+        # Mock temporary file
+        mock_file = Mock()
+        mock_file.name = "/tmp/test.wav"
+        mock_tempfile.return_value.__enter__.return_value = mock_file
+
+        # Mock wave file
+        mock_wf = Mock()
+        mock_wave.return_value.__enter__.return_value = mock_wf
+
+        # Test transcription with custom prompt
+        audio_data = b"test audio data"
+        custom_prompt = "custom prompt"
+        result = easy.transcribe(audio_data, prompt=custom_prompt)
+
+        assert result == "Custom prompt test"
+
+        # Check that whisper was called with custom prompt
+        call_args = easy.whisper.transcribe.call_args
+        assert call_args[1]["initial_prompt"] == custom_prompt
+
+    @patch("wave.open")
+    @patch("os.remove")
+    @patch("tempfile.NamedTemporaryFile")
+    def test_transcribe_multiple_segments(self, mock_tempfile, mock_remove, mock_wave):
+        """Test transcribe method with multiple segments."""
+        easy = EasySpeak()
+
+        # Mock whisper model with multiple segments
+        easy.whisper = Mock()
+        segment1 = Mock()
+        segment1.text = "Hello"
+        segment2 = Mock()
+        segment2.text = " world"
+        easy.whisper.transcribe = Mock(return_value=([segment1, segment2], None))
+
+        # Mock temporary file
+        mock_file = Mock()
+        mock_file.name = "/tmp/test.wav"
+        mock_tempfile.return_value.__enter__.return_value = mock_file
+
+        # Mock wave file
+        mock_wf = Mock()
+        mock_wave.return_value.__enter__.return_value = mock_wf
+
+        # Test transcription
+        audio_data = b"test audio data"
+        result = easy.transcribe(audio_data)
+
+        # The join adds a space between segments
+        assert result == "Hello  world"
+
+
+class TestEasySpeakRun:
+    """Tests for EasySpeak run method."""
+
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    def test_run_no_plugins(
+        self, mock_load_plugins, mock_whisper_model, mock_wakeword_model, capsys
+    ):
+        """Test run method exits early when no plugins are loaded."""
+        easy = EasySpeak()
+
+        # Mock that no plugins were loaded
+        mock_load_plugins.return_value = None
+        easy.plugins = []
+
+        easy.run()
+
+        # Check that models were initialized
+        mock_wakeword_model.assert_called_once()
+        mock_whisper_model.assert_called_once()
+        mock_load_plugins.assert_called_once()
+
+        # Check output
+        captured = capsys.readouterr()
+        assert "No plugins loaded. Exiting." in captured.out
+
+    @patch("subprocess.run")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    def test_run_with_keyboard_interrupt(
+        self,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_subprocess_run,
+        mock_test_plugin,
+        capsys,
+    ):
+        """Test run method handles KeyboardInterrupt gracefully."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Mock PyAudio and stream
+        mock_audio = Mock()
+        mock_stream = Mock()
+        mock_stream.read.side_effect = KeyboardInterrupt()
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        easy.run()
+
+        # Check that audio was properly terminated
+        mock_stream.stop_stream.assert_called_once()
+        mock_stream.close.assert_called_once()
+        mock_audio.terminate.assert_called_once()
+
+        # Check output
+        captured = capsys.readouterr()
+        assert "Bye!" in captured.out
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "record_until_silence")
+    @patch.object(EasySpeak, "transcribe")
+    @patch.object(EasySpeak, "route_command")
+    @patch.object(EasySpeak, "flush_stream")
+    def test_run_wake_word_detected_with_command(
+        self,
+        mock_flush_stream,
+        mock_route_command,
+        mock_transcribe,
+        mock_record,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_test_plugin,
+        capsys,
+    ):
+        """Test run method when wake word is detected and command is processed."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Mock time for cooldown
+        mock_time.return_value = 100.0
+
+        # Mock PyAudio and stream
+        mock_audio = Mock()
+        mock_stream = Mock()
+
+        # Need multiple reads: initial loop read, second loop (interrupt)
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.side_effect = [
+            pcm_data,  # First read in main loop
+            KeyboardInterrupt(),  # Second loop iteration
+        ]
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        # Mock wake word model to detect wake word on first call
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        # Mock speech detection and transcription
+        mock_wait.return_value = b"audio_data"
+        mock_record.return_value = b"more_audio"
+        mock_transcribe.return_value = "test command"
+        mock_route_command.return_value = True
+
+        easy.run()
+
+        # Check that wake word was detected
+        captured = capsys.readouterr()
+        assert "Wake!" in captured.out
+        assert "test command" in captured.out
+
+        # Check that methods were called
+        mock_wait.assert_called_once_with(timeout=5)
+        mock_record.assert_called_once()
+        mock_transcribe.assert_called_once()
+        mock_route_command.assert_called_once()
+
+        # Check that flush_stream was called (3 times: after wake, after beep, after command)
+        assert mock_flush_stream.call_count == 3
+
+        # Check cleanup
+        mock_stream.stop_stream.assert_called_once()
+        mock_stream.close.assert_called_once()
+        mock_audio.terminate.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "speak")
+    @patch.object(EasySpeak, "flush_stream")
+    def test_run_wake_word_detected_no_speech(
+        self,
+        mock_flush_stream,
+        mock_speak,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_test_plugin,
+        capsys,
+    ):
+        """Test run method when wake word is detected but no speech follows."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Mock time for cooldown
+        mock_time.return_value = 100.0
+
+        # Mock PyAudio and stream
+        mock_audio = Mock()
+        mock_stream = Mock()
+
+        # Multiple reads: initial loop read, second loop (interrupt)
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.side_effect = [
+            pcm_data,  # First read in main loop
+            KeyboardInterrupt(),  # Second loop iteration
+        ]
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        # Mock wake word model to detect wake word
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        # Mock no speech detected
+        mock_wait.return_value = None
+
+        easy.run()
+
+        # Check that "I didn't hear anything" was spoken
+        mock_speak.assert_called_once_with("I didn't hear anything.")
+
+        # Check that flush_stream was called (2 times: after wake, after beep)
+        assert mock_flush_stream.call_count == 2
+
+        # Check cleanup
+        mock_stream.stop_stream.assert_called_once()
+        mock_stream.close.assert_called_once()
+        mock_audio.terminate.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "record_until_silence")
+    @patch.object(EasySpeak, "transcribe")
+    @patch.object(EasySpeak, "route_command")
+    @patch.object(EasySpeak, "flush_stream")
+    def test_run_wake_word_cooldown(
+        self,
+        mock_flush_stream,
+        mock_route_command,
+        mock_transcribe,
+        mock_record,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_test_plugin,
+        capsys,
+    ):
+        """Test run method respects wake word cooldown period."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Mock time to simulate cooldown - first call within cooldown, second after
+        mock_time.side_effect = [
+            100.0,
+            101.0,
+            105.0,
+        ]  # 101 is within cooldown, 105 is after
+        easy.last_wake_time = 100.0
+
+        # Mock PyAudio and stream
+        mock_audio = Mock()
+        mock_stream = Mock()
+
+        # Multiple reads: first triggers cooldown skip, second triggers processing, then interrupt
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.side_effect = [
+            pcm_data,  # First read - within cooldown, skip
+            pcm_data,  # Second read - after cooldown, process
+            pcm_data,  # Loop back for next iteration
+            KeyboardInterrupt(),  # Exit
+        ]
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        # Mock wake word model to detect wake word on both calls
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        # Mock speech detection and transcription
+        mock_wait.return_value = b"audio_data"
+        mock_record.return_value = b"more_audio"
+        mock_transcribe.return_value = "test command"
+        mock_route_command.return_value = True
+
+        easy.run()
+
+        # Check that command was only processed once (first wake word was within cooldown)
+        assert mock_route_command.call_count == 1
+
+        # Check cleanup
+        mock_stream.stop_stream.assert_called_once()
+        mock_stream.close.assert_called_once()
+        mock_audio.terminate.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "record_until_silence")
+    @patch.object(EasySpeak, "transcribe")
+    @patch.object(EasySpeak, "route_command")
+    def test_run_exit_command(
+        self,
+        mock_route_command,
+        mock_transcribe,
+        mock_record,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_test_plugin,
+        capsys,
+    ):
+        """Test run method exits when route_command returns False."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Mock time
+        mock_time.return_value = 100.0
+
+        # Mock PyAudio and stream
+        mock_audio = Mock()
+        mock_stream = Mock()
+
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.return_value = pcm_data
+        mock_stream.get_read_available.return_value = 0
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        # Mock wake word model to detect wake word
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        # Mock speech detection and transcription
+        mock_wait.return_value = b"audio_data"
+        mock_record.return_value = b"more_audio"
+        mock_transcribe.return_value = "exit"
+        mock_route_command.return_value = False  # Exit command
+
+        easy.run()
+
+        # Check that route_command was called and returned False
+        mock_route_command.assert_called_once()
+
+        # Check cleanup
+        mock_stream.stop_stream.assert_called_once()
+        mock_stream.close.assert_called_once()
+        mock_audio.terminate.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.WhisperModel")
+    @patch.object(EasySpeak, "load_plugins")
+    def test_run_audio_buffer_management(
+        self,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_test_plugin,
+        capsys,
+    ):
+        """Test run method manages audio buffer correctly when it exceeds 50 items."""
+        easy = EasySpeak()
+        easy.plugins = [mock_test_plugin]
+
+        # Mock time
+        mock_time.return_value = 100.0
+
+        # Mock PyAudio and stream
+        mock_audio = Mock()
+        mock_stream = Mock()
+
+        # Create a long sequence of reads to fill buffer > 50
+        pcm_data = b"\x00\x00" * 1280
+        # 52 reads to ensure buffer management is triggered (first pop happens at 51st iteration)
+        read_sequence = [pcm_data] * 52 + [KeyboardInterrupt()]
+        mock_stream.read.side_effect = read_sequence
+        mock_stream.get_read_available.return_value = 0
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        # Mock wake word model to never detect (score below threshold)
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {
+            "hey_jarvis": 0.3
+        }  # Below threshold
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        easy.run()
+
+        # Verify that the buffer was managed (should have read enough times to trigger buffer management)
+        # The buffer pop happens after 51st item, so we verify that many reads happened
+        assert mock_stream.read.call_count >= 52
+
+        # Check cleanup
+        mock_stream.stop_stream.assert_called_once()
+        mock_stream.close.assert_called_once()
+        mock_audio.terminate.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 
 [[package]]
 name = "ai-edge-litert"
-version = "2.1.1"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-strenum" },
@@ -25,15 +25,15 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/63/2361383f7554b2c623633af372db016766f55845610f34029cfaa870e855/ai_edge_litert-2.1.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3ff9277963a0c13573bed3c16243420bc03c011bd3b4259e3f8b6a4395f8f0c6", size = 5694639, upload-time = "2026-01-27T09:44:37.326Z" },
-    { url = "https://files.pythonhosted.org/packages/40/65/3ac6c34ec7188e773c12bb13cac47dc09a4d10e3c6ef7ded2cb52ab03a91/ai_edge_litert-2.1.1-cp310-cp310-manylinux_2_27_aarch64.whl", hash = "sha256:4802c74607aed7c4179691f598442c8d15e911d7c36bcf1991c994a1b436dc06", size = 7787484, upload-time = "2026-01-27T09:26:37.523Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d6/5b08abdcad560546ad43902570267142898ce7f7758d5d628d1b645c656d/ai_edge_litert-2.1.1-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:805b1727062f6fce17e40dcc0764de3db82380aa9dda64a567c36b721fc8baf6", size = 9570099, upload-time = "2026-01-27T09:20:21.853Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/44/055e0fbffcfc7a4c58940cfa5625632f6a52b964173aad42417097f3179b/ai_edge_litert-2.1.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:8c32214ee34202d8d46066f73c69ad0a258583852fb7d7ac55105683e3127028", size = 5695989, upload-time = "2026-01-27T09:44:39.077Z" },
-    { url = "https://files.pythonhosted.org/packages/37/5a/8f74e1311467204401e01b9acc265f4465929c17c23cf0c8ff1e3042fbe1/ai_edge_litert-2.1.1-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:00508a1d289b5662f78a6f2779b2ed1e11b9fd83df39d384468ba6f9a16ce621", size = 7789836, upload-time = "2026-01-27T09:26:38.975Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/34/57e8207c65210ea6b424c37d07885542188cf1efae00296d0c29024b6b07/ai_edge_litert-2.1.1-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:bfeb8e026691afec82e2c17f7352607246d0b735aa7a0bc30640b0d4c4924c3d", size = 9572637, upload-time = "2026-01-27T09:20:23.604Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/3b/bbeb4d89f4fada090e6101e604b7878a29c1bb7682f1be368fdf68467c24/ai_edge_litert-2.1.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:1a4bfaf9dd66b6c147dde47bb983e325e8a4372375f5f3ce2453a23910ffe0e5", size = 5697059, upload-time = "2026-01-27T09:44:40.408Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/25/779e5747344b34422edbd5fee0448679719729da39e8829bf617fb3e8845/ai_edge_litert-2.1.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:f1254abbfe0faf3f3728ff684127cc6ef26064fe437226c9374fc5df784af8c2", size = 7790959, upload-time = "2026-01-27T09:26:40.818Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/21/d9a24bd9a161f74e4a09be048978f5f021fc5733c22a0174ff603035bdb3/ai_edge_litert-2.1.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:1e57407f317baffbe92b9eee9ad8f2201616cdb251e19d79a39497eace2ca7e5", size = 9575157, upload-time = "2026-01-27T09:20:25.213Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/0fbc63f8e076008481bc21af0d5085501555757194c7c1daaf2542cd7a82/ai_edge_litert-2.1.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0a7dd5d3b7874ba66a382b261bffe2a3d9ef772b841f47aabed0982d6025e0e5", size = 13013547, upload-time = "2026-01-28T07:22:43.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/50/c55cc44c71fce9ef9a567928cdb80f03719b4c5b8309cceb8fad8f549e52/ai_edge_litert-2.1.2-cp310-cp310-manylinux_2_27_aarch64.whl", hash = "sha256:164435bc7ab3426b0c23f4732bd4e2eb8f49d3dde1324901dca5d749cc65a9c9", size = 12631608, upload-time = "2026-01-28T07:05:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/35/52fae12e74e9ee8c8e4e6a99cf478f3379e10a0a272e717b7915e2fa8922/ai_edge_litert-2.1.2-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:e54c8a9006ccbe435a1b4cd91953ffc9bea41e42d7be886ca80a3f3192cdd30c", size = 16323818, upload-time = "2026-01-28T07:00:04.785Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f9/ba44382f353a2b845e9b6242750a7d56b0054ab6c6bcf53d20823bae58e4/ai_edge_litert-2.1.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:07c3f442212de1859dddbcd51ff90f2fcb3048d940a1bddbd6f13b04e5a79083", size = 13014557, upload-time = "2026-01-28T07:22:46.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5a/57d9b8967fa5a2f3055ad3e7666446c8d2271446319e7f17c897b151544c/ai_edge_litert-2.1.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:7dc4afc4b67797e77d879e35ad558e60f746be7c1e616a6653bd2cbf1ffef9ad", size = 12633093, upload-time = "2026-01-28T07:05:38.638Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a8/c8024c9657a76e3589cf2b8b21cbccdef0b9a64b74d98eebcabbbdfaeb7a/ai_edge_litert-2.1.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:b3ff3b12df45dfc540934e33bde9af474b0b4c12c3bb6112b251aaae4d2930a0", size = 16326113, upload-time = "2026-01-28T07:00:07.441Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/59/5f65a091340c6abf26c66a11fc0c8ecbd264e93ad7293aaf1f1b6892cc00/ai_edge_litert-2.1.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:20c96357a7c61600e7ec94a8c131fee4c0a994132e5e6e436c7c7e93d3f31b22", size = 13016970, upload-time = "2026-01-28T07:22:48.654Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/36/8ff07084091272db4df8de3859149be3913a6eaf2939575bb4200379b808/ai_edge_litert-2.1.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:1b412368980b404aa051d09405abd473d3a15130db030938d26966f1a1e7c413", size = 12633952, upload-time = "2026-01-28T07:05:40.805Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/05/072e76dfa2bfd6aa4c5751f1b6d5ad11f74bba70177ad4c973b49678d4c2/ai_edge_litert-2.1.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:67db6de7c729bbe5a31c20adc573ce47b8aa6ea4b6bcfee0ab77ff1a51e20f2e", size = 16330794, upload-time = "2026-01-28T07:00:09.906Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds comprehensive unit tests for the core module, also slightly refactoring the code to reduce duplication and allow for simpler testing.

Most of the test code was written by GitHub Copilot but with substantial human guidance through several rounds of code review.

Updates the dependencies again (`ai-edge-litert` patch version bump).

## Test Coverage

```
Name                          Stmts   Miss  Cover   Missing
-----------------------------------------------------------
src/core/__init__.py              0      0   100%
src/core/main.py                176      0   100%
src/plugins/00_eyetrack.py      266    266     0%   6-511
src/plugins/00_mousegrid.py     246    246     0%   10-516
src/plugins/__init__.py           0      0   100%
src/plugins/apps.py              50     50     0%   5-93
src/plugins/browser.py          269    269     0%   5-573
src/plugins/dictation.py         58     58     0%   5-243
src/plugins/files.py             25     25     0%   5-64
src/plugins/media.py             37     37     0%   5-92
src/plugins/system.py            57     57     0%   5-122
src/plugins/zz_base.py           28     28     0%   5-50
-----------------------------------------------------------
TOTAL                          1212   1036    15%
```