### PR TITLE
Extract config module and move host-env setup into plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,20 +146,6 @@ git clone https://github.com/ctsdownloads/easyspeak.git ~/easyspeak
 cd ~/easyspeak
 ```
 
-### 5. GNOME Shell Extension
-
-```bash
-mkdir -p ~/.local/share/gnome-shell/extensions/easyspeak-grid@local
-cp extension.js metadata.json ~/.local/share/gnome-shell/extensions/easyspeak-grid@local/
-```
-
-**Log out and back in** (GNOME Shell must restart to detect new extensions).
-
-Then enable:
-```bash
-gnome-extensions enable easyspeak-grid@local
-```
-
 ## Usage
 
 ```bash
@@ -336,29 +322,33 @@ easyspeak/
 ├── extension.js               # GNOME Shell extension
 ├── metadata.json              # Extension metadata
 ├── pyproject.toml
-├── [1;38;2;36;114;200msrc[0m
-│   ├── [1;38;2;36;114;200mcore[0m
-│   │   ├── __init__.py
-│   │   └── main.py             # Main application
-│   └── [1;38;2;36;114;200mplugins[0m
-│       ├── __init__.py
-│       ├── 00_eyetrack.py      # Head tracking (experimental)
-│       ├── 00_mousegrid.py     # Grid overlay mouse control
-│       ├── apps.py             # Application launcher
-│       ├── browser.py          # Qutebrowser control
-│       ├── dictation.py        # Voice-to-text
-│       ├── files.py            # Folder navigation
-│       ├── media.py            # Playback controls
-│       ├── system.py           # Volume, brightness, DND
-│       └── zz_base.py          # Help and exit
-└── [1;38;2;36;114;200mtests[0m
-    ├── [1;38;2;36;114;200mcore[0m
-    │   └── test_main.py
-    └── [1;38;2;36;114;200mplugins[0m
-        └── test_apps.py
+├── src
+│   ├── core
+│   │   ├── __init__.py
+│   │   ├── __main__.py
+│   │   ├── config.py          # Tuning constants + Whisper model factory
+│   │   └── main.py            # EasySpeak class + main loop
+│   └── plugins
+│       ├── __init__.py
+│       ├── 00_eyetrack.py     # Head tracking (experimental)
+│       ├── 00_mousegrid.py    # Grid overlay mouse control
+│       ├── apps.py            # Application launcher
+│       ├── browser.py         # Qutebrowser control + auto-config
+│       ├── dictation.py       # Voice-to-text + AT-SPI enablement
+│       ├── files.py           # Folder navigation
+│       ├── media.py           # Playback controls
+│       ├── system.py          # Volume, brightness, DND
+│       └── zz_base.py         # Help and exit
+└── tests
+    ├── benchmarks             # pytest-benchmark suites for bencher.dev
+    ├── core                   # tests for src/core/
+    └── plugins                # tests for src/plugins/
 ```
 
-After installation, the extension is copied to:
+On first start, the `mousegrid` plugin auto-installs the GNOME Shell
+extension to the user-local extensions directory (unless GNOME already
+sees it via a system-wide install). Files copied:
+
 ```
 ~/.local/share/gnome-shell/extensions/easyspeak-grid@local/
 ├── extension.js
@@ -411,11 +401,30 @@ def handle(cmd, core):
 
 ## Troubleshooting
 
-**"Failed to show grid - is extension enabled?"**
+**Mouse grid: "Failed to show grid — is extension enabled?"**
+
+EasySpeak auto-installs the GNOME Shell extension to
+`~/.local/share/gnome-shell/extensions/easyspeak-grid@local/` on first
+run (look for a `mousegrid: installed ...` message at startup). On
+Wayland, GNOME Shell only scans for new extensions at login, so you
+typically have to **log out and back in** before it becomes loadable.
+
+After re-login, enable it from the command line:
+
 ```bash
 gnome-extensions enable easyspeak-grid@local
-# Then log out and back in
 ```
+
+…or open the **Extensions** GNOME app and toggle *EasySpeak Grid* on.
+
+To remove it later:
+
+```bash
+gnome-extensions disable easyspeak-grid@local
+rm -rf ~/.local/share/gnome-shell/extensions/easyspeak-grid@local
+```
+
+…or click the trash icon next to *EasySpeak Grid* in the Extensions app.
 
 **Dictation not working**
 

--- a/README.md
+++ b/README.md
@@ -160,24 +160,6 @@ Then enable:
 gnome-extensions enable easyspeak-grid@local
 ```
 
-### 6. Enable Accessibility
-
-```bash
-gsettings set org.gnome.desktop.interface toolkit-accessibility true
-```
-
-### 7. Configure Qutebrowser
-
-EasySpeak uses number hints (not letters). Configure qutebrowser:
-
-```bash
-mkdir -p ~/.config/qutebrowser
-cat > ~/.config/qutebrowser/config.py << 'EOF'
-config.load_autoconfig(False)
-c.hints.chars = '0123456789'
-EOF
-```
-
 ## Usage
 
 ```bash
@@ -436,9 +418,27 @@ gnome-extensions enable easyspeak-grid@local
 ```
 
 **Dictation not working**
+
+EasySpeak enables the GNOME accessibility bridge on first run; log out and
+back in after seeing the `dictation: enabled GNOME toolkit-accessibility`
+message. If the auto-config printed a `WARNING` instead (e.g. on a
+non-GNOME or locked-down desktop), run it manually:
+
 ```bash
 gsettings set org.gnome.desktop.interface toolkit-accessibility true
 # Log out and back in
+```
+
+**Browser plugin: link numbers don't work**
+
+EasySpeak appends two required lines to `~/.config/qutebrowser/config.py`
+on first run (you'll see a `browser: wrote ...` or `browser: updated ...`
+message). If you see a `browser: note: ... is read-only` or a similar
+error instead, add these lines to the config module yourself:
+
+```python
+config.load_autoconfig(False)
+c.hints.chars = '0123456789'
 ```
 
 **Wake word not detecting**

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,0 +1,48 @@
+"""Tuning constants and model factory for EasySpeak.
+
+Override the EASYSPEAK_* environment variables to customise behaviour
+without editing source. Plugin-specific host-environment setup lives in
+each plugin's own setup() hook, not here.
+"""
+
+import os
+
+from faster_whisper import WhisperModel
+
+# --- Wake word ---
+WAKE_WORD = "hey_jarvis"  # OpenWakeWord model name
+WAKE_THRESHOLD = 0.5
+WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
+
+# --- Audio thresholds ---
+SILENCE_THRESHOLD = 300
+SILENCE_DURATION = 0.3
+
+# --- Models ---
+PIPER_MODEL = os.environ.get(
+    "EASYSPEAK_PIPER_MODEL",
+    os.path.expanduser("~/.local/share/piper/en_US-amy-medium.onnx"),
+)
+WHISPER_MODEL = os.environ.get("EASYSPEAK_WHISPER_MODEL", "base.en")
+WHISPER_COMPUTE_TYPE = os.environ.get("EASYSPEAK_WHISPER_COMPUTE_TYPE", "int8")
+try:
+    # 0 == let CTranslate2 pick (uses all logical cores, which oversubscribes
+    # hyper-threaded CPUs). Set to physical core count for best CPU-only latency.
+    WHISPER_CPU_THREADS = max(
+        0, int(os.environ.get("EASYSPEAK_WHISPER_CPU_THREADS", "0"))
+    )
+except ValueError:
+    WHISPER_CPU_THREADS = 0
+
+# Prompt to help Whisper recognize common commands
+COMMAND_PROMPT = (
+    "numbers, scroll, click, open, close, back, forward, volume, brightness, stop"
+)
+
+
+def load_whisper_model(
+    model_name: str = WHISPER_MODEL,
+    compute_type: str = WHISPER_COMPUTE_TYPE,
+    cpu_threads: int = WHISPER_CPU_THREADS,
+) -> WhisperModel:
+    return WhisperModel(model_name, compute_type=compute_type, cpu_threads=cpu_threads)

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -17,45 +17,20 @@ from pathlib import Path
 
 import numpy as np
 import pyaudio
-from faster_whisper import WhisperModel
 from openwakeword.model import Model as WakeWordModel
 
-# =============================================================================
-# CONFIGURATION
-# =============================================================================
-
-WAKE_WORD = "hey_jarvis"  # OpenWakeWord model name
-PIPER_MODEL = os.environ.get(
-    "EASYSPEAK_PIPER_MODEL",
-    os.path.expanduser("~/.local/share/piper/en_US-amy-medium.onnx"),
-)
-WHISPER_MODEL = os.environ.get("EASYSPEAK_WHISPER_MODEL", "base.en")
-WHISPER_COMPUTE_TYPE = os.environ.get("EASYSPEAK_WHISPER_COMPUTE_TYPE", "int8")
-try:
-    # 0 == let CTranslate2 pick (uses all logical cores, which oversubscribes
-    # hyper-threaded CPUs). Set to physical core count for best CPU-only latency.
-    WHISPER_CPU_THREADS = max(
-        0, int(os.environ.get("EASYSPEAK_WHISPER_CPU_THREADS", "0"))
-    )
-except ValueError:
-    WHISPER_CPU_THREADS = 0
-SILENCE_THRESHOLD = 300
-SILENCE_DURATION = 0.3
-WAKE_THRESHOLD = 0.5
-WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
-
-
-def load_whisper_model(
-    model_name: str = WHISPER_MODEL,
-    compute_type: str = WHISPER_COMPUTE_TYPE,
-    cpu_threads: int = WHISPER_CPU_THREADS,
-) -> WhisperModel:
-    return WhisperModel(model_name, compute_type=compute_type, cpu_threads=cpu_threads)
-
-
-# Prompt to help Whisper recognize common commands
-COMMAND_PROMPT = (
-    "numbers, scroll, click, open, close, back, forward, volume, brightness, stop"
+from .config import (
+    COMMAND_PROMPT,
+    PIPER_MODEL,
+    SILENCE_DURATION,
+    SILENCE_THRESHOLD,
+    WAKE_COOLDOWN,
+    WAKE_THRESHOLD,
+    WAKE_WORD,
+    WHISPER_COMPUTE_TYPE,
+    WHISPER_CPU_THREADS,
+    WHISPER_MODEL,
+    load_whisper_model,
 )
 
 # =============================================================================

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -9,7 +9,10 @@ Features:
 
 import atexit
 import re
+import shutil
 import subprocess
+import sys
+from pathlib import Path
 
 NAME = "mousegrid"
 DESCRIPTION = "Voice-controlled mouse grid"
@@ -95,9 +98,144 @@ DIRECTIONS = {
 }
 
 
+# GNOME Shell extension that this plugin drives via DBus. The extension
+# itself ships at the project root (extension.js + metadata.json) and is
+# auto-installed into the user's extension directory on first run if it
+# isn't already visible to GNOME (whether system-wide or user-local).
+GRID_EXTENSION_UUID = "easyspeak-grid@local"
+
+
+def ensure_grid_extension():
+    """Install the GNOME Shell extension if needed, and enable it.
+
+    Probes state with ``gnome-extensions list`` (covers both system and
+    user paths) and ``gnome-extensions list --enabled``, then reports
+    exactly what it did: found it already enabled, enabled a previously
+    disabled install (e.g. user toggled it off or a GNOME Shell version
+    bump auto-disabled it), or freshly installed and enabled. Silently
+    skipped on non-GNOME systems. Non-fatal on missing source files or
+    write failures — emits a polite note and lets startup proceed.
+    """
+    if shutil.which("gnome-extensions") is None:
+        return  # not a GNOME-based desktop
+
+    try:
+        listed = subprocess.run(
+            ["gnome-extensions", "list"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        listed_enabled = subprocess.run(
+            ["gnome-extensions", "list", "--enabled"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return
+    if listed.returncode != 0:
+        return
+
+    installed = GRID_EXTENSION_UUID in listed.stdout.split()
+    # If the --enabled probe failed we don't know; fall through and try
+    # enabling (a no-op when it's already on).
+    already_enabled = (
+        listed_enabled.returncode == 0
+        and GRID_EXTENSION_UUID in listed_enabled.stdout.split()
+    )
+    dest_dir = (
+        Path.home()
+        / ".local"
+        / "share"
+        / "gnome-shell"
+        / "extensions"
+        / GRID_EXTENSION_UUID
+    )
+
+    if installed and already_enabled:
+        print(
+            f"mousegrid: GNOME extension {GRID_EXTENSION_UUID} "
+            f"already installed and enabled",
+            file=sys.stderr,
+        )
+        return
+
+    if not installed:
+        project_root = Path(__file__).resolve().parents[2]
+        src_ext = project_root / "extension.js"
+        src_meta = project_root / "metadata.json"
+        if not (src_ext.is_file() and src_meta.is_file()):
+            print(
+                f"mousegrid: note: could not auto-install GNOME extension — "
+                f"source files not found at {project_root}. Grid commands "
+                f"will not work until the extension is installed manually.",
+                file=sys.stderr,
+            )
+            return
+
+        try:
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_ext, dest_dir / "extension.js")
+            shutil.copy2(src_meta, dest_dir / "metadata.json")
+        except OSError as e:
+            print(
+                f"mousegrid: note: could not install GNOME extension to "
+                f"{dest_dir} ({e}). Grid commands will not work until it "
+                f"is installed manually.",
+                file=sys.stderr,
+            )
+            return
+
+    # First-time installs require GNOME Shell to rescan, which on Wayland
+    # only happens at login. `enable` will fail with "Unknown extension"
+    # until then — we treat that as "installed, log back in to use".
+    try:
+        enabled = subprocess.run(
+            ["gnome-extensions", "enable", GRID_EXTENSION_UUID],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        ok = enabled.returncode == 0
+    except OSError:
+        ok = False
+
+    if installed:
+        # Was installed but disabled — we just flipped it on (or tried to).
+        if ok:
+            print(
+                f"mousegrid: enabled GNOME extension {GRID_EXTENSION_UUID} "
+                f"(was installed but disabled)",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"mousegrid: note: GNOME extension {GRID_EXTENSION_UUID} is "
+                f"installed but disabled, and could not be enabled. Try: "
+                f"gnome-extensions enable {GRID_EXTENSION_UUID}",
+                file=sys.stderr,
+            )
+        return
+
+    if ok:
+        print(
+            f"mousegrid: installed and enabled GNOME extension "
+            f"{GRID_EXTENSION_UUID} at {dest_dir}",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"mousegrid: installed GNOME extension to {dest_dir} — "
+            f"log out and back in to finish enabling it.",
+            file=sys.stderr,
+        )
+
+
 def setup(c):
     global core
     core = c
+    ensure_grid_extension()
 
 
 def host_run(cmd):

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -3,7 +3,9 @@ Browser Plugin - Qutebrowser voice control via IPC
 """
 
 import re
+import sys
 import time
+from pathlib import Path
 
 NAME = "browser"
 DESCRIPTION = "Qutebrowser voice control"
@@ -91,9 +93,75 @@ SCROLL_TOP_JS = "(function(){var el=document.elementFromPoint(window.innerWidth/
 SCROLL_BOTTOM_JS = "(function(){var el=document.elementFromPoint(window.innerWidth/2,window.innerHeight/2);while(el){if(el.scrollHeight>el.clientHeight&&getComputedStyle(el).overflowY!=='visible'){el.scrollTo(0,el.scrollHeight);return}el=el.parentElement}window.scrollTo(0,document.body.scrollHeight)})()"
 
 
+# Lines this plugin requires in ~/.config/qutebrowser/config.py. Each is
+# checked grep-style (substring on the file as a whole) and appended
+# individually if absent — the user's other settings are left intact.
+REQUIRED_QUTEBROWSER_LINES = [
+    "config.load_autoconfig(False)",
+    "c.hints.chars = '0123456789'",
+]
+
+
+def ensure_qutebrowser_config():
+    """Append any missing required lines to qutebrowser's config.py.
+
+    Preserves everything else the user has written. Tolerates read-only
+    configs (e.g. Nix Home-Manager symlinks into /nix/store): on a write
+    failure we emit a polite note telling the user which lines to add
+    themselves, rather than crashing startup.
+    """
+    cfg = Path.home() / ".config" / "qutebrowser" / "config.py"
+
+    try:
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _note_missing_qb_lines(
+            cfg,
+            REQUIRED_QUTEBROWSER_LINES,
+            reason=f"could not create {cfg.parent} ({e})",
+        )
+        return
+
+    try:
+        existing = cfg.read_text() if cfg.exists() else ""
+    except OSError as e:
+        _note_missing_qb_lines(
+            cfg, REQUIRED_QUTEBROWSER_LINES, reason=f"could not read it ({e})"
+        )
+        return
+
+    missing = [line for line in REQUIRED_QUTEBROWSER_LINES if line not in existing]
+    if not missing:
+        return
+
+    separator = "" if not existing or existing.endswith("\n") else "\n"
+    updated = existing + separator + "\n".join(missing) + "\n"
+
+    try:
+        cfg.write_text(updated)
+    except OSError as e:
+        _note_missing_qb_lines(cfg, missing, reason=f"is read-only ({e})")
+        return
+
+    verb = "wrote" if not existing else "updated"
+    added = "; ".join(missing)
+    print(f"browser: {verb} {cfg} (added: {added})", file=sys.stderr)
+
+
+def _note_missing_qb_lines(cfg, lines, reason):
+    """Politely tell the user to add missing qutebrowser config lines."""
+    body = "\n".join(f"  {line}" for line in lines)
+    print(
+        f"browser: note: {cfg} {reason}. "
+        f"Please make sure your qutebrowser config includes:\n{body}",
+        file=sys.stderr,
+    )
+
+
 def setup(c):
     global core
     core = c
+    ensure_qutebrowser_config()
 
 
 def qb(command):

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -3,7 +3,9 @@ Dictation Plugin - Voice to text via AT-SPI
 """
 
 import re
+import shutil
 import subprocess
+import sys
 
 NAME = "dictation"
 DESCRIPTION = "Voice dictation into any text field"
@@ -22,9 +24,53 @@ core = None
 DICTATION_PROMPT = "comma, period, new sentence, new paragraph, new line, question mark, exclamation mark, colon, semicolon, stop notes, backspace, space, tab, enter, apostrophe, quote, dash, hyphen, at sign, hashtag, percent"
 
 
+def ensure_gnome_accessibility():
+    """Enable GNOME's toolkit-accessibility for the AT-SPI bridge.
+
+    Silently skipped if gsettings isn't on PATH or the schema isn't
+    installed (i.e. user isn't on GNOME). Warns if it's present but the
+    flip fails. Tells the user to re-login when newly enabled.
+    """
+    if shutil.which("gsettings") is None:
+        return
+    schema, key = "org.gnome.desktop.interface", "toolkit-accessibility"
+    try:
+        current = subprocess.run(
+            ["gsettings", "get", schema, key],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if current.returncode != 0:
+            return  # schema missing — not really on GNOME
+        if current.stdout.strip() == "true":
+            return
+        result = subprocess.run(
+            ["gsettings", "set", schema, key, "true"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            print(
+                "dictation: enabled GNOME toolkit-accessibility — "
+                "log out and back in for dictation to work",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "dictation: WARNING could not enable GNOME "
+                "toolkit-accessibility; dictation will not work",
+                file=sys.stderr,
+            )
+    except OSError:
+        pass
+
+
 def setup(c):
     global core
     core = c
+    ensure_gnome_accessibility()
 
 
 ATSPI_INSERT_SCRIPT = """

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,101 @@
+"""Tests for the core config module."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock the heavy external dep before importing
+sys.modules.setdefault("faster_whisper", MagicMock())
+
+from easyspeak.core import config  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _restore_config(monkeypatch):
+    """Clear EASYSPEAK_* env vars and reload to defaults after each test.
+
+    Tests below mutate process env + reload config to exercise the
+    module-level parsing logic. This fixture restores a clean baseline
+    for the next test (and the rest of the suite).
+    """
+    yield
+    for var in [
+        "EASYSPEAK_WHISPER_CPU_THREADS",
+        "EASYSPEAK_WHISPER_MODEL",
+        "EASYSPEAK_WHISPER_COMPUTE_TYPE",
+        "EASYSPEAK_PIPER_MODEL",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    importlib.reload(config)
+
+
+def test_whisper_cpu_threads_default(monkeypatch):
+    """Unset env: defaults to 0 (CTranslate2 auto-pick)."""
+    monkeypatch.delenv("EASYSPEAK_WHISPER_CPU_THREADS", raising=False)
+    importlib.reload(config)
+    assert config.WHISPER_CPU_THREADS == 0
+
+
+def test_whisper_cpu_threads_valid(monkeypatch):
+    """Numeric env value is parsed."""
+    monkeypatch.setenv("EASYSPEAK_WHISPER_CPU_THREADS", "4")
+    importlib.reload(config)
+    assert config.WHISPER_CPU_THREADS == 4
+
+
+def test_whisper_cpu_threads_invalid_falls_back(monkeypatch):
+    """Garbage env value falls back to 0 (covers `except ValueError`)."""
+    monkeypatch.setenv("EASYSPEAK_WHISPER_CPU_THREADS", "not-a-number")
+    importlib.reload(config)
+    assert config.WHISPER_CPU_THREADS == 0
+
+
+def test_whisper_cpu_threads_negative_clamped(monkeypatch):
+    """Negative values are clamped to 0 via max()."""
+    monkeypatch.setenv("EASYSPEAK_WHISPER_CPU_THREADS", "-5")
+    importlib.reload(config)
+    assert config.WHISPER_CPU_THREADS == 0
+
+
+def test_load_whisper_model_invokes_whisper():
+    """load_whisper_model passes its args through to WhisperModel()."""
+    with patch("easyspeak.core.config.WhisperModel") as mock_model:
+        result = config.load_whisper_model("tiny.en", "float32", 4)
+
+    mock_model.assert_called_once_with("tiny.en", compute_type="float32", cpu_threads=4)
+    assert result is mock_model.return_value
+
+
+def test_load_whisper_model_uses_module_defaults():
+    """Called without args, load_whisper_model uses the module constants."""
+    with patch("easyspeak.core.config.WhisperModel") as mock_model:
+        config.load_whisper_model()
+
+    mock_model.assert_called_once_with(
+        config.WHISPER_MODEL,
+        compute_type=config.WHISPER_COMPUTE_TYPE,
+        cpu_threads=config.WHISPER_CPU_THREADS,
+    )
+
+
+def test_piper_model_env_override(monkeypatch):
+    """EASYSPEAK_PIPER_MODEL overrides the default path."""
+    monkeypatch.setenv("EASYSPEAK_PIPER_MODEL", "/nix/store/abc/voice.onnx")
+    importlib.reload(config)
+    assert config.PIPER_MODEL == "/nix/store/abc/voice.onnx"
+
+
+def test_whisper_model_env_override(monkeypatch):
+    """EASYSPEAK_WHISPER_MODEL overrides the default model name."""
+    monkeypatch.setenv("EASYSPEAK_WHISPER_MODEL", "tiny.en")
+    importlib.reload(config)
+    assert config.WHISPER_MODEL == "tiny.en"
+
+
+def test_whisper_compute_type_env_override(monkeypatch):
+    """EASYSPEAK_WHISPER_COMPUTE_TYPE overrides the default compute type."""
+    monkeypatch.setenv("EASYSPEAK_WHISPER_COMPUTE_TYPE", "float16")
+    importlib.reload(config)
+    assert config.WHISPER_COMPUTE_TYPE == "float16"

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -549,7 +549,7 @@ class TestEasySpeakRun:
     """Tests for EasySpeak run method."""
 
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     def test_run_no_plugins(
         self, mock_load_plugins, mock_whisper_model, mock_wakeword_model, capsys
@@ -575,7 +575,7 @@ class TestEasySpeakRun:
     @patch("subprocess.run")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     def test_run_with_keyboard_interrupt(
         self,
@@ -613,7 +613,7 @@ class TestEasySpeakRun:
     @patch("time.time")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     @patch.object(EasySpeak, "wait_for_speech")
     @patch.object(EasySpeak, "record_until_silence")
@@ -692,7 +692,7 @@ class TestEasySpeakRun:
     @patch("time.time")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     @patch.object(EasySpeak, "wait_for_speech")
     @patch.object(EasySpeak, "speak")
@@ -756,7 +756,7 @@ class TestEasySpeakRun:
     @patch("time.time")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     @patch.object(EasySpeak, "wait_for_speech")
     @patch.object(EasySpeak, "record_until_silence")
@@ -831,7 +831,7 @@ class TestEasySpeakRun:
     @patch("time.time")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     @patch.object(EasySpeak, "wait_for_speech")
     @patch.object(EasySpeak, "record_until_silence")
@@ -894,7 +894,7 @@ class TestEasySpeakRun:
     @patch("time.time")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
-    @patch("easyspeak.core.main.WhisperModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     def test_run_audio_buffer_management(
         self,

--- a/tests/plugins/test_browser.py
+++ b/tests/plugins/test_browser.py
@@ -558,11 +558,13 @@ def test_handle_browser_command_unknown(mock_core):
 # Tests for setup function.
 
 
-def test_setup(mock_core):
-    """Test setup function sets core reference."""
+@patch.object(browser, "ensure_qutebrowser_config")
+def test_setup(mock_ensure, mock_core):
+    """Test setup function sets core reference and triggers host-env setup."""
     browser.setup(mock_core)
 
     assert browser.core == mock_core
+    mock_ensure.assert_called_once_with()
 
 
 # Tests for handle function.
@@ -962,3 +964,126 @@ def test_handle_browser_command_phonetic_hint_parsing(mock_qb, mock_core, capsys
     assert mock_qb.call_args.args[0] == "hint-follow 1"
     captured = capsys.readouterr()
     assert "Phonetic parsed:" in captured.out
+
+
+# Tests for ensure_qutebrowser_config and _note_missing_qb_lines.
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect Path.home() to a tmp dir so config writes are isolated."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def _read_cfg(home):
+    return (home / ".config" / "qutebrowser" / "config.py").read_text()
+
+
+def test_ensure_qutebrowser_config_fresh(fake_home, capsys):
+    """When the file is missing, both required lines are written."""
+    browser.ensure_qutebrowser_config()
+
+    content = _read_cfg(fake_home)
+    assert "config.load_autoconfig(False)" in content
+    assert "c.hints.chars = '0123456789'" in content
+
+    captured = capsys.readouterr()
+    assert "browser: wrote" in captured.err
+    assert "config.load_autoconfig(False)" in captured.err
+
+
+def test_ensure_qutebrowser_config_idempotent(fake_home, capsys):
+    """A second call on an already-correct file is silent and doesn't rewrite."""
+    browser.ensure_qutebrowser_config()
+    capsys.readouterr()  # discard the "wrote" message from the first call
+
+    cfg = fake_home / ".config" / "qutebrowser" / "config.py"
+    mtime_before = cfg.stat().st_mtime
+
+    browser.ensure_qutebrowser_config()
+
+    assert cfg.stat().st_mtime == mtime_before
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_ensure_qutebrowser_config_appends_missing(fake_home, capsys):
+    """User content + one of our lines: we append only what's missing."""
+    cfg = fake_home / ".config" / "qutebrowser" / "config.py"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(
+        "# user notes\nconfig.load_autoconfig(False)\nc.tabs.background = True\n"
+    )
+
+    browser.ensure_qutebrowser_config()
+
+    content = cfg.read_text()
+    assert "# user notes" in content
+    assert "c.tabs.background = True" in content
+    assert "c.hints.chars = '0123456789'" in content
+
+    captured = capsys.readouterr()
+    assert "browser: updated" in captured.err
+    assert "c.hints.chars = '0123456789'" in captured.err
+    # The other required line was already present — shouldn't be listed as added.
+    assert "added: config.load_autoconfig" not in captured.err
+
+
+def test_ensure_qutebrowser_config_no_trailing_newline(fake_home):
+    """Existing file without trailing newline gets a separator added."""
+    cfg = fake_home / ".config" / "qutebrowser" / "config.py"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("c.tabs.background = True")  # no trailing newline
+
+    browser.ensure_qutebrowser_config()
+
+    content = cfg.read_text()
+    # Original line must remain intact (not merged with the appended line).
+    assert "c.tabs.background = True\n" in content
+    assert "c.hints.chars = '0123456789'" in content
+
+
+def test_ensure_qutebrowser_config_mkdir_fails(fake_home, capsys):
+    """mkdir OSError routes to the polite note with all required lines."""
+    with patch.object(browser.Path, "mkdir", side_effect=PermissionError("denied")):
+        browser.ensure_qutebrowser_config()
+
+    captured = capsys.readouterr()
+    assert "browser: note:" in captured.err
+    assert "could not create" in captured.err
+    # Lists both required lines since we don't know what's there.
+    assert "config.load_autoconfig(False)" in captured.err
+    assert "c.hints.chars = '0123456789'" in captured.err
+
+
+def test_ensure_qutebrowser_config_read_fails(fake_home, capsys):
+    """read_text OSError routes to the polite note with all required lines."""
+    cfg = fake_home / ".config" / "qutebrowser" / "config.py"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("anything")
+
+    with patch.object(browser.Path, "read_text", side_effect=PermissionError("nope")):
+        browser.ensure_qutebrowser_config()
+
+    captured = capsys.readouterr()
+    assert "browser: note:" in captured.err
+    assert "could not read" in captured.err
+    assert "config.load_autoconfig(False)" in captured.err
+
+
+def test_ensure_qutebrowser_config_write_fails(fake_home, capsys):
+    """Read-only file: warning lists only the lines that still need adding."""
+    cfg = fake_home / ".config" / "qutebrowser" / "config.py"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("config.load_autoconfig(False)\n")  # one line already present
+
+    with patch.object(browser.Path, "write_text", side_effect=PermissionError("ro")):
+        browser.ensure_qutebrowser_config()
+
+    captured = capsys.readouterr()
+    assert "browser: note:" in captured.err
+    assert "is read-only" in captured.err
+    # Only the still-missing line should be listed.
+    assert "c.hints.chars = '0123456789'" in captured.err
+    assert "config.load_autoconfig(False)" not in captured.err.split("includes:")[1]

--- a/tests/plugins/test_dictation.py
+++ b/tests/plugins/test_dictation.py
@@ -6,13 +6,96 @@ import pytest
 from easyspeak.plugins import dictation
 
 
-def test_setup():
+@patch.object(dictation, "ensure_gnome_accessibility")
+def test_setup(mock_ensure):
     """Test that setup correctly assigns the core object."""
     mock_core = Mock()
 
     dictation.setup(mock_core)
 
     assert dictation.core == mock_core
+    mock_ensure.assert_called_once_with()
+
+
+# Tests for ensure_gnome_accessibility.
+
+
+@patch("easyspeak.plugins.dictation.shutil.which", return_value=None)
+def test_ensure_gnome_accessibility_no_gsettings(mock_which, capsys):
+    """No gsettings on PATH (non-GNOME): silent no-op."""
+    dictation.ensure_gnome_accessibility()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+@patch("easyspeak.plugins.dictation.subprocess.run")
+@patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
+def test_ensure_gnome_accessibility_schema_missing(mock_which, mock_run, capsys):
+    """gsettings present but schema lookup fails: silent no-op."""
+    mock_run.return_value = Mock(returncode=1, stdout="")
+
+    dictation.ensure_gnome_accessibility()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    mock_run.assert_called_once()  # only 'get' is attempted, no 'set'
+
+
+@patch("easyspeak.plugins.dictation.subprocess.run")
+@patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
+def test_ensure_gnome_accessibility_already_on(mock_which, mock_run, capsys):
+    """Setting is already true: silent no-op, no 'set' call."""
+    mock_run.return_value = Mock(returncode=0, stdout="true\n")
+
+    dictation.ensure_gnome_accessibility()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    mock_run.assert_called_once()
+
+
+@patch("easyspeak.plugins.dictation.subprocess.run")
+@patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
+def test_ensure_gnome_accessibility_enables(mock_which, mock_run, capsys):
+    """Setting is false and 'set' succeeds: prints enabled message + re-login hint."""
+    mock_run.side_effect = [
+        Mock(returncode=0, stdout="false\n"),  # get
+        Mock(returncode=0, stdout=""),  # set
+    ]
+
+    dictation.ensure_gnome_accessibility()
+
+    captured = capsys.readouterr()
+    assert "enabled GNOME toolkit-accessibility" in captured.err
+    assert "log out" in captured.err
+    assert mock_run.call_count == 2
+
+
+@patch("easyspeak.plugins.dictation.subprocess.run")
+@patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
+def test_ensure_gnome_accessibility_set_fails(mock_which, mock_run, capsys):
+    """Setting is false but 'set' fails: prints WARNING."""
+    mock_run.side_effect = [
+        Mock(returncode=0, stdout="false\n"),  # get
+        Mock(returncode=1, stdout=""),  # set fails
+    ]
+
+    dictation.ensure_gnome_accessibility()
+
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "could not enable" in captured.err
+
+
+@patch("easyspeak.plugins.dictation.subprocess.run", side_effect=OSError("nope"))
+@patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
+def test_ensure_gnome_accessibility_oserror(mock_which, mock_run, capsys):
+    """subprocess.run raising OSError is swallowed silently."""
+    dictation.ensure_gnome_accessibility()
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_mousegrid.py
+++ b/tests/plugins/test_mousegrid.py
@@ -28,11 +28,244 @@ def reset_mousegrid_state():
     mousegrid_plugin.drag_start = None
 
 
-def test_setup(mock_core):
-    """When setup is called with a core object then it stores the reference."""
+@patch.object(mousegrid_plugin, "ensure_grid_extension")
+def test_setup(mock_ensure, mock_core):
+    """setup() stores the core reference and triggers extension auto-install."""
     mousegrid_plugin.setup(mock_core)
 
     assert mousegrid_plugin.core is mock_core
+    mock_ensure.assert_called_once_with()
+
+
+# Tests for ensure_grid_extension.
+
+
+@patch.object(mousegrid_plugin.shutil, "which", return_value=None)
+def test_ensure_grid_extension_no_gnome_cli(mock_which, capsys):
+    """No gnome-extensions on PATH (non-GNOME): silent no-op."""
+    mousegrid_plugin.ensure_grid_extension()
+
+    assert capsys.readouterr().err == ""
+
+
+@patch.object(mousegrid_plugin.subprocess, "run", side_effect=OSError("nope"))
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_list_oserror(mock_which, mock_run, capsys):
+    """`gnome-extensions list` raising OSError is swallowed silently."""
+    mousegrid_plugin.ensure_grid_extension()
+
+    assert capsys.readouterr().err == ""
+
+
+@patch.object(
+    mousegrid_plugin.subprocess, "run", return_value=Mock(returncode=1, stdout="")
+)
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_list_returncode_nonzero(mock_which, mock_run, capsys):
+    """`gnome-extensions list` returning non-zero: silent no-op."""
+    mousegrid_plugin.ensure_grid_extension()
+
+    assert capsys.readouterr().err == ""
+
+
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_already_installed_and_enabled(mock_which, capsys):
+    """UUID in both `list` and `list --enabled`: short-circuit, announce state."""
+    listed = Mock(
+        returncode=0, stdout="other@one.com\neasyspeak-grid@local\nthird@two.org\n"
+    )
+    listed_enabled = Mock(
+        returncode=0, stdout="easyspeak-grid@local\nother-on@two.org\n"
+    )
+    with patch.object(
+        mousegrid_plugin.subprocess, "run", side_effect=[listed, listed_enabled]
+    ) as mock_run:
+        mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "already installed and enabled" in captured.err
+    assert "easyspeak-grid@local" in captured.err
+    # No `enable` call needed — only the two probe calls.
+    assert mock_run.call_count == 2
+
+
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_installed_but_disabled_enable_succeeds(
+    mock_which, capsys
+):
+    """UUID in `list` but not in `list --enabled`: flip it on and announce."""
+    listed = Mock(returncode=0, stdout="other@one.com\neasyspeak-grid@local\n")
+    listed_enabled = Mock(returncode=0, stdout="other-on@two.org\n")
+    enabled = Mock(returncode=0, stdout="")
+    with patch.object(
+        mousegrid_plugin.subprocess,
+        "run",
+        side_effect=[listed, listed_enabled, enabled],
+    ) as mock_run:
+        mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "enabled GNOME extension easyspeak-grid@local" in captured.err
+    assert "was installed but disabled" in captured.err
+    assert mock_run.call_count == 3
+    assert mock_run.call_args_list[2].args[0] == [
+        "gnome-extensions",
+        "enable",
+        "easyspeak-grid@local",
+    ]
+
+
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_installed_but_disabled_enable_fails(mock_which, capsys):
+    """Installed-but-disabled and `enable` fails: print a hint, no log-out wording."""
+    listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
+    listed_enabled = Mock(returncode=0, stdout="")
+    enabled = Mock(returncode=1, stdout="")
+    with patch.object(
+        mousegrid_plugin.subprocess,
+        "run",
+        side_effect=[listed, listed_enabled, enabled],
+    ):
+        mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "installed but disabled, and could not be enabled" in captured.err
+    assert "gnome-extensions enable easyspeak-grid@local" in captured.err
+    # The "log out and back in" hint is only for fresh installs.
+    assert "log out" not in captured.err
+
+
+@patch.object(mousegrid_plugin.Path, "is_file", return_value=False)
+@patch.object(
+    mousegrid_plugin.subprocess, "run", return_value=Mock(returncode=0, stdout="")
+)
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_source_files_missing(
+    mock_which, mock_run, mock_is_file, capsys
+):
+    """When extension source files aren't at the project root: polite note."""
+    mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "mousegrid: note:" in captured.err
+    assert "source files not found" in captured.err
+
+
+@patch.object(
+    mousegrid_plugin.subprocess, "run", return_value=Mock(returncode=0, stdout="")
+)
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+@patch.object(mousegrid_plugin.shutil, "copy2", side_effect=PermissionError("ro"))
+def test_ensure_grid_extension_copy_fails(
+    mock_copy, mock_which, mock_run, tmp_path, monkeypatch, capsys
+):
+    """copy2 raising OSError: polite note, no enable attempt."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "mousegrid: note:" in captured.err
+    assert "could not install GNOME extension" in captured.err
+    # Only the two probe calls (`list` and `list --enabled`); no `enable`
+    # attempt after copy failure.
+    assert mock_run.call_count == 2
+
+
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_install_and_enable_success(
+    mock_which, tmp_path, monkeypatch, capsys
+):
+    """Happy path: copies files and enables, prints success message."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    listed = Mock(returncode=0, stdout="other@one.com\n")
+    listed_enabled = Mock(returncode=0, stdout="other-on@two.org\n")
+    enabled = Mock(returncode=0, stdout="")
+    with patch.object(
+        mousegrid_plugin.subprocess,
+        "run",
+        side_effect=[listed, listed_enabled, enabled],
+    ):
+        mousegrid_plugin.ensure_grid_extension()
+
+    dest = (
+        tmp_path
+        / ".local"
+        / "share"
+        / "gnome-shell"
+        / "extensions"
+        / "easyspeak-grid@local"
+    )
+    assert (dest / "extension.js").is_file()
+    assert (dest / "metadata.json").is_file()
+
+    captured = capsys.readouterr()
+    assert "installed and enabled" in captured.err
+
+
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_install_succeeds_enable_returncode_nonzero(
+    mock_which, tmp_path, monkeypatch, capsys
+):
+    """Install succeeds, but `enable` returns non-zero: log-out hint."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    listed = Mock(returncode=0, stdout="other@one.com\n")
+    listed_enabled = Mock(returncode=0, stdout="")
+    enabled = Mock(returncode=1, stdout="")
+    with patch.object(
+        mousegrid_plugin.subprocess,
+        "run",
+        side_effect=[listed, listed_enabled, enabled],
+    ):
+        mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "log out and back in" in captured.err
+    # No manual `gnome-extensions enable` instruction — next startup
+    # picks it up via the installed-but-disabled branch.
+    assert "gnome-extensions enable" not in captured.err
+
+
+@patch.object(
+    mousegrid_plugin.shutil, "which", return_value="/usr/bin/gnome-extensions"
+)
+def test_ensure_grid_extension_install_succeeds_enable_oserror(
+    mock_which, tmp_path, monkeypatch, capsys
+):
+    """Install succeeds, but `enable` raises OSError: log-out hint."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    listed = Mock(returncode=0, stdout="other@one.com\n")
+    listed_enabled = Mock(returncode=0, stdout="")
+    with patch.object(
+        mousegrid_plugin.subprocess,
+        "run",
+        side_effect=[listed, listed_enabled, OSError("boom")],
+    ):
+        mousegrid_plugin.ensure_grid_extension()
+
+    captured = capsys.readouterr()
+    assert "log out and back in" in captured.err
 
 
 @patch("subprocess.run", return_value=Mock(returncode=0, stdout="", stderr=""))


### PR DESCRIPTION
This change is both a refactoring (new config module) and a usability enhancement (auto-configuration).

We add `src/core/config.py` for tuning constants, env overrides, and the Whisper model factory — `main.py` now imports from it instead of defining everything inline.

We move the qutebrowser config write into `plugins/browser.py`, the GNOME toolkit-accessibility flip into `plugins/dictation.py` and installing the Grid GNOME Shell extension into `plugins/00_mousegrid.py`, where each runs from the plugin's `setup()` hook. The helpers are idempotent and fail politely (the qutebrowser helper appends only missing lines via a grep-style check so existing user content is preserved, and warns gracefully on read-only configs like Nix Home-Manager symlinks).

README sections 6 and 7 are now obsolete and were hence dropped; the troubleshooting block keeps the manual gsettings + qutebrowser snippets as fallbacks for when the auto-config can't apply.

All three modules at 100% test coverage.