### PR TITLE
feat(apps): add more GNOME apps, handle default terminal

### DIFF
--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -22,9 +22,34 @@ FLATPAK_APPS = {
 
 # Local binary apps
 LOCAL_APPS = {
-    "files": "nautilus",
-    "terminal": "gnome-terminal",
+    "alarm": "gnome-clocks",
     "browser": "qutebrowser",
+    "calculator": "gnome-calculator",
+    "calendar": "gnome-calendar",
+    "camera": "snapshot",
+    "characters": "gnome-characters",
+    "clocks": "gnome-clocks",
+    "connections": "gnome-connections",
+    "contacts": "gnome-contacts",
+    "editor": "gnome-text-editor",
+    "epiphany": "epiphany",
+    "extensions": "gnome-extensions-app",
+    "files": "nautilus",
+    "gimp": "gimp",
+    "inkscape": "inkscape",
+    "logs": "gnome-logs",
+    "maps": "gnome-maps",
+    "music player": "gnome-music",
+    "nautilus": "nautilus",
+    "radio": "shortwave",
+    "scanner": "simple-scan",
+    "settings": "gnome-control-center",
+    "software": "gnome-software",
+    "terminal": "gnome-terminal",
+    "timer": "gnome-clocks",
+    "video player": "showtime",
+    "weather": "gnome-weather",
+    "web": "epiphany",
 }
 
 core = None

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -2,6 +2,8 @@
 Apps Plugin - Launch and close applications
 """
 
+import os
+
 NAME = "apps"
 DESCRIPTION = "Launch and close applications"
 
@@ -45,12 +47,28 @@ LOCAL_APPS = {
     "scanner": "simple-scan",
     "settings": "gnome-control-center",
     "software": "gnome-software",
-    "terminal": "gnome-terminal",
     "timer": "gnome-clocks",
     "video player": "showtime",
     "weather": "gnome-weather",
     "web": "epiphany",
 }
+
+TERMINAL_LAUNCHER = "xdg-terminal-exec"
+TERMINAL_FALLBACKS = [
+    # GNOME's official terminal (Console) and its aliases / predecessor first
+    "kgx",  # GNOME Console (current official terminal) binary name
+    "gnome-console",  # alias / package name for the same app
+    "gnome-terminal",  # legacy GNOME terminal
+    # then GTK / cross-platform terminals commonly used on GNOME, by popularity
+    "ghostty",
+    "alacritty",
+    "kitty",
+    "wezterm",
+    "tilix",
+    "terminator",
+    "guake",
+    "xterm",  # universal last-resort fallback
+]
 
 core = None
 
@@ -58,6 +76,72 @@ core = None
 def setup(c):
     global core
     core = c
+    _register_terminal(c)
+
+
+def _has(binary, core):
+    """Whether a binary is available in PATH."""
+    return core.host_run(["which", binary]).returncode == 0
+
+
+def _register_terminal(core):
+    """Discover the default terminal and register it under the "terminal" key.
+
+    The freedesktop launcher xdg-terminal-exec knows the user's configured
+    default terminal but execs into it, so its own name never appears in the
+    process list (which would break closing via pkill); ask it which binary it
+    would actually run. If it is not installed, fall back to the first known
+    terminal in PATH. When nothing is found no entry is added, so "open
+    terminal" falls through to the normal unrecognized-command handling rather
+    than trying to launch a missing binary.
+    """
+    if _has(TERMINAL_LAUNCHER, core):
+        result = core.host_run([TERMINAL_LAUNCHER, "--print-cmd"])
+        if result.returncode == 0:
+            argv = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+            if _register_from_argv(argv, core):
+                return
+    terminal = next((t for t in TERMINAL_FALLBACKS if _has(t, core)), None)
+    if terminal:
+        LOCAL_APPS["terminal"] = terminal
+
+
+def _register_from_argv(argv, core):
+    """Register the terminal described by xdg-terminal-exec's argv output.
+
+    The argv may be prefixed with env-var assignments or an "env" wrapper (both
+    skipped). A flatpak terminal is registered by app-id so it launches and
+    closes through the flatpak path; a snap terminal is registered by its name,
+    which is itself an executable in PATH; a plain binary is registered as-is.
+
+    The resolved target is validated (flatpak app installed, or binary in PATH)
+    before registering. A stale or uninstalled default terminal returns False so
+    the caller falls back to TERMINAL_FALLBACKS instead of registering a
+    "terminal" entry whose launch would raise.
+    """
+    args = [a for a in argv if "=" not in a and os.path.basename(a) != "env"]
+    if not args:
+        return False
+    command = os.path.basename(args[0])
+    if command in ("flatpak", "snap"):
+        target = next(
+            (a for a in args[1:] if a != "run" and not a.startswith("-")), None
+        )
+        if not target:
+            return False
+        if command == "flatpak":
+            if core.host_run(["flatpak", "info", target]).returncode != 0:
+                return False
+            FLATPAK_APPS["terminal"] = target
+        else:  # snap target is itself an executable in PATH
+            if not _has(target, core):
+                return False
+            LOCAL_APPS["terminal"] = target
+        return True
+    if not _has(args[0], core):
+        return False
+    LOCAL_APPS["terminal"] = args[0]
+    return True
 
 
 def find_app(name, core):

--- a/tests/plugins/test_apps.py
+++ b/tests/plugins/test_apps.py
@@ -1,6 +1,6 @@
 """Tests for the apps plugin module."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from easyspeak.plugins import apps
@@ -61,7 +61,6 @@ def test_find_app_flatpak_not_installed(mock_core_failure, app_name):
     ["app_name", "binary_name"],
     [
         ["files", "nautilus"],
-        ["terminal", "gnome-terminal"],
         ["browser", "qutebrowser"],
     ],
 )
