### PR TITLE
Run software safety related jobs only once a day

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -16,11 +16,9 @@ jobs:
     strategy:
       matrix:
         task:
-        - format
+        - format --diff
         - lint
         - types
-        - audit
-        - requirements
         - package
         - functional
       fail-fast: false

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -1,0 +1,22 @@
+name: Safety
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  safety:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+        - audit
+        - requirements
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.12'
+    - uses: extractions/setup-just@v3
+    - run: just ${{ matrix.task }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Say "Hey Jarvis" and control your desktop with your voice.
 ![Platform](https://img.shields.io/badge/platform-Linux-lightgrey.svg)
 ![Desktop](https://img.shields.io/badge/desktop-GNOME%20%7C%20Wayland-green.svg)
 ![Status](https://img.shields.io/badge/status-Alpha-orange.svg)
-[![Pipeline](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions)
+[![Pipeline](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml)
+[![Safety](https://github.com/ctsdownloads/easyspeak/actions/workflows/safety.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/safety.yml)
 
 > ⚠️ **Early development.** This project works but is not polished. Expect bugs, incomplete docs, and changes without notice.
 


### PR DESCRIPTION
To make the GHA jobs related to safety (audit, requirements) less disturbing we can run them independently from all PRs, e.g. with a schedule, once every day or so. This will turn all ticks green on our PRs, finally. :vertical_traffic_light: 

The format job should also better show a diff of the proposed changes directly, so it's more useful.