### PR TITLE
Build Python package, configure automatic release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.12'
+    - uses: extractions/setup-just@v3
+    - name: Build the Python package
+      run: just package
+    - name: Verify that package version matches Git tag
+      run: just ensure_version_matches ${{ github.ref_name }}
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/justfile
+++ b/justfile
@@ -76,11 +76,11 @@ coverage:
 [group('tests')]
 functional: (clean '--quiet') (package '--quiet')
     # Python package should not contain tests (MANIFEST.in)
-    ! unzip -l dist/easyspeak-*-py3-none-any.whl | grep tests
-    ! tar tfz dist/easyspeak-*.tar.gz | grep tests
+    ! unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep tests
+    ! tar tfz dist/easyspeak_linux-*.tar.gz | grep tests
     # Python package should contain Core module
-    tar tfz dist/easyspeak-*.tar.gz | grep -q core
-    unzip -l dist/easyspeak-*-py3-none-any.whl | grep -q core
+    tar tfz dist/easyspeak_linux-*.tar.gz | grep -q core
+    unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q core
 
 # Build package and check metadata
 [group('release')]
@@ -92,7 +92,7 @@ package *args:
 ensure_version_matches tag:
     python -c '\
     from importlib.metadata import version ;\
-    ver = version("easyspeak") ;\
+    ver = version("easyspeak-linux") ;\
     tag = "{{ tag }}" ;\
     error = f"`{ver}` != `{tag}`" ;\
     abort = f"Package version does not match the Git tag ({error}). ABORTING." ;\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools>=77", "setuptools_scm>=9"]
 
 [project]
-name = "easyspeak"
+name = "easyspeak-linux"
 dynamic = ["version"]
 description = "Voice control for Linux desktops. Fully local, no cloud, Wayland-native."
 license = "GPL-3.0-only"


### PR DESCRIPTION
Adds a GitHub Actions (GHA) workflow that automatically builds a Python package (named "easyspeak-linux") and publishes it on PyPI whenever a Git tag is pushed.

The Git tag is expected to follow [semver](https://semver.org), i.e. `<major>.<minor>.<patch>`, e.g. `1.0.0`.

Closes #16 

## Background Information

I prepared a "publisher" for this repository on PyPI.

<img width="780" height="173" alt="image" src="https://github.com/user-attachments/assets/d04fdf9d-803f-4d01-94ed-fc3f4be49a33" />

### TODO :bookmark_tabs: 

@ctsdownloads

1. You need to [create an environment](https://github.com/ctsdownloads/easyspeak/settings/environments) named "pypi" in the project settings. The final steps of the publishing workflow will only work if this is configured.
2. _After_ this PR is _merged_, you must create a Git tag `0.1.0` on the "[First release v0.1.0](https://github.com/ctsdownloads/easyspeak/pull/32/commits/556365ac88bc72c0e5bd83a7328296f5b856424a)" commit (and push this tag to GitHub), e.g.

```console
git tag 0.1.0 556365ac88
git push 0.1.0
```

### Motivation

Username/Password authentication is no longer supported:

```python
$ just publish
...
uv publish
Publishing 2 files to https://upload.pypi.org/legacy/
Enter username ('__token__' if using a token):
Enter password:
Uploading easyspeak_linux-0.1.0.tar.gz (125.8KiB)
error: Failed to publish `dist/easyspeak_linux-0.1.0.tar.gz` to https://upload.pypi.org/legacy/
  Caused by: Upload failed with status code 403 Forbidden. Server says: 403 Username/Password authentication is no longer supported. Migrate to API Tokens or Trusted Publishers instead. See https://pypi.org/help/#apitoken and https://pypi.org/help/#trusted-publishers
```

### Reading Resources

- [Creating a PyPI project with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) (to create the above)
- [Publishing with a Trusted Publisher](https://docs.pypi.org/trusted-publishers/using-a-publisher/) (GHA example)
- [How environments relate to deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#how-environments-relate-to-deployments) (GitHub docs)
