### PR TITLE
Run safety workflow also in PRs

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -1,6 +1,14 @@
 name: Safety
 
 on:
+  pull_request:
+    branches:
+    - main
+    - dev
+  push:
+    branches:
+    - main
+    - dev
   schedule:
   - cron: "0 0 * * *"
 


### PR DESCRIPTION
It's tedious to find out on the next day after merging a PR or pushing to the default branch that requirements would have needed to be updated. Also, there seems to be no way to trigger a scheduled workflow manually from the GitHub user interface.