### PR TITLE
Fix mousegrid error caused by duplicate import

### DIFF
--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -277,7 +277,6 @@ def get_screen_size():
 
     if result.returncode == 0:
         # Parse output like "((1920, 1200),)"
-        import re
 
         match = re.search(r"\((\d+),\s*(\d+)\)", result.stdout)
         if match:

--- a/tests/plugins/test_mousegrid.py
+++ b/tests/plugins/test_mousegrid.py
@@ -362,6 +362,19 @@ def test_get_screen_size_with_fallback_to_drm(mock_host_run):
     assert result == (2560, 1440)
 
 
+@patch.object(mousegrid_plugin, "host_run")
+def test_get_screen_size_drm_fallback_when_gdbus_returncode_nonzero(mock_host_run):
+    """When gdbus fails outright get_screen_size still parses drm output (PR #48)."""
+    mock_host_run.side_effect = [
+        Mock(returncode=1, stdout=""),
+        Mock(returncode=0, stdout="2560x1440@60\n"),
+    ]
+
+    result = mousegrid_plugin.get_screen_size()
+
+    assert result == (2560, 1440)
+
+
 @pytest.mark.parametrize(
     ["text", "expected"],
     [


### PR DESCRIPTION
Mousegrid doesn't work for me and fails with this error:

`Plugin error (mousegrid): cannot access local variable 're' where it is not associated with a value`

This is caused by an additional conditional import of `re` inside `get_screen_size()` (in addition to the first file scoped import), making it a local variable.

If the conditional import doesn't run, `re` is not available. I am testing this on Ubuntu which could explain why the fallback branch was executed and this issue became apparent.

By removing the conditional import, `re` is not treated as a local variable and thus always visible file-wide via the first import.