### PR TITLE
refactor(core): new `speech` module, suppress ALSA error output

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -7,16 +7,13 @@ Uses OpenWakeWord for fast wake detection.
 """
 
 import importlib
-import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
 import time
 import wave
 from pathlib import Path
-from subprocess import TimeoutExpired
 
 import numpy as np
 import pyaudio
@@ -24,7 +21,6 @@ from openwakeword.model import Model as WakeWordModel
 
 from .config import (
     COMMAND_PROMPT,
-    PIPER_MODEL,
     SILENCE_DURATION,
     SILENCE_THRESHOLD,
     WAKE_COOLDOWN,
@@ -35,15 +31,11 @@ from .config import (
     WHISPER_MODEL,
     load_whisper_model,
 )
+from .speech import SpeechPipeline, suppressed_c_stderr
 
 # =============================================================================
 # CORE CLASS
 # =============================================================================
-
-# Seconds to wait after spawning the piper -> player pipeline before trusting
-# it: long enough for an immediate failure (bad model, bad flag) to surface,
-# short enough to barely register during the one-time warmup.
-SPEECH_SPAWN_GRACE = 0.2
 
 
 class EasySpeak:
@@ -56,8 +48,7 @@ class EasySpeak:
         self.last_wake_time = 0
         # Persistent text-to-speech pipeline (piper -> audio player) so the
         # voice model is loaded only once.
-        self._piper = None
-        self._player = None
+        self.speech = SpeechPipeline()
 
     # --- Utilities for plugins ---
 
@@ -69,161 +60,9 @@ class EasySpeak:
             )
         return subprocess.run(cmd, capture_output=True, text=True)
 
-    def _piper_sample_rate(self):
-        """Read the model's output sample rate (defaults to 22050)."""
-        try:
-            with open(f"{PIPER_MODEL}.json") as f:
-                return int(json.load(f)["audio"]["sample_rate"])
-        except (OSError, ValueError, KeyError, TypeError):
-            return 22050
-
-    def _player_cmd(self, rate):
-        """Pick a player that streams raw 16-bit mono PCM from stdin."""
-        if shutil.which("pw-play"):
-            return [
-                "pw-play",
-                "--raw",
-                "--format",
-                "s16",
-                "--rate",
-                str(rate),
-                "--channels",
-                "1",
-                "-",
-            ]
-        if shutil.which("paplay"):
-            return [
-                "paplay",
-                "--raw",
-                "--format=s16le",
-                f"--rate={rate}",
-                "--channels=1",
-            ]
-        # Last resort: ffplay (may quit on long silent gaps between utterances).
-        return [
-            "ffplay",
-            "-f",
-            "s16le",
-            "-ar",
-            str(rate),
-            "-ch_layout",
-            "mono",
-            "-nodisp",
-            "-autoexit",
-            "-i",
-            "-",
-        ]
-
-    @staticmethod
-    def _alive(proc):
-        return proc is not None and proc.poll() is None
-
-    def _ensure_speech(self):
-        """Spawn the persistent piper -> player pipeline if not already running.
-
-        Keeping piper alive avoids reloading its model (~2s) on every phrase,
-        and streaming raw audio straight to the player means playback starts as
-        soon as synthesis does instead of after a temp WAV is fully written.
-        """
-        if self._alive(self._piper) and self._alive(self._player):
-            return
-        self._kill_speech()  # clear out any half-dead pipeline first
-        rate = self._piper_sample_rate()
-        try:
-            self._player = subprocess.Popen(
-                self._player_cmd(rate),
-                stdin=subprocess.PIPE,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            self._piper = subprocess.Popen(
-                ["piper", "--model", PIPER_MODEL, "--output-raw"],
-                stdin=subprocess.PIPE,
-                stdout=self._player.stdin,
-                stderr=subprocess.DEVNULL,
-            )
-            # A bad model path or unsupported player flag lets Popen succeed but
-            # the process dies milliseconds later. Give it a brief grace period
-            # and confirm both are still alive, so warmup reports the failure
-            # once instead of speak() rebuilding a dead pipeline on every phrase.
-            time.sleep(SPEECH_SPAWN_GRACE)
-            if not (self._alive(self._piper) and self._alive(self._player)):
-                raise OSError("speech pipeline exited immediately after start")
-        except Exception:
-            self._kill_speech()  # don't leak a half-spawned pipeline
-            raise
-
     def speak(self, text):
-        """Text-to-speech output.
-
-        Non-blocking: the phrase is handed to a warm piper process that streams
-        audio to the player, so this returns immediately and the speech plays
-        concurrently with whatever the caller does next.
-        """
-        text = text.strip()
-        if not text:
-            return
-        print(f"💬 {text}")
-        for _ in range(2):
-            try:
-                self._ensure_speech()
-                self._piper.stdin.write((text + "\n").encode())
-                self._piper.stdin.flush()
-                return
-            except (BrokenPipeError, OSError, ValueError):
-                self._kill_speech()  # tear down the broken pipeline, then retry
-
-    @staticmethod
-    def _reap(proc):
-        """Kill a process, close its parent-side pipes, and wait for it, best-effort.
-
-        Both pipeline processes are spawned with stdin=PIPE, so the parent holds
-        a pipe fd for each; without closing them here, a repeatedly rebuilt
-        pipeline would leak two fds per cycle until it hits the fd limit. kill()
-        polls first and suppresses the PID-reuse race internally on Python 3.10+,
-        but ProcessLookupError is named anyway to stay safe on other versions;
-        AttributeError covers a malformed process handle and TimeoutExpired a
-        process that refuses to die.
-        """
-        for name in ("stdin", "stdout", "stderr"):
-            handle = getattr(proc, name, None)  # tolerate a handle missing these
-            if handle is not None:
-                try:
-                    handle.close()
-                except (AttributeError, OSError):
-                    pass
-        try:
-            proc.kill()
-            proc.wait(timeout=1)
-        except (AttributeError, ProcessLookupError, TimeoutExpired):
-            pass
-
-    def _kill_speech(self):
-        """Stop the pipeline at once (no wait for playback) so it can rebuild."""
-        for proc in (self._piper, self._player):
-            if proc is not None:
-                self._reap(proc)
-        self._piper = self._player = None
-
-    @staticmethod
-    def _close(proc):
-        """Close stdin and wait for the process, killing it if it overruns."""
-        try:
-            proc.stdin.close()  # flush may raise if the downstream player died
-            proc.wait(timeout=15)
-        except (AttributeError, OSError, TimeoutExpired):
-            EasySpeak._reap(proc)
-
-    def _drain_speech(self):
-        """Flush pending speech and wait for playback to finish, then stop the
-        pipeline. Used on shutdown so a final phrase (e.g. "Goodbye.") is heard
-        in full before the process exits."""
-        piper, player = self._piper, self._player
-        self._piper = self._player = None
-        if piper is not None:
-            self._close(piper)
-        if player is not None:
-            self._close(player)
+        """Speak a phrase. Stable plugin-facing API; delegates to the pipeline."""
+        self.speech.speak(text)
 
     # --- Plugin management ---
 
@@ -374,7 +213,7 @@ class EasySpeak:
         # during startup, not on the first spoken response.
         print("Warming up speech...")
         try:
-            self._ensure_speech()
+            self.speech.ensure()
         except OSError:
             print("Speech unavailable; continuing without it.")
 
@@ -388,14 +227,19 @@ class EasySpeak:
 """)
 
         try:
-            self.audio = pyaudio.PyAudio()
-            self.stream = self.audio.open(
-                format=pyaudio.paInt16,
-                channels=1,
-                rate=16000,
-                input=True,
-                frames_per_buffer=1280,
-            )
+            # PortAudio probes every ALSA/JACK device on init and on open,
+            # spamming stderr about hardware this machine lacks; redirect fd 2
+            # to silence that C-level noise just for these two calls, which
+            # emit no Python stderr output of their own.
+            with suppressed_c_stderr():
+                self.audio = pyaudio.PyAudio()
+                self.stream = self.audio.open(
+                    format=pyaudio.paInt16,
+                    channels=1,
+                    rate=16000,
+                    input=True,
+                    frames_per_buffer=1280,
+                )
 
             print("Listening for wake word...")
             audio_buffer = []
@@ -456,7 +300,7 @@ class EasySpeak:
         except KeyboardInterrupt:
             print("\nBye!")
         finally:
-            self._drain_speech()
+            self.speech.drain()
             if self.stream is not None:
                 self.stream.stop_stream()
                 self.stream.close()

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -1,0 +1,235 @@
+"""Text-to-speech playback pipeline and audio-device noise suppression.
+
+Extracted from core.main so the orchestration loop isn't tangled up with the
+subprocess plumbing that keeps a piper voice model warm. `SpeechPipeline` owns
+a persistent `piper -> player` pair; `suppressed_c_stderr` hides the unrelated
+ALSA/JACK probe spew PortAudio emits when the input side (PyAudio) starts up.
+"""
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from subprocess import TimeoutExpired
+
+from .config import PIPER_MODEL
+
+# Seconds to wait after spawning the piper -> player pipeline before trusting
+# it: long enough for an immediate failure (bad model, bad flag) to surface,
+# short enough to barely register during the one-time warmup.
+SPEECH_SPAWN_GRACE = 0.2
+
+
+@contextlib.contextmanager
+def suppressed_c_stderr():
+    """Silence the device-probe spew PortAudio dumps when PyAudio starts up.
+
+    Initializing PyAudio makes PortAudio enumerate every ALSA PCM named in the
+    system alsa.conf (surround*, hdmi, iec958, ...) and ping JACK. Devices the
+    machine doesn't have each print a harmless error, and libasound/libjack
+    write them straight to file descriptor 2 from C — Python's sys.stderr never
+    sees them, so only redirecting the fd itself can hide them.
+
+    Suppression is best-effort: if stderr has no real fd (e.g. captured in
+    tests), the fd can't be snapshotted (e.g. fd exhaustion), or the fd swap
+    itself fails (e.g. fd 2 closed/invalid), there's nothing safe to redirect,
+    so pass through rather than abort the caller.
+    """
+    try:
+        stderr_fd = sys.stderr.fileno()
+        # Flush first so already-buffered Python output lands on the real
+        # stderr and not the /dev/null we're about to swap in.
+        sys.stderr.flush()
+        saved_fd = os.dup(stderr_fd)
+    except (AttributeError, OSError, ValueError):
+        yield
+        return
+    try:
+        with open(os.devnull, "w") as devnull:
+            try:
+                os.dup2(devnull.fileno(), stderr_fd)
+            except OSError:
+                # Couldn't point fd 2 at /dev/null; run the body unsuppressed
+                # rather than abort the caller, as the docstring promises.
+                yield
+                return
+            try:
+                yield
+            finally:
+                # Best-effort restore: a failed swap-back must not mask the
+                # outcome of the body we just ran.
+                with contextlib.suppress(OSError):
+                    os.dup2(saved_fd, stderr_fd)
+    finally:
+        os.close(saved_fd)
+
+
+class SpeechPipeline:
+    """A persistent ``piper -> audio player`` pipeline for low-latency speech.
+
+    Keeping piper alive avoids reloading its voice model (~2s) on every phrase,
+    and streaming raw PCM straight to the player means playback starts as soon
+    as synthesis does instead of after a temp WAV is fully written.
+    """
+
+    def __init__(self):
+        self._piper = None
+        self._player = None
+
+    def _piper_sample_rate(self):
+        """Read the model's output sample rate (defaults to 22050)."""
+        try:
+            with open(f"{PIPER_MODEL}.json") as f:
+                return int(json.load(f)["audio"]["sample_rate"])
+        except (OSError, ValueError, KeyError, TypeError):
+            return 22050
+
+    def _player_cmd(self, rate):
+        """Pick a player that streams raw 16-bit mono PCM from stdin."""
+        if shutil.which("pw-play"):
+            return [
+                "pw-play",
+                "--raw",
+                "--format",
+                "s16",
+                "--rate",
+                str(rate),
+                "--channels",
+                "1",
+                "-",
+            ]
+        if shutil.which("paplay"):
+            return [
+                "paplay",
+                "--raw",
+                "--format=s16le",
+                f"--rate={rate}",
+                "--channels=1",
+            ]
+        # Last resort: ffplay (may quit on long silent gaps between utterances).
+        return [
+            "ffplay",
+            "-f",
+            "s16le",
+            "-ar",
+            str(rate),
+            "-ch_layout",
+            "mono",
+            "-nodisp",
+            "-autoexit",
+            "-i",
+            "-",
+        ]
+
+    @staticmethod
+    def _alive(proc):
+        return proc is not None and proc.poll() is None
+
+    def ensure(self):
+        """Spawn the persistent piper -> player pipeline if not already running.
+
+        Raises OSError if the pipeline can't be brought up (missing binary, bad
+        model), so callers can warn once rather than silently failing per phrase.
+        """
+        if self._alive(self._piper) and self._alive(self._player):
+            return
+        self._kill_speech()  # clear out any half-dead pipeline first
+        rate = self._piper_sample_rate()
+        try:
+            self._player = subprocess.Popen(
+                self._player_cmd(rate),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            self._piper = subprocess.Popen(
+                ["piper", "--model", PIPER_MODEL, "--output-raw"],
+                stdin=subprocess.PIPE,
+                stdout=self._player.stdin,
+                stderr=subprocess.DEVNULL,
+            )
+            # A bad model path or unsupported player flag lets Popen succeed but
+            # the process dies milliseconds later. Give it a brief grace period
+            # and confirm both are still alive, so warmup reports the failure
+            # once instead of speak() rebuilding a dead pipeline on every phrase.
+            time.sleep(SPEECH_SPAWN_GRACE)
+            if not (self._alive(self._piper) and self._alive(self._player)):
+                raise OSError("speech pipeline exited immediately after start")
+        except Exception:
+            self._kill_speech()  # don't leak a half-spawned pipeline
+            raise
+
+    def speak(self, text):
+        """Text-to-speech output.
+
+        Non-blocking: the phrase is handed to a warm piper process that streams
+        audio to the player, so this returns immediately and the speech plays
+        concurrently with whatever the caller does next.
+        """
+        text = text.strip()
+        if not text:
+            return
+        print(f"💬 {text}")
+        for _ in range(2):
+            try:
+                self.ensure()
+                self._piper.stdin.write((text + "\n").encode())
+                self._piper.stdin.flush()
+                return
+            except (BrokenPipeError, OSError, ValueError):
+                self._kill_speech()  # tear down the broken pipeline, then retry
+
+    @staticmethod
+    def _reap(proc):
+        """Kill a process, close its parent-side pipes, and wait for it, best-effort.
+
+        Both pipeline processes are spawned with stdin=PIPE, so the parent holds
+        a pipe fd for each; without closing them here, a repeatedly rebuilt
+        pipeline would leak two fds per cycle until it hits the fd limit. kill()
+        polls first and suppresses the PID-reuse race internally on Python 3.10+,
+        but ProcessLookupError is named anyway to stay safe on other versions;
+        AttributeError covers a malformed process handle and TimeoutExpired a
+        process that refuses to die.
+        """
+        for name in ("stdin", "stdout", "stderr"):
+            handle = getattr(proc, name, None)  # tolerate a handle missing these
+            if handle is not None:
+                try:
+                    handle.close()
+                except (AttributeError, OSError):
+                    pass
+        try:
+            proc.kill()
+            proc.wait(timeout=1)
+        except (AttributeError, ProcessLookupError, TimeoutExpired):
+            pass
+
+    def _kill_speech(self):
+        """Stop the pipeline at once (no wait for playback) so it can rebuild."""
+        for proc in (self._piper, self._player):
+            if proc is not None:
+                self._reap(proc)
+        self._piper = self._player = None
+
+    @staticmethod
+    def _close(proc):
+        """Close stdin and wait for the process, killing it if it overruns."""
+        try:
+            proc.stdin.close()  # flush may raise if the downstream player died
+            proc.wait(timeout=15)
+        except (AttributeError, OSError, TimeoutExpired):
+            SpeechPipeline._reap(proc)
+
+    def drain(self):
+        """Flush pending speech and wait for playback to finish, then stop the
+        pipeline. Used on shutdown so a final phrase (e.g. "Goodbye.") is heard
+        in full before the process exits."""
+        piper, player = self._piper, self._player
+        self._piper = self._player = None
+        if piper is not None:
+            self._close(piper)
+        if player is not None:
+            self._close(player)

--- a/tests/acceptance/test_voice_feedback.py
+++ b/tests/acceptance/test_voice_feedback.py
@@ -50,7 +50,7 @@ def speak_phrase(speech, phrase):
 
 @when("the app drains speech on shutdown")
 def drain_on_shutdown(speech):
-    speech["easy"]._drain_speech()
+    speech["easy"].speech.drain()
 
 
 @then("the voice model is loaded only once")

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -3,7 +3,7 @@
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
 import pytest
@@ -35,12 +35,6 @@ class TestEasySpeakInit:
 class TestEasySpeakUtilities:
     """Tests for EasySpeak utility methods."""
 
-    @pytest.fixture(autouse=True)
-    def _no_spawn_grace(self):
-        """Skip the post-spawn liveness wait so pipeline tests stay instant."""
-        with patch("easyspeak.core.main.SPEECH_SPAWN_GRACE", 0):
-            yield
-
     @patch("subprocess.run")
     def test_host_run_foreground(self, mock_run):
         """Test host_run method in foreground mode."""
@@ -71,298 +65,14 @@ class TestEasySpeakUtilities:
         assert call_args[1]["stderr"] == subprocess.DEVNULL
         assert result == mock_process
 
-    @patch("shutil.which", return_value="/usr/bin/pw-play")
-    @patch("subprocess.Popen")
-    def test_speak(self, mock_popen, mock_which, capsys):
-        """When speak is called then it streams the phrase to a warm piper process."""
+    def test_speak_delegates_to_pipeline(self):
+        """EasySpeak.speak is a thin delegate to the speech pipeline."""
         easy = EasySpeak()
+        easy.speech = Mock()
 
-        # Two Popen calls: the player, then piper (whose stdin we write to).
-        mock_player = Mock()
-        mock_player.poll.return_value = None
-        mock_piper = Mock()
-        mock_piper.poll.return_value = None
-        mock_popen.side_effect = [mock_player, mock_piper]
+        easy.speak("hello")
 
-        easy.speak("Hello world")
-
-        # Check that text was printed
-        captured = capsys.readouterr()
-        assert "💬 Hello world" in captured.out
-
-        # Pipeline spawned: player + piper
-        assert mock_popen.call_count == 2
-        piper_cmd = mock_popen.call_args_list[1].args[0]
-        assert piper_cmd[0] == "piper"
-        assert "--output-raw" in piper_cmd
-
-        # Phrase was written to piper's stdin (newline-terminated)
-        mock_piper.stdin.write.assert_called_once_with(b"Hello world\n")
-        assert mock_piper.stdin.flush.called
-
-    @patch("subprocess.Popen")
-    def test_speak_reuses_warm_piper(self, mock_popen, capsys):
-        """When speak is called twice then the piper process is reused (model loaded once)."""
-        easy = EasySpeak()
-        mock_player = Mock()
-        mock_player.poll.return_value = None
-        mock_piper = Mock()
-        mock_piper.poll.return_value = None
-        mock_popen.side_effect = [mock_player, mock_piper]
-
-        easy.speak("first")
-        easy.speak("second")
-
-        # Pipeline spawned only once across both phrases
-        assert mock_popen.call_count == 2
-        assert mock_piper.stdin.write.call_count == 2
-
-    @patch("shutil.which", return_value="/usr/bin/pw-play")
-    @patch("subprocess.Popen")
-    def test_ensure_speech_rebuilds_when_player_dies(self, mock_popen, mock_which):
-        """When the player exits but piper survives then the stale pipeline is
-        killed and rebuilt (no leaked player)."""
-        easy = EasySpeak()
-        old_player = Mock()
-        # Alive at the post-spawn liveness check, dead by the next _ensure_speech.
-        old_player.poll.side_effect = [None, 0]
-        old_piper = Mock()
-        old_piper.poll.return_value = None  # piper still alive
-        new_player, new_piper = Mock(), Mock()
-        new_player.poll.return_value = new_piper.poll.return_value = None
-        mock_popen.side_effect = [old_player, old_piper, new_player, new_piper]
-
-        easy._ensure_speech()  # spawns old pair
-        easy._ensure_speech()  # player dead -> rebuild
-
-        old_piper.kill.assert_called_once()
-        old_player.kill.assert_called_once()
-        assert easy._piper is new_piper and easy._player is new_player
-
-    @patch("shutil.which", return_value="/usr/bin/pw-play")
-    @patch("subprocess.Popen")
-    def test_ensure_speech_cleans_up_when_piper_spawn_fails(
-        self, mock_popen, mock_which
-    ):
-        """When the player spawns but piper fails (e.g. missing binary) then the
-        partial pipeline is torn down and the error propagates (no leaked player)."""
-        easy = EasySpeak()
-        player = Mock()
-        mock_popen.side_effect = [player, FileNotFoundError("piper")]
-
-        with pytest.raises(FileNotFoundError):
-            easy._ensure_speech()
-
-        player.kill.assert_called_once()
-        assert easy._piper is None and easy._player is None
-
-    @patch("shutil.which", return_value="/usr/bin/pw-play")
-    @patch("subprocess.Popen")
-    def test_ensure_speech_raises_when_pipeline_dies_immediately(
-        self, mock_popen, mock_which
-    ):
-        """When piper exits right after spawn (e.g. bad model) then the dead
-        pipeline is torn down and OSError is raised so warmup can report it."""
-        easy = EasySpeak()
-        player = Mock()
-        player.poll.return_value = None  # player alive
-        piper = Mock()
-        piper.poll.return_value = 1  # piper died on startup
-        mock_popen.side_effect = [player, piper]
-
-        with pytest.raises(OSError):
-            easy._ensure_speech()
-
-        player.kill.assert_called_once()
-        piper.kill.assert_called_once()
-        assert easy._piper is None and easy._player is None
-
-    def test_kill_speech_swallows_reap_failure(self):
-        """When wait() after kill() fails then _kill_speech still resets state."""
-        easy = EasySpeak()
-        piper = Mock()
-        piper.wait.side_effect = subprocess.TimeoutExpired("piper", 1)
-        easy._piper = piper
-
-        easy._kill_speech()  # must not raise
-
-        piper.kill.assert_called_once()
-        assert easy._piper is None and easy._player is None
-
-    def test_kill_speech_closes_parent_pipes(self):
-        """_kill_speech closes the parent-side stdin handles so a rebuilt
-        pipeline doesn't leak a pipe fd per cycle."""
-        easy = EasySpeak()
-        piper, player = Mock(), Mock()
-        easy._piper, easy._player = piper, player
-
-        easy._kill_speech()
-
-        piper.stdin.close.assert_called_once()
-        player.stdin.close.assert_called_once()
-
-    def test_kill_speech_swallows_pipe_close_failure(self):
-        """A handle whose close() raises (e.g. already-broken pipe) is ignored,
-        and _kill_speech still kills and resets state."""
-        easy = EasySpeak()
-        piper = Mock()
-        piper.stdin.close.side_effect = OSError("broken pipe")
-        easy._piper = piper
-
-        easy._kill_speech()  # must not raise
-
-        piper.kill.assert_called_once()
-        assert easy._piper is None and easy._player is None
-
-    def test_kill_speech_tolerates_malformed_handle(self):
-        """A handle missing stdin/stdout/stderr (and kill) is reaped without
-        raising, as _reap's docstring promises."""
-        easy = EasySpeak()
-        easy._piper = object()  # no stdin/stdout/stderr/kill attributes
-
-        easy._kill_speech()  # must not raise
-
-        assert easy._piper is None and easy._player is None
-
-    @patch("subprocess.Popen")
-    def test_drain_speech_waits_for_playback(self, mock_popen):
-        """When draining then piper stdin is closed and the pipeline is awaited."""
-        easy = EasySpeak()
-        mock_player = Mock()
-        mock_player.poll.return_value = None
-        mock_piper = Mock()
-        mock_piper.poll.return_value = None
-        mock_popen.side_effect = [mock_player, mock_piper]
-
-        easy.speak("Goodbye.")
-        easy._drain_speech()
-
-        mock_piper.stdin.close.assert_called_once()
-        mock_piper.wait.assert_called_once()
-        mock_player.stdin.close.assert_called_once()
-        mock_player.wait.assert_called_once()
-        assert easy._piper is None and easy._player is None
-
-    @patch("subprocess.Popen")
-    def test_speak_ignores_blank_text(self, mock_popen):
-        """When speak is given blank text then no pipeline is spawned."""
-        easy = EasySpeak()
-
-        easy.speak("   ")
-
-        mock_popen.assert_not_called()
-
-    def test_speak_rebuilds_pipeline_on_broken_pipe(self):
-        """When the pipeline write fails then speak rebuilds it and retries once."""
-        easy = EasySpeak()
-        broken = Mock()
-        broken.poll.return_value = None
-        broken.stdin.write.side_effect = BrokenPipeError()
-        healthy = Mock()
-        healthy.poll.return_value = None
-        pipers = [broken, healthy]
-
-        def fake_ensure():
-            easy._piper = pipers.pop(0)
-
-        with patch.object(easy, "_ensure_speech", side_effect=fake_ensure):
-            easy.speak("hello")
-
-        # The rebuilt (healthy) piper received the phrase.
-        healthy.stdin.write.assert_called_once_with(b"hello\n")
-
-    def test_speak_gives_up_after_two_failures(self):
-        """When the pipeline keeps failing then speak gives up without raising."""
-        easy = EasySpeak()
-
-        def fake_ensure():
-            piper = Mock()
-            piper.poll.return_value = None
-            piper.stdin.write.side_effect = OSError()
-            easy._piper = piper
-
-        with patch.object(
-            easy, "_ensure_speech", side_effect=fake_ensure
-        ) as mock_ensure:
-            easy.speak("hello")  # must not raise
-
-        # Tried to (re)build the pipeline twice before giving up.
-        assert mock_ensure.call_count == 2
-
-    def test_piper_sample_rate_reads_model_json(self):
-        """When the model json is readable then its sample rate is used."""
-        easy = EasySpeak()
-
-        with patch(
-            "builtins.open", mock_open(read_data='{"audio": {"sample_rate": 16000}}')
-        ):
-            assert easy._piper_sample_rate() == 16000
-
-    def test_piper_sample_rate_defaults_on_error(self):
-        """When the model json is unreadable then the rate defaults to 22050."""
-        easy = EasySpeak()
-
-        with patch("builtins.open", side_effect=OSError()):
-            assert easy._piper_sample_rate() == 22050
-
-    def test_player_cmd_prefers_pw_play(self):
-        """When pw-play is available then it is used to stream raw audio."""
-        easy = EasySpeak()
-
-        with patch(
-            "shutil.which",
-            side_effect=lambda p: "/bin/pw-play" if p == "pw-play" else None,
-        ):
-            cmd = easy._player_cmd(22050)
-
-        assert cmd[0] == "pw-play"
-        assert "--raw" in cmd and "22050" in cmd
-
-    def test_player_cmd_falls_back_to_paplay(self):
-        """When only paplay is available then it is used."""
-        easy = EasySpeak()
-
-        with patch(
-            "shutil.which",
-            side_effect=lambda p: "/bin/paplay" if p == "paplay" else None,
-        ):
-            cmd = easy._player_cmd(16000)
-
-        assert cmd[0] == "paplay"
-        assert "--rate=16000" in cmd
-
-    def test_player_cmd_falls_back_to_ffplay(self):
-        """When no PipeWire/PulseAudio player exists then ffplay is the last resort."""
-        easy = EasySpeak()
-
-        with patch("shutil.which", return_value=None):
-            cmd = easy._player_cmd(22050)
-
-        assert cmd[0] == "ffplay"
-        assert "-ar" in cmd and "22050" in cmd
-
-    def test_drain_speech_kills_pipeline_on_timeout(self):
-        """When the pipeline does not exit in time then both processes are killed."""
-        easy = EasySpeak()
-        piper = Mock()
-        piper.wait.side_effect = subprocess.TimeoutExpired("piper", 15)
-        player = Mock()
-        player.wait.side_effect = subprocess.TimeoutExpired("player", 15)
-        easy._piper = piper
-        easy._player = player
-
-        easy._drain_speech()
-
-        piper.kill.assert_called_once()
-        player.kill.assert_called_once()
-
-    def test_drain_speech_noop_when_idle(self):
-        """When nothing has been spoken then draining does nothing."""
-        easy = EasySpeak()
-
-        easy._drain_speech()  # must not raise
-
-        assert easy._piper is None and easy._player is None
+        easy.speech.speak.assert_called_once_with("hello")
 
 
 class TestEasySpeakPlugins:
@@ -836,7 +546,7 @@ class TestEasySpeakRun:
     @pytest.fixture(autouse=True)
     def _stub_speech_warmup(self):
         """Keep run() from spawning the real piper/player pipeline at startup."""
-        with patch.object(EasySpeak, "_ensure_speech") as mock_ensure:
+        with patch("easyspeak.core.speech.SpeechPipeline.ensure") as mock_ensure:
             yield mock_ensure
 
     @patch("easyspeak.core.main.WakeWordModel")

--- a/tests/core/test_speech.py
+++ b/tests/core/test_speech.py
@@ -1,0 +1,410 @@
+"""Tests for the core speech module (persistent piper -> player pipeline)."""
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, Mock, mock_open, patch
+
+import pytest
+
+# easyspeak.core.config imports faster_whisper at module load; stub the heavy
+# deps so importing the speech module doesn't require a model or GPU.
+sys.modules["pyaudio"] = MagicMock()
+sys.modules["openwakeword"] = MagicMock()
+sys.modules["openwakeword.model"] = MagicMock()
+sys.modules["faster_whisper"] = MagicMock()
+
+from easyspeak.core.speech import SpeechPipeline  # noqa: E402
+
+
+class TestSpeechPipeline:
+    """Tests for the persistent piper -> player speech pipeline."""
+
+    @pytest.fixture(autouse=True)
+    def _no_spawn_grace(self):
+        """Skip the post-spawn liveness wait so pipeline tests stay instant."""
+        with patch("easyspeak.core.speech.SPEECH_SPAWN_GRACE", 0):
+            yield
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_speak(self, mock_popen, mock_which, capsys):
+        """When speak is called then it streams the phrase to a warm piper process."""
+        pipe = SpeechPipeline()
+
+        # Two Popen calls: the player, then piper (whose stdin we write to).
+        mock_player = Mock()
+        mock_player.poll.return_value = None
+        mock_piper = Mock()
+        mock_piper.poll.return_value = None
+        mock_popen.side_effect = [mock_player, mock_piper]
+
+        pipe.speak("Hello world")
+
+        # Check that text was printed
+        captured = capsys.readouterr()
+        assert "💬 Hello world" in captured.out
+
+        # Pipeline spawned: player + piper
+        assert mock_popen.call_count == 2
+        piper_cmd = mock_popen.call_args_list[1].args[0]
+        assert piper_cmd[0] == "piper"
+        assert "--output-raw" in piper_cmd
+
+        # Phrase was written to piper's stdin (newline-terminated)
+        mock_piper.stdin.write.assert_called_once_with(b"Hello world\n")
+        assert mock_piper.stdin.flush.called
+
+    @patch("subprocess.Popen")
+    def test_speak_reuses_warm_piper(self, mock_popen, capsys):
+        """When speak is called twice then the piper process is reused (model loaded once)."""
+        pipe = SpeechPipeline()
+        mock_player = Mock()
+        mock_player.poll.return_value = None
+        mock_piper = Mock()
+        mock_piper.poll.return_value = None
+        mock_popen.side_effect = [mock_player, mock_piper]
+
+        pipe.speak("first")
+        pipe.speak("second")
+
+        # Pipeline spawned only once across both phrases
+        assert mock_popen.call_count == 2
+        assert mock_piper.stdin.write.call_count == 2
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_ensure_rebuilds_when_player_dies(self, mock_popen, mock_which):
+        """When the player exits but piper survives then the stale pipeline is
+        killed and rebuilt (no leaked player)."""
+        pipe = SpeechPipeline()
+        old_player = Mock()
+        # Alive at the post-spawn liveness check, dead by the next ensure().
+        old_player.poll.side_effect = [None, 0]
+        old_piper = Mock()
+        old_piper.poll.return_value = None  # piper still alive
+        new_player, new_piper = Mock(), Mock()
+        new_player.poll.return_value = new_piper.poll.return_value = None
+        mock_popen.side_effect = [old_player, old_piper, new_player, new_piper]
+
+        pipe.ensure()  # spawns old pair
+        pipe.ensure()  # player dead -> rebuild
+
+        old_piper.kill.assert_called_once()
+        old_player.kill.assert_called_once()
+        assert pipe._piper is new_piper and pipe._player is new_player
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_ensure_cleans_up_when_piper_spawn_fails(self, mock_popen, mock_which):
+        """When the player spawns but piper fails (e.g. missing binary) then the
+        partial pipeline is torn down and the error propagates (no leaked player)."""
+        pipe = SpeechPipeline()
+        player = Mock()
+        mock_popen.side_effect = [player, FileNotFoundError("piper")]
+
+        with pytest.raises(FileNotFoundError):
+            pipe.ensure()
+
+        player.kill.assert_called_once()
+        assert pipe._piper is None and pipe._player is None
+
+    @patch("shutil.which", return_value="/usr/bin/pw-play")
+    @patch("subprocess.Popen")
+    def test_ensure_raises_when_pipeline_dies_immediately(self, mock_popen, mock_which):
+        """When piper exits right after spawn (e.g. bad model) then the dead
+        pipeline is torn down and OSError is raised so warmup can report it."""
+        pipe = SpeechPipeline()
+        player = Mock()
+        player.poll.return_value = None  # player alive
+        piper = Mock()
+        piper.poll.return_value = 1  # piper died on startup
+        mock_popen.side_effect = [player, piper]
+
+        with pytest.raises(OSError):
+            pipe.ensure()
+
+        player.kill.assert_called_once()
+        piper.kill.assert_called_once()
+        assert pipe._piper is None and pipe._player is None
+
+    def test_kill_speech_swallows_reap_failure(self):
+        """When wait() after kill() fails then _kill_speech still resets state."""
+        pipe = SpeechPipeline()
+        piper = Mock()
+        piper.wait.side_effect = subprocess.TimeoutExpired("piper", 1)
+        pipe._piper = piper
+
+        pipe._kill_speech()  # must not raise
+
+        piper.kill.assert_called_once()
+        assert pipe._piper is None and pipe._player is None
+
+    def test_kill_speech_closes_parent_pipes(self):
+        """_kill_speech closes the parent-side stdin handles so a rebuilt
+        pipeline doesn't leak a pipe fd per cycle."""
+        pipe = SpeechPipeline()
+        piper, player = Mock(), Mock()
+        pipe._piper, pipe._player = piper, player
+
+        pipe._kill_speech()
+
+        piper.stdin.close.assert_called_once()
+        player.stdin.close.assert_called_once()
+
+    def test_kill_speech_swallows_pipe_close_failure(self):
+        """A handle whose close() raises (e.g. already-broken pipe) is ignored,
+        and _kill_speech still kills and resets state."""
+        pipe = SpeechPipeline()
+        piper = Mock()
+        piper.stdin.close.side_effect = OSError("broken pipe")
+        pipe._piper = piper
+
+        pipe._kill_speech()  # must not raise
+
+        piper.kill.assert_called_once()
+        assert pipe._piper is None and pipe._player is None
+
+    def test_kill_speech_tolerates_malformed_handle(self):
+        """A handle missing stdin/stdout/stderr (and kill) is reaped without
+        raising, as _reap's docstring promises."""
+        pipe = SpeechPipeline()
+        pipe._piper = object()  # no stdin/stdout/stderr/kill attributes
+
+        pipe._kill_speech()  # must not raise
+
+        assert pipe._piper is None and pipe._player is None
+
+    @patch("subprocess.Popen")
+    def test_drain_waits_for_playback(self, mock_popen):
+        """When draining then piper stdin is closed and the pipeline is awaited."""
+        pipe = SpeechPipeline()
+        mock_player = Mock()
+        mock_player.poll.return_value = None
+        mock_piper = Mock()
+        mock_piper.poll.return_value = None
+        mock_popen.side_effect = [mock_player, mock_piper]
+
+        pipe.speak("Goodbye.")
+        pipe.drain()
+
+        mock_piper.stdin.close.assert_called_once()
+        mock_piper.wait.assert_called_once()
+        mock_player.stdin.close.assert_called_once()
+        mock_player.wait.assert_called_once()
+        assert pipe._piper is None and pipe._player is None
+
+    @patch("subprocess.Popen")
+    def test_speak_ignores_blank_text(self, mock_popen):
+        """When speak is given blank text then no pipeline is spawned."""
+        pipe = SpeechPipeline()
+
+        pipe.speak("   ")
+
+        mock_popen.assert_not_called()
+
+    def test_speak_rebuilds_pipeline_on_broken_pipe(self):
+        """When the pipeline write fails then speak rebuilds it and retries once."""
+        pipe = SpeechPipeline()
+        broken = Mock()
+        broken.poll.return_value = None
+        broken.stdin.write.side_effect = BrokenPipeError()
+        healthy = Mock()
+        healthy.poll.return_value = None
+        pipers = [broken, healthy]
+
+        def fake_ensure():
+            pipe._piper = pipers.pop(0)
+
+        with patch.object(pipe, "ensure", side_effect=fake_ensure):
+            pipe.speak("hello")
+
+        # The rebuilt (healthy) piper received the phrase.
+        healthy.stdin.write.assert_called_once_with(b"hello\n")
+
+    def test_speak_gives_up_after_two_failures(self):
+        """When the pipeline keeps failing then speak gives up without raising."""
+        pipe = SpeechPipeline()
+
+        def fake_ensure():
+            piper = Mock()
+            piper.poll.return_value = None
+            piper.stdin.write.side_effect = OSError()
+            pipe._piper = piper
+
+        with patch.object(pipe, "ensure", side_effect=fake_ensure) as mock_ensure:
+            pipe.speak("hello")  # must not raise
+
+        # Tried to (re)build the pipeline twice before giving up.
+        assert mock_ensure.call_count == 2
+
+    def test_piper_sample_rate_reads_model_json(self):
+        """When the model json is readable then its sample rate is used."""
+        pipe = SpeechPipeline()
+
+        with patch(
+            "builtins.open", mock_open(read_data='{"audio": {"sample_rate": 16000}}')
+        ):
+            assert pipe._piper_sample_rate() == 16000
+
+    def test_piper_sample_rate_defaults_on_error(self):
+        """When the model json is unreadable then the rate defaults to 22050."""
+        pipe = SpeechPipeline()
+
+        with patch("builtins.open", side_effect=OSError()):
+            assert pipe._piper_sample_rate() == 22050
+
+    def test_player_cmd_prefers_pw_play(self):
+        """When pw-play is available then it is used to stream raw audio."""
+        pipe = SpeechPipeline()
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda p: "/bin/pw-play" if p == "pw-play" else None,
+        ):
+            cmd = pipe._player_cmd(22050)
+
+        assert cmd[0] == "pw-play"
+        assert "--raw" in cmd and "22050" in cmd
+
+    def test_player_cmd_falls_back_to_paplay(self):
+        """When only paplay is available then it is used."""
+        pipe = SpeechPipeline()
+
+        with patch(
+            "shutil.which",
+            side_effect=lambda p: "/bin/paplay" if p == "paplay" else None,
+        ):
+            cmd = pipe._player_cmd(16000)
+
+        assert cmd[0] == "paplay"
+        assert "--rate=16000" in cmd
+
+    def test_player_cmd_falls_back_to_ffplay(self):
+        """When no PipeWire/PulseAudio player exists then ffplay is the last resort."""
+        pipe = SpeechPipeline()
+
+        with patch("shutil.which", return_value=None):
+            cmd = pipe._player_cmd(22050)
+
+        assert cmd[0] == "ffplay"
+        assert "-ar" in cmd and "22050" in cmd
+
+    def test_drain_kills_pipeline_on_timeout(self):
+        """When the pipeline does not exit in time then both processes are killed."""
+        pipe = SpeechPipeline()
+        piper = Mock()
+        piper.wait.side_effect = subprocess.TimeoutExpired("piper", 15)
+        player = Mock()
+        player.wait.side_effect = subprocess.TimeoutExpired("player", 15)
+        pipe._piper = piper
+        pipe._player = player
+
+        pipe.drain()
+
+        piper.kill.assert_called_once()
+        player.kill.assert_called_once()
+
+    def test_drain_noop_when_idle(self):
+        """When nothing has been spoken then draining does nothing."""
+        pipe = SpeechPipeline()
+
+        pipe.drain()  # must not raise
+
+        assert pipe._piper is None and pipe._player is None
+
+
+class TestSuppressedCStderr:
+    """Tests for the PortAudio stderr-noise suppressor."""
+
+    def test_passes_through_when_stderr_has_no_fileno(self):
+        """When stderr has no real fd (e.g. captured) the helper is a no-op."""
+        from easyspeak.core.speech import suppressed_c_stderr
+
+        broken = Mock()
+        broken.fileno.side_effect = ValueError("no fd")
+        with patch("easyspeak.core.speech.sys.stderr", broken):
+            with suppressed_c_stderr():  # must not raise
+                pass
+
+    def test_passes_through_when_fd_snapshot_fails(self):
+        """When os.dup can't snapshot the fd (e.g. fd exhaustion) the helper
+        degrades to a no-op rather than aborting the caller."""
+        from easyspeak.core.speech import suppressed_c_stderr
+
+        stderr = Mock()
+        stderr.fileno.return_value = 2
+        with (
+            patch("easyspeak.core.speech.sys.stderr", stderr),
+            patch("easyspeak.core.speech.os.dup", side_effect=OSError("too many fds")),
+            patch("easyspeak.core.speech.os.dup2") as mock_dup2,
+        ):
+            with suppressed_c_stderr():  # must not raise
+                pass
+
+        mock_dup2.assert_not_called()  # never got far enough to redirect
+
+    def test_passes_through_when_redirect_fails(self):
+        """When the fd swap to /dev/null fails (e.g. fd 2 closed/invalid) the
+        helper runs the body unsuppressed rather than aborting the caller, and
+        still closes the snapshot fd so it isn't leaked."""
+        from easyspeak.core.speech import suppressed_c_stderr
+
+        stderr = Mock()
+        stderr.fileno.return_value = 2
+        with (
+            patch("easyspeak.core.speech.sys.stderr", stderr),
+            patch("easyspeak.core.speech.os.dup", return_value=99),
+            patch("easyspeak.core.speech.os.dup2", side_effect=OSError("bad fd")),
+            patch("easyspeak.core.speech.os.close") as mock_close,
+            patch("builtins.open", mock_open()),
+        ):
+            ran = False
+            with suppressed_c_stderr():  # must not raise
+                ran = True
+
+        assert ran  # body executed despite the failed redirect
+        mock_close.assert_called_once_with(99)  # snapshot fd not leaked
+
+    def test_restore_failure_does_not_propagate(self):
+        """When the swap-back fails after a successful redirect, the failure is
+        swallowed rather than leaking out of the context manager exit."""
+        from easyspeak.core.speech import suppressed_c_stderr
+
+        stderr = Mock()
+        stderr.fileno.return_value = 2
+        with (
+            patch("easyspeak.core.speech.sys.stderr", stderr),
+            patch("easyspeak.core.speech.os.dup", return_value=99),
+            patch(
+                "easyspeak.core.speech.os.dup2",
+                side_effect=[None, OSError("bad fd")],
+            ),
+            patch("easyspeak.core.speech.os.close"),
+            patch("builtins.open", mock_open()),
+        ):
+            with suppressed_c_stderr():  # must not raise
+                pass
+
+    def test_flushes_stderr_before_redirecting(self):
+        """Buffered stderr is flushed before the fd is swapped, so pending output
+        isn't lost to /dev/null."""
+        from easyspeak.core.speech import suppressed_c_stderr
+
+        order = []
+        stderr = Mock()
+        stderr.fileno.return_value = 2
+        stderr.flush.side_effect = lambda: order.append("flush")
+        with (
+            patch("easyspeak.core.speech.sys.stderr", stderr),
+            patch("easyspeak.core.speech.os.dup", return_value=99),
+            patch(
+                "easyspeak.core.speech.os.dup2",
+                side_effect=lambda *a: order.append("dup2"),
+            ),
+            patch("easyspeak.core.speech.os.close"),
+            patch("builtins.open", mock_open()),
+        ):
+            with suppressed_c_stderr():
+                pass
+
+        assert order.index("flush") < order.index("dup2")

--- a/tests/integration/test_speech_pipeline.py
+++ b/tests/integration/test_speech_pipeline.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 from easyspeak.core.config import PIPER_MODEL
-from easyspeak.core.main import EasySpeak
+from easyspeak.core.speech import SpeechPipeline
 
 # Only the players _player_cmd can actually emit, in its own priority order.
 # (pacat is intentionally absent: _player_cmd never selects it — paplay --raw
@@ -54,11 +54,11 @@ def test_player_accepts_our_raw_invocation(player, audio_server, monkeypatch):
     # Force _player_cmd to select exactly this player, regardless of priority.
     real_which = shutil.which
     monkeypatch.setattr(
-        "easyspeak.core.main.shutil.which",
+        "easyspeak.core.speech.shutil.which",
         lambda name: real_which(name) if name == player else None,
     )
     rate = 22050
-    cmd = EasySpeak()._player_cmd(rate)
+    cmd = SpeechPipeline()._player_cmd(rate)
     assert cmd[0] == player
 
     # ~0.3s of finite silence so the player consumes the stream and exits.


### PR DESCRIPTION
Introduces a new `core.speech` module, and adds ALSA error suppression to it.

## New `speech` module in `core`

The persistent text-to-speech pipeline had accreted inside the `EasySpeak` god-object, mixing subprocess lifecycle management in with the wake-word loop and plugin plumbing. We pull it into a dedicated core.speech module so the speech concern owns its own state and can be reasoned about and tested in isolation.

`EasySpeak` composes the pipeline rather than inheriting its mechanics, and keeps `speak()` as a thin delegate so the plugin-facing API is untouched. The pipeline's tests move alongside it. No behaviour change.

## Suppress ALSA error output

Also lands the previously-deferred PortAudio noise suppression here, where it belongs with the rest of the audio-subsystem plumbing rather than as a standalone patch. This makes the startup clean, cutting out distracting low-level error messages from the ALSA library.

<details><summary><strong>Example of error output now suppressed</strong> (click to expand)</summary>
<p>

```
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.front.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM front
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.rear
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.center_lfe
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.side
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround51.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround21
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround51.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround21
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround40.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround40
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround51.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround41
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround51.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround50
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround51.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround51
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.surround71.0:CARD=0'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM surround71
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.iec958.0:CARD=0,AES0=4,AES1=130,AES2=0,AES3=2'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM iec958
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.iec958.0:CARD=0,AES0=4,AES1=130,AES2=0,AES3=2'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM spdif
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.iec958.0:CARD=0,AES0=4,AES1=130,AES2=0,AES3=2'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM spdif
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.hdmi.0:CARD=0,AES0=4,AES1=130,AES2=0,AES3=2'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM hdmi
ALSA lib confmisc.c:1377:(snd_func_refer) [error.core] Unable to find definition 'cards.0.pcm.hdmi.0:CARD=0,AES0=4,AES1=130,AES2=0,AES3=2'
ALSA lib conf.c:5207:(_snd_config_evaluate) [error.core] function snd_func_refer returned error: No such file or directory
ALSA lib conf.c:5730:(snd_config_expand) [error.core] Evaluate error: No such file or directory
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM hdmi
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.modem
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.modem
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.phoneline
ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM cards.pcm.phoneline
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock...
```

</p>
</details> 