### PR TITLE
perf(tts): load the voice model once via a persistent piper process

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,7 +20,7 @@ jobs:
         - lint --
         - types
         - package
-        - functional
+        - gate
       fail-fast: false
     steps:
     - uses: actions/checkout@v6

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@
 
 # Show this usage screen (default)
 @help:
-    just --list
+    just --list --unsorted
 
 # Run codestyle and safety checks, tests, packaging and cleanup
 [group('lifecycle')]
@@ -65,7 +65,7 @@ test *args:
 # Run pytest (use -q for silent, -v for verbose, -s for debug, -x to stop on error)
 [group('tests')]
 pytest *args:
-    uv run --with=coverage[toml] --with=pytest coverage run -m pytest {{ args }}
+    uv run --extra=unittest coverage run -m pytest {{ args }}
 
 # Display test coverage report
 [group('tests')]
@@ -73,26 +73,36 @@ coverage:
     uvx coverage[toml] xml
     uvx coverage[toml] report
 
+# Run integration tests (exercise external commands for real)
+[group('tests')]
+integration *args=('-v'):
+    uv run --extra=integration pytest tests/integration {{ args }}
+
+# Run acceptance tests (Gherkin scenarios via pytest-bdd)
+[group('tests')]
+acceptance *args:
+    uv run --extra=acceptance pytest tests/acceptance {{ args }}
+
 # Run Whisper benchmarks (writes results.json for bencher.dev)
 [group('tests')]
 benchmark *args:
     uv run --extra=benchmark pytest tests/benchmarks/ \
         --benchmark-json=results.json {{ args }}
 
