### PR TITLE
Fix No plugins directory found error

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -80,7 +80,7 @@ class EasySpeak:
     # --- Plugin management ---
 
     def load_plugins(self):
-        plugins_dir = Path(__file__).parent / "plugins"
+        plugins_dir = Path(__file__).parent.parent / "plugins"
         if not plugins_dir.exists():
             print("No plugins directory found")
             return

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -221,6 +221,25 @@ class TestEasySpeakPlugins:
         captured = capsys.readouterr()
         assert "Failed to load broken_plugin.py" in captured.out
 
+    def test_load_plugins_loads_all_shipped_plugins(self):
+        """All shipped plugins are discovered against the real filesystem layout."""
+        easy = EasySpeak()
+
+        easy.load_plugins()
+        loaded = {module.__name__.rsplit(".", 1)[-1] for module in easy.plugins}
+
+        assert loaded == {
+            "00_eyetrack",
+            "00_mousegrid",
+            "apps",
+            "browser",
+            "dictation",
+            "files",
+            "media",
+            "system",
+            "zz_base",
+        }
+
     def test_get_all_commands_empty(self):
         """Test get_all_commands with no plugins."""
         easy = EasySpeak()


### PR DESCRIPTION
I'm receiving this error upon starting easyspeak:

Loading plugins...
No plugins directory found
No plugins loaded. Exiting.

In this block:

```
def load_plugins(self):
        plugins_dir = Path(__file__).parent / "plugins"
        if not plugins_dir.exists():
            print("No plugins directory found")
            return
```

`plugins_dir = Path(__file__).parent / "plugins" `

should be

`plugins_dir = Path(__file__).parent.parent / "plugins"`

to search for "plugins" folder in parent dir of parent dir of main.py (home/username/easyspeak/src/).