@@ -175,6 +174,260 @@ def test_close_app_not_found(mock_find_app, mock_core):
     assert result is False
     assert mock_find_app.call_args.args == (app_name, mock_core)
     assert not mock_core.host_run.called
+
+
+@pytest.fixture(autouse=True)
+def _reset_apps():
+    """Keep setup()'s discovered terminal entry from leaking between tests."""
+    local, flatpak = apps.LOCAL_APPS.copy(), apps.FLATPAK_APPS.copy()
+    yield
+    apps.LOCAL_APPS.clear()
+    apps.LOCAL_APPS.update(local)
+    apps.FLATPAK_APPS.clear()
+    apps.FLATPAK_APPS.update(flatpak)
+
+
+def test_setup_registers_terminal_via_xdg_spec(mock_core):
+    """When the spec launcher exists, then setup registers the real terminal binary."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(
+                returncode=0,
+                stdout="/opt/ghostty/bin/ghostty\n--gtk-single-instance=true\n",
+            )
+        if cmd == ["which", "/opt/ghostty/bin/ghostty"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "/opt/ghostty/bin/ghostty"
+
+
+def test_setup_skips_env_wrapper_in_xdg_spec(mock_core):
+    """When the spec wraps the terminal in env, then setup registers the binary, not env."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="/usr/bin/env\nFOO=bar\nghostty\n")
+        if cmd == ["which", "ghostty"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "ghostty"
+
+
+def test_setup_registers_flatpak_terminal_by_app_id(mock_core):
+    """When the default terminal is a flatpak, then setup registers it by app-id."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(
+                returncode=0,
+                stdout="flatpak\nrun\n--branch=stable\ncom.raggesilver.BlackBox\n",
+            )
+        if cmd == ["flatpak", "info", "com.raggesilver.BlackBox"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.FLATPAK_APPS["terminal"] == "com.raggesilver.BlackBox"
+    assert "terminal" not in apps.LOCAL_APPS
+
+
+def test_setup_registers_snap_terminal_by_name(mock_core):
+    """When the default terminal is a snap, then setup registers its executable name."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="snap\nrun\nalacritty\n")
+        if cmd == ["which", "alacritty"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "alacritty"
+
+
+def test_setup_falls_back_when_spec_terminal_uninstalled(mock_core):
+    """When the spec names a terminal not in PATH, then setup falls back to PATH."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="ghostty\n")
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+
+
+def test_setup_falls_back_when_spec_flatpak_uninstalled(mock_core):
+    """When the spec names an uninstalled flatpak terminal, then setup falls back."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="flatpak\nrun\ncom.raggesilver.BlackBox\n")
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+    assert "terminal" not in apps.FLATPAK_APPS
+
+
+def test_setup_falls_back_when_spec_snap_uninstalled(mock_core):
+    """When the spec names an uninstalled snap terminal, then setup falls back."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="snap\nrun\nalacritty\n")
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+
+
+def test_setup_falls_back_when_spec_yields_only_env(mock_core):
+    """When the spec output is only an env prefix, then setup falls back to PATH."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="env\nFOO=bar\n")
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+
+
+def test_setup_falls_back_when_wrapper_has_no_target(mock_core):
+    """When a wrapper command names no app, then setup falls back to PATH."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=0, stdout="flatpak\nrun\n--branch=stable\n")
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+
+
+def test_setup_registers_terminal_via_fallback(mock_core):
+    """When the spec launcher is missing, then setup registers the first terminal in PATH."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=1)
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+
+
+def test_setup_falls_back_when_spec_print_fails(mock_core):
+    """When the spec launcher cannot report a command, then setup falls back to PATH."""
+
+    def side_effect(cmd, **kwargs):
+        if cmd == ["which", "xdg-terminal-exec"]:
+            return Mock(returncode=0)
+        if cmd == ["xdg-terminal-exec", "--print-cmd"]:
+            return Mock(returncode=1, stdout="")
+        if cmd == ["which", "kgx"]:
+            return Mock(returncode=0)
+        return Mock(returncode=1)
+
+    mock_core.host_run.side_effect = side_effect
+
+    apps.setup(mock_core)
+
+    assert apps.LOCAL_APPS["terminal"] == "kgx"
+
+
+def test_setup_no_terminal_not_registered(mock_core_failure):
+    """When no terminal can be found, then no terminal entry is registered."""
+    apps.setup(mock_core_failure)
+
+    assert "terminal" not in apps.LOCAL_APPS
+
+
+def test_launch_registered_terminal(mock_core):
+    """When a registered terminal is launched, then its binary runs in the background."""
+    apps.LOCAL_APPS["terminal"] = "ghostty"
+
+    result = apps.launch_app("terminal", mock_core)
+
+    assert result is True
+    assert mock_core.host_run.call_args.args == (["ghostty"],)
+    assert mock_core.host_run.call_args.kwargs == {"background": True}
+
+
+def test_close_registered_terminal(mock_core):
+    """When a registered terminal is closed, then its binary is killed."""
+    apps.LOCAL_APPS["terminal"] = "ghostty"
+
+    result = apps.close_app("terminal", mock_core)
+
+    assert result is True
+    assert mock_core.host_run.call_args.args == (["pkill", "-f", "ghostty"],)
 
 
 @patch("easyspeak.plugins.apps.launch_app", return_value=True)


### PR DESCRIPTION
Adds more GNOME apps to the apps plugin and handles the (default) terminal as a special case.

## More apps

Expands, sorts and alphabetizes `LOCAL_APPS` with common GNOME applications (calendar, contacts, editor, maps, music, weather, ...) so they can be opened and closed by voice.

## Handling the default terminal

`gnome-terminal` is not installed on current GNOME setups (GNOME's terminal is now Console/kgx), so "open terminal" silently failed. Also, some users may prefer a different terminal application and/or uninstall GNOME's default.

We now resolve the real terminal once at `setup()` via the freedesktop default terminal spec (`xdg-terminal-exec --print-cmd`), falling back to a GNOME-first list of known terminals in PATH. The resolved binary is registered in `LOCAL_APPS`, so the existing launch/close logic handles it like any other app; when none is found no entry is added and the command falls through to normal unrecognized-command handling.

Querying `xdg-terminal-exec` for the actual binary is required because it execs into the terminal, so its own name never appears in the process list and `pkill`-based closing would otherwise never match.