### PR TITLE
Run performance benchmarks for Whisper transcribe latency

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,99 @@
+name: Benchmark
+
+# Tracks Whisper transcribe latency on bencher.dev.
+# Pattern follows https://bencher.dev/docs/how-to/github-actions/
+#
+# Required GitHub configuration:
+#   - secret  BENCHER_API_KEY   (from bencher.dev account)
+#   - variable BENCHER_PROJECT  (the project slug on bencher.dev)
+#
+# Fork PRs are skipped — secrets aren't available there. For fork-PR support
+# see the two-workflow pattern in the Bencher docs.
+
+on:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - edited
+    - synchronize
+  push:
+    branches:
+    - main
+    - dev
+
+jobs:
+  benchmark_branch:
+    name: Track base branch benchmarks
+    if: github.event_name == 'push'
+    permissions:
+      checks: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.13'
+    - uses: taiki-e/install-action@just
+    - uses: bencherdev/bencher@main
+    - run: |
+        sudo apt update
+        sudo apt install -y portaudio19-dev ffmpeg
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/huggingface
+        key: hf-${{ runner.os }}-whisper-base.en-tiny.en
+    - name: Track base branch benchmarks with Bencher
+      run: |
+        bencher run \
+        --project '${{ vars.BENCHER_PROJECT }}' \
+        --key '${{ secrets.BENCHER_API_KEY }}' \
+        --branch '${{ github.ref_name }}' \
+        --testbed ubuntu-latest \
+        --threshold-measure latency \
+        --threshold-test t_test \
+        --threshold-max-sample-size 64 \
+        --threshold-upper-boundary 0.99 \
+        --thresholds-reset \
+        --error-on-alert \
+        --adapter python_pytest \
+        --file results.json \
+        --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+        "just benchmark"
+
+  benchmark_pr:
+    name: Track PR benchmarks
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.13'
+    - uses: taiki-e/install-action@just
+    - uses: bencherdev/bencher@main
+    - run: |
+        sudo apt update
+        sudo apt install -y portaudio19-dev ffmpeg
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/huggingface
+        key: hf-${{ runner.os }}-whisper-base.en-tiny.en
+    - name: Track PR benchmarks with Bencher
+      run: |
+        bencher run \
+        --project '${{ vars.BENCHER_PROJECT }}' \
+        --key '${{ secrets.BENCHER_API_KEY }}' \
+        --branch "$GITHUB_HEAD_REF" \
+        --start-point "$GITHUB_BASE_REF" \
+        --start-point-hash '${{ github.event.pull_request.base.sha }}' \
+        --start-point-clone-thresholds \
+        --start-point-reset \
+        --testbed ubuntu-latest \
+        --error-on-alert \
+        --adapter python_pytest \
+        --file results.json \
+        --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+        "just benchmark"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage.json
 coverage.xml
 htmlcov/
 junit-report.xml
+results.json
 
 # Virtual environments
 .env

--- a/justfile
+++ b/justfile
@@ -73,6 +73,12 @@ coverage:
     uvx coverage[toml] xml
     uvx coverage[toml] report
 