-# Run functional tests on a built package
-[group('tests')]
-functional: (clean '--quiet') (package '--quiet')
+# Build package and check metadata
+[group('release')]
+package *args:
+    uv build {{ args }}
+
+# Runs plausibility checks against freshly built packages
+[group('release')]
+gate: (clean '--quiet') (package '--quiet')
     # Python package should not contain tests (MANIFEST.in)
     ! unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep tests
     ! tar tfz dist/easyspeak_linux-*.tar.gz | grep tests
     # Python package should contain Core module
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q core
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q core
-
-# Build package and check metadata
-[group('release')]
-package *args:
-    uv build {{ args }}
 
 # Verify package version is same as Git tag
 [group('release')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+acceptance = [
+  "pytest>=8",
+  "pytest-bdd>=7",
+]
 benchmark = [
   "pytest>=8",
   "pytest-benchmark>=5",
@@ -59,9 +63,16 @@ head-tracking = [
   "opencv-python>=4.13.0.90",
   "sixdrepnet>=0.1.6",
 ]
+integration = [
+  "pytest>=8",
+]
 mypy = [
   "mypy>=1.19.1",
   "types-pyaudio>=0.2.16.20250801",
+]
+unittest = [
+  "coverage[toml]>=7.14",
+  "pytest>=8",
 ]
 
 [project.scripts]
@@ -84,9 +95,13 @@ warn_unreachable = true
 warn_unused_ignores = true
 
 [tool.pytest.ini_options]
-# Whisper benchmarks download large models and take minutes; opt-in only.
-# Run them with `just benchmark` or `pytest tests/benchmarks/`.
-addopts = "--ignore=tests/benchmarks"
+# Folders excluded from default discovery are opt-in: they need preparation
+# the plain unit run doesn't (large model downloads, real external binaries,
+# an audio server). Each has its own `just` target.
+#   tests/acceptance  -> `just acceptance`  (Gherkin scenarios; needs pytest-bdd)
+#   tests/benchmarks  -> `just benchmark`   (downloads large Whisper models)
+#   tests/integration -> `just integration` (runs real piper/audio-player binaries)
+addopts = "--ignore=tests/acceptance --ignore=tests/benchmarks --ignore=tests/integration"
 
 [tool.ruff.lint]
 extend-select = ["I"]  # "ALL" one day

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -7,13 +7,16 @@ Uses OpenWakeWord for fast wake detection.
 """
 
 import importlib
+import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 import time
 import wave
 from pathlib import Path
+from subprocess import TimeoutExpired
 
 import numpy as np
 import pyaudio
@@ -37,6 +40,11 @@ from .config import (
 # CORE CLASS
 # =============================================================================
 
+# Seconds to wait after spawning the piper -> player pipeline before trusting
+# it: long enough for an immediate failure (bad model, bad flag) to surface,
+# short enough to barely register during the one-time warmup.
+SPEECH_SPAWN_GRACE = 0.2
+
 
 class EasySpeak:
     def __init__(self):
@@ -46,6 +54,10 @@ class EasySpeak:
         self.audio = None
         self.stream = None
         self.last_wake_time = 0
+        # Persistent text-to-speech pipeline (piper -> audio player) so the
+        # voice model is loaded only once.
+        self._piper = None
+        self._player = None
 
     # --- Utilities for plugins ---
 
@@ -57,25 +69,161 @@ class EasySpeak:
             )
         return subprocess.run(cmd, capture_output=True, text=True)
 
+    def _piper_sample_rate(self):
+        """Read the model's output sample rate (defaults to 22050)."""
+        try:
+            with open(f"{PIPER_MODEL}.json") as f:
+                return int(json.load(f)["audio"]["sample_rate"])
+        except (OSError, ValueError, KeyError, TypeError):
+            return 22050
+
+    def _player_cmd(self, rate):
+        """Pick a player that streams raw 16-bit mono PCM from stdin."""
+        if shutil.which("pw-play"):
+            return [
+                "pw-play",
+                "--raw",
+                "--format",
+                "s16",
+                "--rate",
+                str(rate),
+                "--channels",
+                "1",
+                "-",
+            ]
+        if shutil.which("paplay"):
+            return [
+                "paplay",
+                "--raw",
+                "--format=s16le",
+                f"--rate={rate}",
+                "--channels=1",
+            ]
+        # Last resort: ffplay (may quit on long silent gaps between utterances).
+        return [
+            "ffplay",
+            "-f",
+            "s16le",
+            "-ar",
+            str(rate),
+            "-ch_layout",
+            "mono",
+            "-nodisp",
+            "-autoexit",
+            "-i",
+            "-",
+        ]
+
+    @staticmethod
+    def _alive(proc):
+        return proc is not None and proc.poll() is None
+
+    def _ensure_speech(self):
+        """Spawn the persistent piper -> player pipeline if not already running.
+
+        Keeping piper alive avoids reloading its model (~2s) on every phrase,
+        and streaming raw audio straight to the player means playback starts as
+        soon as synthesis does instead of after a temp WAV is fully written.
+        """
+        if self._alive(self._piper) and self._alive(self._player):
+            return
+        self._kill_speech()  # clear out any half-dead pipeline first
+        rate = self._piper_sample_rate()
+        try:
+            self._player = subprocess.Popen(
+                self._player_cmd(rate),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            self._piper = subprocess.Popen(
+                ["piper", "--model", PIPER_MODEL, "--output-raw"],
+                stdin=subprocess.PIPE,
+                stdout=self._player.stdin,
+                stderr=subprocess.DEVNULL,
+            )
+            # A bad model path or unsupported player flag lets Popen succeed but
+            # the process dies milliseconds later. Give it a brief grace period
+            # and confirm both are still alive, so warmup reports the failure
+            # once instead of speak() rebuilding a dead pipeline on every phrase.
+            time.sleep(SPEECH_SPAWN_GRACE)
+            if not (self._alive(self._piper) and self._alive(self._player)):
+                raise OSError("speech pipeline exited immediately after start")
+        except Exception:
+            self._kill_speech()  # don't leak a half-spawned pipeline
+            raise
+
     def speak(self, text):
-        """Text-to-speech output."""
+        """Text-to-speech output.
+
+        Non-blocking: the phrase is handed to a warm piper process that streams
+        audio to the player, so this returns immediately and the speech plays
+        concurrently with whatever the caller does next.
+        """
+        text = text.strip()
+        if not text:
+            return
         print(f"💬 {text}")
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            output_file = f.name
+        for _ in range(2):
+            try:
+                self._ensure_speech()
+                self._piper.stdin.write((text + "\n").encode())
+                self._piper.stdin.flush()
+                return
+            except (BrokenPipeError, OSError, ValueError):
+                self._kill_speech()  # tear down the broken pipeline, then retry
 
-        subprocess.Popen(
-            ["piper", "--model", PIPER_MODEL, "--output_file", output_file],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        ).communicate(input=text.encode())
+    @staticmethod
+    def _reap(proc):
+        """Kill a process, close its parent-side pipes, and wait for it, best-effort.
 
-        subprocess.run(
-            ["ffplay", "-nodisp", "-autoexit", output_file],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        os.remove(output_file)
+        Both pipeline processes are spawned with stdin=PIPE, so the parent holds
+        a pipe fd for each; without closing them here, a repeatedly rebuilt
+        pipeline would leak two fds per cycle until it hits the fd limit. kill()
+        polls first and suppresses the PID-reuse race internally on Python 3.10+,
+        but ProcessLookupError is named anyway to stay safe on other versions;
+        AttributeError covers a malformed process handle and TimeoutExpired a
+        process that refuses to die.
+        """
+        for name in ("stdin", "stdout", "stderr"):
+            handle = getattr(proc, name, None)  # tolerate a handle missing these
+            if handle is not None:
+                try:
+                    handle.close()
+                except (AttributeError, OSError):
+                    pass
+        try:
+            proc.kill()
+            proc.wait(timeout=1)
+        except (AttributeError, ProcessLookupError, TimeoutExpired):
+            pass
+
+    def _kill_speech(self):
+        """Stop the pipeline at once (no wait for playback) so it can rebuild."""
+        for proc in (self._piper, self._player):
+            if proc is not None:
+                self._reap(proc)
+        self._piper = self._player = None
+
+    @staticmethod
+    def _close(proc):
+        """Close stdin and wait for the process, killing it if it overruns."""
+        try:
+            proc.stdin.close()  # flush may raise if the downstream player died
+            proc.wait(timeout=15)
+        except (AttributeError, OSError, TimeoutExpired):
+            EasySpeak._reap(proc)
+
+    def _drain_speech(self):
+        """Flush pending speech and wait for playback to finish, then stop the
+        pipeline. Used on shutdown so a final phrase (e.g. "Goodbye.") is heard
+        in full before the process exits."""
+        piper, player = self._piper, self._player
+        self._piper = self._player = None
+        if piper is not None:
+            self._close(piper)
+        if player is not None:
+            self._close(player)
 
     # --- Plugin management ---
 
@@ -222,6 +370,14 @@ class EasySpeak:
             print("No plugins loaded. Exiting.")
             return
 
+        # Warm up the text-to-speech pipeline now so the piper model is loaded
+        # during startup, not on the first spoken response.
+        print("Warming up speech...")
+        try:
+            self._ensure_speech()
+        except OSError:
+            print("Speech unavailable; continuing without it.")
+
         print("""
 ╔══════════════════════════════════════════╗
 ║            EasySpeak                     ║
@@ -231,16 +387,16 @@ class EasySpeak:
 ╚══════════════════════════════════════════╝
 """)
 
-        self.audio = pyaudio.PyAudio()
-        self.stream = self.audio.open(
-            format=pyaudio.paInt16,
-            channels=1,
-            rate=16000,
-            input=True,
-            frames_per_buffer=1280,
-        )
-
         try:
+            self.audio = pyaudio.PyAudio()
+            self.stream = self.audio.open(
+                format=pyaudio.paInt16,
+                channels=1,
+                rate=16000,
+                input=True,
+                frames_per_buffer=1280,
+            )
+
             print("Listening for wake word...")
             audio_buffer = []
 
@@ -300,9 +456,12 @@ class EasySpeak:
         except KeyboardInterrupt:
             print("\nBye!")
         finally:
-            self.stream.stop_stream()
-            self.stream.close()
-            self.audio.terminate()
+            self._drain_speech()
+            if self.stream is not None:
+                self.stream.stop_stream()
+                self.stream.close()
+            if self.audio is not None:
+                self.audio.terminate()
 
 
 def run():

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -1,0 +1,30 @@
+# Acceptance tests
+
+Behavioral, user-facing scenarios written in **Gherkin** and run by
+**pytest-bdd**.
+
+They describe the *contract* of a behaviour in business-readable language
+— `Given / When / Then` — rather than poking at internals.
+
+## How they run
+
+Spoken audio can't be verified by listening in an automated run, so these
+scenarios drive the real `EasySpeak` object with the **subprocess boundary
+stubbed** and assert the observable contract (model loaded once, blank
+ignored, flushed on shutdown, recovery).
+
+Like `tests/integration` and `tests/benchmarks`, this folder is **excluded
+from default discovery** (see `pyproject.toml`) and is opt-in:
+
+```sh
+just acceptance       # uv run --extra=acceptance pytest tests/acceptance
+just acceptance -v    # extra pytest args pass through
+```
+
+## Layout
+
+```sh
+features/*.feature    # Gherkin scenarios (the readable spec)
+test_*.py             # scenarios(...) binding + @given/@when/@then steps
+conftest.py           # stubs the ML/audio imports so EasySpeak loads
+```

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,0 +1,20 @@
+"""Setup for the voice-feedback acceptance scenarios (pytest-bdd).
+
+Spoken feedback can't be checked by listening in an automated run, so
+these scenarios drive the real EasySpeak object with the subprocess boundary
+stubbed. They assert the *observable contract* of speak()/drain — model
+loaded once, blank ignored, flushed on shutdown, recovery after a break —
+rather than audio leaving a speaker.
+
+**Note:** See integration tests for test-driving external binaries for real.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# easyspeak.core imports pyaudio/openwakeword/faster_whisper at load time; stub
+# them so importing EasySpeak doesn't require the ML/audio stack.
+sys.modules["pyaudio"] = MagicMock()
+sys.modules["openwakeword"] = MagicMock()
+sys.modules["openwakeword.model"] = MagicMock()
+sys.modules["faster_whisper"] = MagicMock()

--- a/tests/acceptance/features/voice_feedback.feature
+++ b/tests/acceptance/features/voice_feedback.feature
@@ -1,0 +1,30 @@
+Feature: Spoken voice feedback
+  As someone controlling my Linux desktop by voice
+  I want each command confirmed by immediate spoken feedback
+  So that I know it registered without watching the screen
+
+  (**Note:** The real piper/player binaries are exercised
+  separately in tests/integration.)
+
+  Scenario: The voice model is loaded only once across phrases
+    Given a fresh EasySpeak with a stubbed speech pipeline
+    When I speak "opening files"
+    And I speak "closing files"
+    Then the voice model is loaded only once
+    And both phrases are sent to the speech pipeline
+
+  Scenario: Blank feedback is never spoken
+    Given a fresh EasySpeak with a stubbed speech pipeline
+    When I speak "   "
+    Then no speech pipeline is started
+
+  Scenario: A final phrase is heard in full on shutdown
+    Given a fresh EasySpeak with a stubbed speech pipeline
+    And I have spoken "goodbye"
+    When the app drains speech on shutdown
+    Then the pending phrase is flushed and played to completion
+
+  Scenario: Speech recovers when the pipeline breaks
+    Given a fresh EasySpeak whose speech pipeline fails once then recovers
+    When I speak "open browser"
+    Then the phrase is delivered after the pipeline is rebuilt

--- a/tests/acceptance/test_voice_feedback.py
+++ b/tests/acceptance/test_voice_feedback.py
@@ -1,0 +1,83 @@
+"""Step definitions binding voice_feedback.feature to EasySpeak's behaviour."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from easyspeak.core.main import EasySpeak
+from pytest_bdd import given, parsers, scenarios, then, when
+
+scenarios("features/voice_feedback.feature")
+
+
+def _live_proc():
+    """A subprocess mock that reports itself as still running."""
+    proc = Mock()
+    proc.poll.return_value = None
+    return proc
+
+
+@pytest.fixture
+def speech():
+    """Patch the subprocess boundary and carry per-scenario state between steps."""
+    with patch("subprocess.Popen") as popen:
+        yield {"popen": popen}
+
+
+@given("a fresh EasySpeak with a stubbed speech pipeline")
+def fresh_easyspeak(speech):
+    player, piper = _live_proc(), _live_proc()
+    speech["popen"].side_effect = [player, piper]
+    speech["easy"] = EasySpeak()
+    speech["player"], speech["piper"] = player, piper
+
+
+@given("a fresh EasySpeak whose speech pipeline fails once then recovers")
+def flaky_easyspeak(speech):
+    player1, broken = _live_proc(), _live_proc()
+    broken.stdin.write.side_effect = BrokenPipeError()
+    player2, healthy = _live_proc(), _live_proc()
+    speech["popen"].side_effect = [player1, broken, player2, healthy]
+    speech["easy"] = EasySpeak()
+    speech["healthy"] = healthy
+
+
+@given(parsers.parse('I have spoken "{phrase}"'))
+@when(parsers.parse('I speak "{phrase}"'))
+def speak_phrase(speech, phrase):
+    speech["last_phrase"] = phrase
+    speech["easy"].speak(phrase)
+
+
+@when("the app drains speech on shutdown")
+def drain_on_shutdown(speech):
+    speech["easy"]._drain_speech()
+
+
+@then("the voice model is loaded only once")
+def model_loaded_once(speech):
+    # One pipeline build == one player + one piper spawn; reuse spawns nothing.
+    assert speech["popen"].call_count == 2
+
+
+@then("both phrases are sent to the speech pipeline")
+def both_phrases_sent(speech):
+    assert speech["piper"].stdin.write.call_count == 2
+
+
+@then("no speech pipeline is started")
+def no_pipeline_started(speech):
+    speech["popen"].assert_not_called()
+
+
+@then("the pending phrase is flushed and played to completion")
+def pending_phrase_flushed(speech):
+    piper, player = speech["piper"], speech["player"]
+    piper.stdin.close.assert_called_once()  # flush the queued phrase to piper
+    piper.wait.assert_called_once()  # wait for synthesis to finish
+    player.wait.assert_called_once()  # and for playback to drain
+
+
+@then("the phrase is delivered after the pipeline is rebuilt")
+def delivered_after_rebuild(speech):
+    expected = (speech["last_phrase"] + "\n").encode()
+    speech["healthy"].stdin.write.assert_called_once_with(expected)

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock
 # openwakeword isn't a hard dependency on Python 3.13+ (speexdsp-ns wheels
 # missing) and the benchmark doesn't exercise the wake-word path. Stub it
 # before tests import easyspeak.core.main. Same pattern as tests/core/test_main.py.
-sys.modules.setdefault("openwakeword", MagicMock())
-sys.modules.setdefault("openwakeword.model", MagicMock())
+sys.modules["openwakeword"] = MagicMock()
+sys.modules["openwakeword.model"] = MagicMock()
 
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -82,9 +82,9 @@ def test_load_whisper_model_uses_module_defaults():
 
 def test_piper_model_env_override(monkeypatch):
     """EASYSPEAK_PIPER_MODEL overrides the default path."""
-    monkeypatch.setenv("EASYSPEAK_PIPER_MODEL", "/nix/store/abc/voice.onnx")
+    monkeypatch.setenv("EASYSPEAK_PIPER_MODEL", "/opt/voices/voice.onnx")
     importlib.reload(config)
-    assert config.PIPER_MODEL == "/nix/store/abc/voice.onnx"
+    assert config.PIPER_MODEL == "/opt/voices/voice.onnx"
 
 
 def test_whisper_model_env_override(monkeypatch):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # Mock the heavy external dep before importing
-sys.modules.setdefault("faster_whisper", MagicMock())
+sys.modules["faster_whisper"] = MagicMock()
 
 from easyspeak.core import config  # noqa: E402
 

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -3,9 +3,10 @@
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import numpy as np
+import pytest
 
 # Mock all external dependencies before importing the module
 sys.modules["pyaudio"] = MagicMock()
@@ -33,6 +34,12 @@ class TestEasySpeakInit:
 
 class TestEasySpeakUtilities:
     """Tests for EasySpeak utility methods."""
+
+    @pytest.fixture(autouse=True)
+    def _no_spawn_grace(self):
+        """Skip the post-spawn liveness wait so pipeline tests stay instant."""
+        with patch("easyspeak.core.main.SPEECH_SPAWN_GRACE", 0):
+            yield
 
     @patch("subprocess.run")
     def test_host_run_foreground(self, mock_run):
@@ -64,23 +71,18 @@ class TestEasySpeakUtilities:
         assert call_args[1]["stderr"] == subprocess.DEVNULL
         assert result == mock_process
 
-    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
     @patch("subprocess.Popen")
-    @patch("os.remove")
-    @patch("tempfile.NamedTemporaryFile")
-    def test_speak(self, mock_tempfile, mock_remove, mock_popen, mock_run, capsys):
-        """Test speak method."""
+    def test_speak(self, mock_popen, mock_which, capsys):
+        """When speak is called then it streams the phrase to a warm piper process."""
         easy = EasySpeak()
 
-        # Mock temporary file
-        mock_file = Mock()
-        mock_file.name = "/tmp/test.wav"
-        mock_tempfile.return_value.__enter__.return_value = mock_file
-
-        # Mock piper process
+        # Two Popen calls: the player, then piper (whose stdin we write to).
+        mock_player = Mock()
+        mock_player.poll.return_value = None
         mock_piper = Mock()
-        mock_piper.communicate.return_value = (b"", b"")
-        mock_popen.return_value = mock_piper
+        mock_piper.poll.return_value = None
+        mock_popen.side_effect = [mock_player, mock_piper]
 
         easy.speak("Hello world")
 
@@ -88,15 +90,279 @@ class TestEasySpeakUtilities:
         captured = capsys.readouterr()
         assert "💬 Hello world" in captured.out
 
-        # Check that piper was called
-        mock_popen.assert_called_once()
-        assert mock_piper.communicate.called
+        # Pipeline spawned: player + piper
+        assert mock_popen.call_count == 2
+        piper_cmd = mock_popen.call_args_list[1].args[0]
+        assert piper_cmd[0] == "piper"
+        assert "--output-raw" in piper_cmd
 
-        # Check that ffplay was called
-        mock_run.assert_called_once()
+        # Phrase was written to piper's stdin (newline-terminated)
+        mock_piper.stdin.write.assert_called_once_with(b"Hello world\n")
+        assert mock_piper.stdin.flush.called
 
-        # Check that temp file was removed
-        mock_remove.assert_called_once_with("/tmp/test.wav")
+    @patch("subprocess.Popen")
+    def test_speak_reuses_warm_piper(self, mock_popen, capsys):
+        """When speak is called twice then the piper process is reused (model loaded once)."""
+        easy = EasySpeak()
+        mock_player = Mock()
+        mock_player.poll.return_value = None
+        mock_piper = Mock()
+        mock_piper.poll.return_value = None
+        mock_popen.side_effect = [mock_player, mock_piper]
+
+        easy.speak("first")
+        easy.speak("second")
+
+        # Pipeline spawned only once across both phrases
+        assert mock_popen.call_count == 2
+        assert mock_piper.stdin.write.call_count == 2
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_ensure_speech_rebuilds_when_player_dies(self, mock_popen, mock_which):
+        """When the player exits but piper survives then the stale pipeline is
+        killed and rebuilt (no leaked player)."""
+        easy = EasySpeak()
+        old_player = Mock()
+        # Alive at the post-spawn liveness check, dead by the next _ensure_speech.
+        old_player.poll.side_effect = [None, 0]
+        old_piper = Mock()
+        old_piper.poll.return_value = None  # piper still alive
+        new_player, new_piper = Mock(), Mock()
+        new_player.poll.return_value = new_piper.poll.return_value = None
+        mock_popen.side_effect = [old_player, old_piper, new_player, new_piper]
+
+        easy._ensure_speech()  # spawns old pair
+        easy._ensure_speech()  # player dead -> rebuild
+
+        old_piper.kill.assert_called_once()
+        old_player.kill.assert_called_once()
+        assert easy._piper is new_piper and easy._player is new_player
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_ensure_speech_cleans_up_when_piper_spawn_fails(
+        self, mock_popen, mock_which
+    ):
+        """When the player spawns but piper fails (e.g. missing binary) then the
+        partial pipeline is torn down and the error propagates (no leaked player)."""
+        easy = EasySpeak()
+        player = Mock()
+        mock_popen.side_effect = [player, FileNotFoundError("piper")]
+
+        with pytest.raises(FileNotFoundError):
+            easy._ensure_speech()
+
+        player.kill.assert_called_once()
+        assert easy._piper is None and easy._player is None
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_ensure_speech_raises_when_pipeline_dies_immediately(
+        self, mock_popen, mock_which
+    ):
+        """When piper exits right after spawn (e.g. bad model) then the dead
+        pipeline is torn down and OSError is raised so warmup can report it."""
+        easy = EasySpeak()
+        player = Mock()
+        player.poll.return_value = None  # player alive
+        piper = Mock()
+        piper.poll.return_value = 1  # piper died on startup
+        mock_popen.side_effect = [player, piper]
+
+        with pytest.raises(OSError):
+            easy._ensure_speech()
+
+        player.kill.assert_called_once()
+        piper.kill.assert_called_once()
+        assert easy._piper is None and easy._player is None
+
+    def test_kill_speech_swallows_reap_failure(self):
+        """When wait() after kill() fails then _kill_speech still resets state."""
+        easy = EasySpeak()
+        piper = Mock()
+        piper.wait.side_effect = subprocess.TimeoutExpired("piper", 1)
+        easy._piper = piper
+
+        easy._kill_speech()  # must not raise
+
+        piper.kill.assert_called_once()
+        assert easy._piper is None and easy._player is None
+
+    def test_kill_speech_closes_parent_pipes(self):
+        """_kill_speech closes the parent-side stdin handles so a rebuilt
+        pipeline doesn't leak a pipe fd per cycle."""
+        easy = EasySpeak()
+        piper, player = Mock(), Mock()
+        easy._piper, easy._player = piper, player
+
+        easy._kill_speech()
+
+        piper.stdin.close.assert_called_once()
+        player.stdin.close.assert_called_once()
+
+    def test_kill_speech_swallows_pipe_close_failure(self):
+        """A handle whose close() raises (e.g. already-broken pipe) is ignored,
+        and _kill_speech still kills and resets state."""
+        easy = EasySpeak()
+        piper = Mock()
+        piper.stdin.close.side_effect = OSError("broken pipe")
+        easy._piper = piper
+
+        easy._kill_speech()  # must not raise
+
+        piper.kill.assert_called_once()
+        assert easy._piper is None and easy._player is None
+
+    def test_kill_speech_tolerates_malformed_handle(self):
+        """A handle missing stdin/stdout/stderr (and kill) is reaped without
+        raising, as _reap's docstring promises."""
+        easy = EasySpeak()
+        easy._piper = object()  # no stdin/stdout/stderr/kill attributes
+
+        easy._kill_speech()  # must not raise
+
+        assert easy._piper is None and easy._player is None
+
+    @patch("subprocess.Popen")
+    def test_drain_speech_waits_for_playback(self, mock_popen):
+        """When draining then piper stdin is closed and the pipeline is awaited."""
+        easy = EasySpeak()
+        mock_player = Mock()
+        mock_player.poll.return_value = None
+        mock_piper = Mock()
+        mock_piper.poll.return_value = None
+        mock_popen.side_effect = [mock_player, mock_piper]
+
+        easy.speak("Goodbye.")
+        easy._drain_speech()
+
+        mock_piper.stdin.close.assert_called_once()
+        mock_piper.wait.assert_called_once()
+        mock_player.stdin.close.assert_called_once()
+        mock_player.wait.assert_called_once()
+        assert easy._piper is None and easy._player is None
+
+    @patch("subprocess.Popen")
+    def test_speak_ignores_blank_text(self, mock_popen):
+        """When speak is given blank text then no pipeline is spawned."""
+        easy = EasySpeak()
+
+        easy.speak("   ")
+
+        mock_popen.assert_not_called()
+
+    def test_speak_rebuilds_pipeline_on_broken_pipe(self):
+        """When the pipeline write fails then speak rebuilds it and retries once."""
+        easy = EasySpeak()
+        broken = Mock()
+        broken.poll.return_value = None
+        broken.stdin.write.side_effect = BrokenPipeError()
+        healthy = Mock()
+        healthy.poll.return_value = None
+        pipers = [broken, healthy]
+
+        def fake_ensure():
+            easy._piper = pipers.pop(0)
+
+        with patch.object(easy, "_ensure_speech", side_effect=fake_ensure):
+            easy.speak("hello")
+
+        # The rebuilt (healthy) piper received the phrase.
+        healthy.stdin.write.assert_called_once_with(b"hello\n")
+
+    def test_speak_gives_up_after_two_failures(self):
+        """When the pipeline keeps failing then speak gives up without raising."""
+        easy = EasySpeak()
+
+        def fake_ensure():
+            piper = Mock()
+            piper.poll.return_value = None
+            piper.stdin.write.side_effect = OSError()
+            easy._piper = piper
+
+        with patch.object(
+            easy, "_ensure_speech", side_effect=fake_ensure
+        ) as mock_ensure:
+            easy.speak("hello")  # must not raise
+
+        # Tried to (re)build the pipeline twice before giving up.
+        assert mock_ensure.call_count == 2
+
+    def test_piper_sample_rate_reads_model_json(self):
+        """When the model json is readable then its sample rate is used."""
+        easy = EasySpeak()
+
+        with patch(
+            "builtins.open", mock_open(read_data='{"audio": {"sample_rate": 16000}}')
+        ):
+            assert easy._piper_sample_rate() == 16000
+
+    def test_piper_sample_rate_defaults_on_error(self):
+        """When the model json is unreadable then the rate defaults to 22050."""
+        easy = EasySpeak()
+
+        with patch("builtins.open", side_effect=OSError()):
+            assert easy._piper_sample_rate() == 22050
+
+    def test_player_cmd_prefers_pw_play(self):
+        """When pw-play is available then it is used to stream raw audio."""
+        easy = EasySpeak()
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda p: "/bin/pw-play" if p == "pw-play" else None,
+        ):
+            cmd = easy._player_cmd(22050)
+
+        assert cmd[0] == "pw-play"
+        assert "--raw" in cmd and "22050" in cmd
+
+    def test_player_cmd_falls_back_to_paplay(self):
+        """When only paplay is available then it is used."""
+        easy = EasySpeak()
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda p: "/bin/paplay" if p == "paplay" else None,
+        ):
+            cmd = easy._player_cmd(16000)
+
+        assert cmd[0] == "paplay"
+        assert "--rate=16000" in cmd
+
+    def test_player_cmd_falls_back_to_ffplay(self):
+        """When no PipeWire/PulseAudio player exists then ffplay is the last resort."""
+        easy = EasySpeak()
+
+        with patch("shutil.which", return_value=None):
+            cmd = easy._player_cmd(22050)
+
+        assert cmd[0] == "ffplay"
+        assert "-ar" in cmd and "22050" in cmd
+
+    def test_drain_speech_kills_pipeline_on_timeout(self):
+        """When the pipeline does not exit in time then both processes are killed."""
+        easy = EasySpeak()
+        piper = Mock()
+        piper.wait.side_effect = subprocess.TimeoutExpired("piper", 15)
+        player = Mock()
+        player.wait.side_effect = subprocess.TimeoutExpired("player", 15)
+        easy._piper = piper
+        easy._player = player
+
+        easy._drain_speech()
+
+        piper.kill.assert_called_once()
+        player.kill.assert_called_once()
+
+    def test_drain_speech_noop_when_idle(self):
+        """When nothing has been spoken then draining does nothing."""
+        easy = EasySpeak()
+
+        easy._drain_speech()  # must not raise
+
+        assert easy._piper is None and easy._player is None
 
 
 class TestEasySpeakPlugins:
@@ -567,6 +833,12 @@ class TestEasySpeakAudio:
 class TestEasySpeakRun:
     """Tests for EasySpeak run method."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_speech_warmup(self):
+        """Keep run() from spawning the real piper/player pipeline at startup."""
+        with patch.object(EasySpeak, "_ensure_speech") as mock_ensure:
+            yield mock_ensure
+
     @patch("easyspeak.core.main.WakeWordModel")
     @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
@@ -590,6 +862,66 @@ class TestEasySpeakRun:
         # Check output
         captured = capsys.readouterr()
         assert "No plugins loaded. Exiting." in captured.out
+
+    @patch("subprocess.run")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
+    @patch.object(EasySpeak, "load_plugins")
+    def test_run_warms_up_speech(
+        self,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_subprocess_run,
+        mock_plugin,
+        _stub_speech_warmup,
+    ):
+        """When run starts with plugins then the speech pipeline is warmed up once."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin]
+
+        mock_stream = Mock()
+        mock_stream.read.side_effect = KeyboardInterrupt()
+        mock_audio = Mock()
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        easy.run()
+
+        _stub_speech_warmup.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
+    @patch.object(EasySpeak, "load_plugins")
+    def test_run_survives_speech_warmup_failure(
+        self,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_subprocess_run,
+        mock_plugin,
+        _stub_speech_warmup,
+        capsys,
+    ):
+        """When warmup fails (e.g. piper missing) then run still starts."""
+        _stub_speech_warmup.side_effect = OSError()
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin]
+
+        mock_stream = Mock()
+        mock_stream.read.side_effect = KeyboardInterrupt()
+        mock_audio = Mock()
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        easy.run()  # must not raise
+
+        assert "Speech unavailable" in capsys.readouterr().out
 
     @patch("subprocess.run")
     @patch("easyspeak.core.main.pyaudio")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,59 @@
+"""Shared setup for integration tests that drive real external commands.
+
+These tests actually run the piper and audio-player binaries, so they are
+opt-in: `tests/integration` is excluded from default discovery (see
+pyproject.toml) and run via `just integration`. Every test still skips
+gracefully when the binary or audio server it needs is absent, so on an
+unprepared machine the folder degrades to a no-op rather than a failure.
+"""
+
+import shutil
+import subprocess
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# easyspeak.core.config imports faster_whisper at module load, and main imports
+# pyaudio/openwakeword. We only need the command-building helpers here, so stub
+# the heavy deps rather than require a GPU/model just to read an argv list.
+sys.modules["pyaudio"] = MagicMock()
+sys.modules["openwakeword"] = MagicMock()
+sys.modules["openwakeword.model"] = MagicMock()
+sys.modules["faster_whisper"] = MagicMock()
+
+
+def _audio_server_reachable():
+    """True when a PulseAudio or PipeWire server is reachable for playback.
+
+    `pactl info` covers PulseAudio and PipeWire's pulse-compat layer, but a
+    PipeWire box can ship `pw-play` without that layer (no `pactl`); probe the
+    PipeWire server directly so such setups aren't a false negative.
+    """
+    probes = []
+    if shutil.which("pactl"):
+        probes.append(["pactl", "info"])
+    if shutil.which("pw-cli"):
+        probes.append(["pw-cli", "info", "0"])
+    for cmd in probes:
+        try:
+            if (
+                subprocess.run(
+                    cmd,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                ).returncode
+                == 0
+            ):
+                return True
+        except (OSError, subprocess.SubprocessError):
+            continue
+    return False
+
+
+@pytest.fixture(scope="session")
+def audio_server():
+    """Skip the test unless an audio server is available to play into."""
+    if not _audio_server_reachable():
+        pytest.skip("no PulseAudio/PipeWire server reachable")