+# Run Whisper benchmarks (writes results.json for bencher.dev)
+[group('tests')]
+benchmark *args:
+    uv run --extra=benchmark pytest tests/benchmarks/ \
+        --benchmark-json=results.json {{ args }}
+
 # Run functional tests on a built package
 [group('tests')]
 functional: (clean '--quiet') (package '--quiet')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+benchmark = [
+  "pytest>=8",
+  "pytest-benchmark>=5",
+]
 head-tracking = [
   "opencv-python>=4.13.0.90",
   "sixdrepnet>=0.1.6",
@@ -78,6 +82,11 @@ ignore_missing_imports = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+# Whisper benchmarks download large models and take minutes; opt-in only.
+# Run them with `just benchmark` or `pytest tests/benchmarks/`.
+addopts = "--ignore=tests/benchmarks"
 
 [tool.ruff.lint]
 extend-select = ["I"]  # "ALL" one day

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -29,11 +29,29 @@ PIPER_MODEL = os.environ.get(
     "EASYSPEAK_PIPER_MODEL",
     os.path.expanduser("~/.local/share/piper/en_US-amy-medium.onnx"),
 )
-WHISPER_MODEL = "base.en"
+WHISPER_MODEL = os.environ.get("EASYSPEAK_WHISPER_MODEL", "base.en")
+WHISPER_COMPUTE_TYPE = os.environ.get("EASYSPEAK_WHISPER_COMPUTE_TYPE", "int8")
+try:
+    # 0 == let CTranslate2 pick (uses all logical cores, which oversubscribes
+    # hyper-threaded CPUs). Set to physical core count for best CPU-only latency.
+    WHISPER_CPU_THREADS = max(
+        0, int(os.environ.get("EASYSPEAK_WHISPER_CPU_THREADS", "0"))
+    )
+except ValueError:
+    WHISPER_CPU_THREADS = 0
 SILENCE_THRESHOLD = 300
 SILENCE_DURATION = 0.3
 WAKE_THRESHOLD = 0.5
 WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
+
+
+def load_whisper_model(
+    model_name: str = WHISPER_MODEL,
+    compute_type: str = WHISPER_COMPUTE_TYPE,
+    cpu_threads: int = WHISPER_CPU_THREADS,
+) -> WhisperModel:
+    return WhisperModel(model_name, compute_type=compute_type, cpu_threads=cpu_threads)
+
 
 # Prompt to help Whisper recognize common commands
 COMMAND_PROMPT = (
@@ -216,8 +234,11 @@ class EasySpeak:
         print("Loading OpenWakeWord...")
         self.wakeword = WakeWordModel()
 
-        print("Loading Whisper...")
-        self.whisper = WhisperModel(WHISPER_MODEL, compute_type="int8")
+        print(
+            f"Loading Whisper ({WHISPER_MODEL}, {WHISPER_COMPUTE_TYPE}, "
+            f"cpu_threads={WHISPER_CPU_THREADS or 'auto'})..."
+        )
+        self.whisper = load_whisper_model()
 
         print("\nLoading plugins...")
         self.load_plugins()

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for Whisper benchmarks."""
+
+from __future__ import annotations
+
+import sys
+import urllib.request
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# openwakeword isn't a hard dependency on Python 3.13+ (speexdsp-ns wheels
+# missing) and the benchmark doesn't exercise the wake-word path. Stub it
+# before tests import easyspeak.core.main. Same pattern as tests/core/test_main.py.
+sys.modules.setdefault("openwakeword", MagicMock())
+sys.modules.setdefault("openwakeword.model", MagicMock())
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+from faster_whisper.audio import decode_audio  # noqa: E402
+
+SAMPLE_URL = "https://github.com/SYSTRAN/faster-whisper/raw/master/tests/data/jfk.flac"
+
+
+@pytest.fixture(scope="session")
+def sample_audio(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """JFK FLAC clip (~11s) — the canonical Whisper test sample."""
+    path = tmp_path_factory.mktemp("audio") / "jfk.flac"
+    with urllib.request.urlopen(SAMPLE_URL, timeout=30) as resp, path.open("wb") as f:
+        f.write(resp.read())
+    return path
+
+
+@pytest.fixture(scope="session")
+def sample_pcm(sample_audio: Path) -> bytes:
+    """Raw 16 kHz mono int16 PCM — the shape EasySpeak.transcribe expects from PyAudio."""
+    audio = decode_audio(str(sample_audio), sampling_rate=16000)
+    return (audio * 32767).clip(-32768, 32767).astype(np.int16).tobytes()

--- a/tests/benchmarks/test_whisper.py
+++ b/tests/benchmarks/test_whisper.py
@@ -1,0 +1,41 @@
+"""
+Whisper transcription benchmarks.
+
+Each variant times EasySpeak.transcribe() so the benchmark covers the WAV
+temp-file round-trip and prompt/VAD defaults, not just the bare faster-whisper
+call. Results upload to bencher.dev via:
+
+    bencher run --adapter python_pytest --file results.json \\
+        "pytest --benchmark-json=results.json tests/benchmarks/"
+"""
+
+from __future__ import annotations
+
+import pytest
+from easyspeak.core.main import EasySpeak, load_whisper_model
+
+VARIANTS = [
+    # (model_name, cpu_threads)
+    pytest.param("base.en", 0, id="base.en-auto"),
+    pytest.param("base.en", 2, id="base.en-2threads"),
+    pytest.param("base.en", 10, id="base.en-10threads"),
+    pytest.param("tiny.en", 2, id="tiny.en-2threads"),
+    pytest.param("tiny.en", 10, id="tiny.en-10threads"),
+]
+
+
+@pytest.mark.parametrize("model_name,cpu_threads", VARIANTS)
+def test_transcribe(
+    benchmark, sample_pcm: bytes, model_name: str, cpu_threads: int
+) -> None:
+    app = EasySpeak()
+    app.whisper = load_whisper_model(
+        model_name=model_name, cpu_threads=cpu_threads, compute_type="int8"
+    )
+
+    benchmark.pedantic(
+        lambda: app.transcribe(sample_pcm),
+        rounds=5,
+        iterations=1,
+        warmup_rounds=1,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+benchmark = [
+    { name = "pytest" },
+    { name = "pytest-benchmark" },
+]
 head-tracking = [
     { name = "opencv-python" },
     { name = "sixdrepnet" },
@@ -398,10 +402,12 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "opencv-python", marker = "extra == 'head-tracking'", specifier = ">=4.13.0.90" },
     { name = "pyaudio", specifier = ">=0.2.14" },
+    { name = "pytest", marker = "extra == 'benchmark'", specifier = ">=8" },
+    { name = "pytest-benchmark", marker = "extra == 'benchmark'", specifier = ">=5" },
     { name = "sixdrepnet", marker = "extra == 'head-tracking'", specifier = ">=0.1.6" },
     { name = "types-pyaudio", marker = "extra == 'mypy'", specifier = ">=0.2.16.20250801" },
 ]
-provides-extras = ["head-tracking", "mypy"]
+provides-extras = ["benchmark", "head-tracking", "mypy"]
 
 [[package]]
 name = "exceptiongroup"
@@ -600,6 +606,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1567,6 +1582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1579,6 +1603,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
     { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
     { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]
@@ -1622,6 +1655,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I thought it might be useful to start tracking the local performance of EasySpeak. It might come handy later in case performance optimizations are being asked for.

This adds a `pytest-benchmark` suite that times `EasySpeak.transcribe()` across five (model, `cpu_threads`) variants on the canonical JFK audio sample, plus a GitHub Actions workflow that uploads results to bencher.dev (with regression thresholds on `main`/`dev` and PR-comment alerts on same-repo pull requests). The supporting changes expose Whisper's model name, compute type, and CPU thread count as `EASYSPEAK_WHISPER_*` environment variables so the same knobs the benchmark sweeps can be tuned at runtime.

_Note:_ It might be necessary to merge this PR first, before we can see the benchmark job run, because the required secrets are not available for fork PRs.

## Configuration

I added the following two resources in the project's settings for GitHub Actions:

- [`BENCHER_API_KEY`](https://github.com/ctsdownloads/easyspeak/settings/secrets/actions) secret
- [`BENCHER_PROJECT`](https://github.com/ctsdownloads/easyspeak/settings/variables/actions) variable

## Related Resources

Here's what prompted me to work on this change:

- [A 10 year old Xeon is all you need](https://point.free/blog/gemma-4-on-a-2016-xeon/) – _running local LLMs on low-end hardware_
- [How to benchmark Python code with pytest-benchmark](https://bencher.dev/learn/benchmarking/python/pytest-benchmark/)