--- a/tests/integration/test_speech_pipeline.py
+++ b/tests/integration/test_speech_pipeline.py
@@ -1,0 +1,73 @@
+"""Real-execution checks for the text-to-speech pipeline.
+
+The unit suite asserts that ``_player_cmd`` *returns* the right argv; nothing
+there proves the chosen binary actually accepts that invocation. These tests
+close that gap by running the commands for real. They are tiered by how much
+environment preparation each needs:
+
+- ``piper`` synthesis: needs the ``piper`` binary + voice model; no audio device.
+- player playback:      needs the player binary *and* a running audio server.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from easyspeak.core.config import PIPER_MODEL
+from easyspeak.core.main import EasySpeak
+
+# Only the players _player_cmd can actually emit, in its own priority order.
+# (pacat is intentionally absent: _player_cmd never selects it — paplay --raw
+# is the same binary and is what the code uses.)
+PLAYERS = ["pw-play", "paplay", "ffplay"]
+
+
+@pytest.mark.skipif(not shutil.which("piper"), reason="piper not installed")
+@pytest.mark.skipif(
+    not Path(PIPER_MODEL).exists(), reason=f"voice model missing: {PIPER_MODEL}"
+)
+def test_piper_streams_raw_pcm():
+    """piper --output-raw turns a phrase into non-empty PCM on stdout."""
+    proc = subprocess.run(
+        ["piper", "--model", PIPER_MODEL, "--output-raw"],
+        input=b"Integration test.\n",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=60,
+    )
+    assert proc.returncode == 0
+    assert len(proc.stdout) > 0  # got audio samples, not an empty stream
+
+
+@pytest.mark.parametrize("player", PLAYERS)
+def test_player_accepts_our_raw_invocation(player, audio_server, monkeypatch):
+    """The exact argv _player_cmd builds is accepted by the real player.
+
+    This is the check that would have settled the paplay-vs-pacat question:
+    we feed a short, finite silent PCM buffer through the actual command and
+    require a clean exit, which fails loudly if the binary rejects our flags.
+    """
+    if not shutil.which(player):
+        pytest.skip(f"{player} not installed")
+
+    # Force _player_cmd to select exactly this player, regardless of priority.
+    real_which = shutil.which
+    monkeypatch.setattr(
+        "easyspeak.core.main.shutil.which",
+        lambda name: real_which(name) if name == player else None,
+    )
+    rate = 22050
+    cmd = EasySpeak()._player_cmd(rate)
+    assert cmd[0] == player
+
+    # ~0.3s of finite silence so the player consumes the stream and exits.
+    pcm = b"\x00\x00" * int(rate * 0.3)
+    proc = subprocess.run(
+        cmd,
+        input=pcm,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+    )
+    assert proc.returncode == 0, f"{player} rejected our raw-PCM invocation"

--- a/uv.lock
+++ b/uv.lock
@@ -260,6 +260,94 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/69/0d2ef01ff4b8fcecd4cba920d11e92fa4f96ae412441d3b56a90a258e69b/coverage-7.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e3680291c4a1d0dadfa84a2c459576a4af5133abb617905714339a0c73138cf", size = 219722, upload-time = "2026-05-26T20:38:14.002Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ae/9afdeaa31b9d9ce98124b6abf8bb49119bf71aecae04f8567c189d91299f/coverage-7.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a5274669f37f2343635a347b91a60777621341ab3378e9c6ac9335eee704bddf", size = 220240, upload-time = "2026-05-26T20:38:17.424Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/c998589871df7ea7dba865cc5ee32b5a3e1d47ba6c68ef91104c7c46fa5e/coverage-7.14.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cfe5a5fec635799ef33428f1e5e61bafa45a92a96190ba731561ba558ccc214d", size = 246981, upload-time = "2026-05-26T20:38:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/10/1c7d04c13040dac531d21b712bbe08f902e6dd9b58f5d77875c4d030f8f2/coverage-7.14.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:62a9f70b52e0b5a95cfef4a5c5641b06983cadc5e538a3feeb5c00211f523ac2", size = 248812, upload-time = "2026-05-26T20:38:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/65/2a38a4607ef27cadcfbcee034dba5830ae2569f90144a0f4c7dbf47d30b0/coverage-7.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c18ebc343e15be53049b3a2dce38fe82d58f37e20ab9094b3a39c0aa4f6bb47", size = 250675, upload-time = "2026-05-26T20:38:22.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a2/a446ed9752a4a59b79e0fb6cbb319f6facb2183045c0725462625e66f87e/coverage-7.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b84ffdf877644e7096aa936991efeed873f7f3df57b9cd001312b7668ab08550", size = 252590, upload-time = "2026-05-26T20:38:23.63Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/fd/e81fbd7ba752365546e9842b1cbdaad3d6919d2a522c590aef16a281ec5e/coverage-7.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e854312c4103f2ad4c0dc023b69b77ebfd2c89db5f86c4c94dc2353f9a92167e", size = 247691, upload-time = "2026-05-26T20:38:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/53/35/f3c26fdaae9ea937d154ca4d372e5ea0a4167ff70d36c6074ac2eacb2f83/coverage-7.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c643734307300234fafa36bf2a040a7235f8f177ea1fd6ec1423aea6fb7b929f", size = 248716, upload-time = "2026-05-26T20:38:26.406Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/14/940b6c49551fd343e8507ee2b0ba7af5d0aa04ed5bf768285cb7c72a9884/coverage-7.14.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:84ac9499e48700399a5dd0ea7085b5091961fec52c68d66b4ec0d3cf7f4441b1", size = 246721, upload-time = "2026-05-26T20:38:28.282Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2c/40fc0634186c28292a662dff578866b3913983d6c375a3c2a74020938719/coverage-7.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7f02d09f70776579b926d889a4c9c235070a1f47c40458aeaca563fae5acfdb5", size = 250533, upload-time = "2026-05-26T20:38:29.753Z" },
+    { url = "https://files.pythonhosted.org/packages/de/e3/2c26bf1e811f9df991ff2a9bdddebdd13ee0665d564df7d05979f9146297/coverage-7.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ce66d8e46da2bb5ee313a745cbd2e391d319176c1f7a9451bfcd3a2fb920859b", size = 246990, upload-time = "2026-05-26T20:38:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b0/060260ef56bd92363ebdce0c7095ce422b06e69aae71828efeca473ab1ca/coverage-7.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c912c259304cfb5ee584481cfb7ce1ff932b4d61e6c9140b8f19cb7b5ed82332", size = 247593, upload-time = "2026-05-26T20:38:33.065Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f3/501502046efeb0d6d94b5ca54941d95f1184183dd6bdb7f283985783bb4a/coverage-7.14.1-cp310-cp310-win32.whl", hash = "sha256:1238cb94638e610e972c60dac68e813f868dc7d6e982535270558443058d9d59", size = 222330, upload-time = "2026-05-26T20:38:35.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5d/1bf99f2c558f128faf7906817ccbdb576ba815d3b41ce2ac1719b70a3663/coverage-7.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:fc459e5d73be2d6332fcfe8dbf3d8994671fe33c700f4565988ecfa511547253", size = 223261, upload-time = "2026-05-26T20:38:37.196Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "ctranslate2"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -380,6 +468,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+acceptance = [
+    { name = "pytest" },
+    { name = "pytest-bdd" },
+]
 benchmark = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -388,13 +480,21 @@ head-tracking = [
     { name = "opencv-python" },
     { name = "sixdrepnet" },
 ]
+integration = [
+    { name = "pytest" },
+]
 mypy = [
     { name = "mypy" },
     { name = "types-pyaudio" },
 ]
+unittest = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "coverage", extras = ["toml"], marker = "extra == 'unittest'", specifier = ">=7.14" },
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "mypy", marker = "extra == 'mypy'", specifier = ">=1.19.1" },
     { name = "numpy", specifier = ">=2.2.6" },
@@ -402,12 +502,16 @@ requires-dist = [
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "opencv-python", marker = "extra == 'head-tracking'", specifier = ">=4.13.0.90" },
     { name = "pyaudio", specifier = ">=0.2.14" },
+    { name = "pytest", marker = "extra == 'acceptance'", specifier = ">=8" },
     { name = "pytest", marker = "extra == 'benchmark'", specifier = ">=8" },
+    { name = "pytest", marker = "extra == 'integration'", specifier = ">=8" },
+    { name = "pytest", marker = "extra == 'unittest'", specifier = ">=8" },
+    { name = "pytest-bdd", marker = "extra == 'acceptance'", specifier = ">=7" },
     { name = "pytest-benchmark", marker = "extra == 'benchmark'", specifier = ">=5" },
     { name = "sixdrepnet", marker = "extra == 'head-tracking'", specifier = ">=0.1.6" },
     { name = "types-pyaudio", marker = "extra == 'mypy'", specifier = ">=0.2.16.20250801" },
 ]
-provides-extras = ["benchmark", "head-tracking", "mypy"]
+provides-extras = ["acceptance", "benchmark", "head-tracking", "integration", "mypy", "unittest"]
 
 [[package]]
 name = "exceptiongroup"
@@ -503,6 +607,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "gherkin-official"
+version = "29.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
 ]
 
 [[package]]
@@ -780,6 +893,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
     { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
     { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1500,6 +1625,28 @@ wheels = [
 ]
 
 [[package]]
+name = "parse"
+version = "1.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f2/0b504486c2a5564798607d3860e48ed19c6443d5e9cc3ec61cc6b8b4ef58/parse-1.22.1.tar.gz", hash = "sha256:d3a4740ec3da338e2b258b2d69741b731eadfddca59e24a14bc4ee5fce38c911", size = 36970, upload-time = "2026-05-26T03:44:52.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/c5/7c16e99869e1f422629092cfd23e3b58e461988c3f9c36fd3624bb4142e6/parse-1.22.1-py2.py3-none-any.whl", hash = "sha256:20f0925a46f06602485ac90d751764d0697fd8455aaa97489ba8953a4b66de32", size = 20925, upload-time = "2026-05-26T03:44:51.156Z" },
+]
+
+[[package]]
+name = "parse-type"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parse" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1673,6 +1820,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-bdd"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gherkin-official" },
+    { name = "mako" },
+    { name = "packaging" },
+    { name = "parse" },
+    { name = "parse-type" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/2f/14c2e55372a5718a93b56aea48cd6ccc15d2d245364e516cd7b19bbd07ad/pytest_bdd-8.1.0.tar.gz", hash = "sha256:ef0896c5cd58816dc49810e8ff1d632f4a12019fb3e49959b2d349ffc1c9bfb5", size = 56147, upload-time = "2024-12-05T21:45:58.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/7d/1461076b0cc9a9e6fa8b51b9dea2677182ba8bc248d99d95ca321f2c666f/pytest_bdd-8.1.0-py3-none-any.whl", hash = "sha256:2124051e71a05ad7db15296e39013593f72ebf96796e1b023a40e5453c47e5fb", size = 49149, upload-time = "2024-12-05T21:45:56.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`speak()` currently spawns a fresh piper process on every call, so the ~1.8s voice model is reloaded each time — spoken feedback always lags ~2s behind the action that triggered it (e.g. opening/closing an app).

We replace this with a single, persistent piper process, so the model loads only once. Its raw PCM is streamed straight to an audio player, which also drops the per-call temp WAV and lets `speak()` return without waiting for playback — feedback now plays concurrently with whatever the caller does next.

- Reuse one long-lived piper process so the model loads once
- Stream its raw PCM to a player instead of writing a temp WAV per call
- Warm up during startup; drain pending speech on shutdown
- Add tests for the new paths