### PR TITLE
test(extension): extract pure JS helpers and unit-test them

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
     - uses: taiki-e/install-action@just
     - run: npm install --global eslint@10
     - run: just lint-js
+    - run: just test-js
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,8 +33,14 @@ jobs:
         sudo apt install -y portaudio19-dev
     - run: just ${{ matrix.task }}
 
-  lint-js:
+  js:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+        - lint-js
+        - test-js
+      fail-fast: false
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-node@v5
@@ -42,8 +48,7 @@ jobs:
         node-version: '22'
     - uses: taiki-e/install-action@just
     - run: npm install --global eslint@10
-    - run: just lint-js
-    - run: just test-js
+    - run: just ${{ matrix.task }}
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v5
       with:
         node-version: '22'
     - uses: taiki-e/install-action@just

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-exclude CONTRIBUTING.md flake.* justfile MANIFEST.in *.mjs *.yml
+exclude CONTRIBUTING.md flake.* justfile MANIFEST.in *.mjs package.json *.yml
 prune images
 prune tests

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@
 // (undefined names, unused vars) without trying to resolve modules.
 export default [
   {
-    files: ["src/extension.js"],
+    files: ["src/extension.js", "src/extension-helpers.js"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",

--- a/flake.nix
+++ b/flake.nix
@@ -160,6 +160,7 @@
             pkgs.uv
             pkgs.just
             pkgs.eslint # JS linter for the GNOME Shell extension (see `just lint-js`)
+            pkgs.nodejs # `node --test` for the extension's JS helpers (see `just test-js`)
           ]
           ++ runtimeTools
           ++ buildTools;

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ lint *args=('--statistics'):
 # Lint the GNOME Shell extension JS (use --fix to autocorrect)
 [group('codestyle')]
 lint-js *args:
-    eslint src/extension.js {{ args }}
+    eslint src/extension.js src/extension-helpers.js {{ args }}
 
 # Static type checking (use --pretty for error details)
 [group('safety')]
@@ -118,10 +118,13 @@ gate: (clean '--quiet') (package '--quiet')
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q core
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q core
     # Python package should bundle the GNOME Shell extension assets, which
-    # core.gnome_extension copies into the user's extensions dir at startup
+    # core.gnome_extension copies into the user's extensions dir at startup.
+    # extension.js imports extension-helpers.js, so the helper must ship too.
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension.js
+    tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension-helpers.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q metadata.json
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension.js
+    unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension-helpers.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q metadata.json
 
 # Verify package version is same as Git tag

--- a/justfile
+++ b/justfile
@@ -114,11 +114,13 @@ gate: (clean '--quiet') (package '--quiet')
     ! unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep eslint.config.mjs
     ! unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep flake.nix
     ! unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep flake.lock
+    ! unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep package.json
     ! tar tfz dist/easyspeak_linux-*.tar.gz | grep CONTRIBUTING.md
     ! tar tfz dist/easyspeak_linux-*.tar.gz | grep tests
     ! tar tfz dist/easyspeak_linux-*.tar.gz | grep eslint.config.mjs
     ! tar tfz dist/easyspeak_linux-*.tar.gz | grep flake.nix
     ! tar tfz dist/easyspeak_linux-*.tar.gz | grep flake.lock
+    ! tar tfz dist/easyspeak_linux-*.tar.gz | grep package.json
     # Python package should contain Core module
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q core
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q core

--- a/justfile
+++ b/justfile
@@ -89,6 +89,11 @@ integration *args=('-v'):
 acceptance *args:
     uv run --extra=acceptance pytest tests/acceptance {{ args }}
 
+# Unit-test the GNOME Shell extension's pure JS helpers (needs node >= 21)
+[group('tests')]
+test-js *args:
+    node --test tests/js/*.test.js {{ args }}
+
 # Run Whisper benchmarks (writes results.json for bencher.dev)
 [group('tests')]
 benchmark *args:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ easyspeak = "src"
 # copies it into the user's extensions directory at startup, so it must ship
 # inside the wheel (alongside the easyspeak package), not just the sdist.
 [tool.setuptools.package-data]
-easyspeak = ["extension.js", "metadata.json"]
+easyspeak = ["extension.js", "extension-helpers.js", "metadata.json"]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -2,11 +2,13 @@
 
 Core owns the extension's lifecycle because both the mousegrid plugin and
 ``core.tray`` drive it over D-Bus; :func:`ensure_extension` runs once at startup.
-The extension ships as package data and is copied into the user's extensions
-dir. On Wayland GNOME only loads extension code at login, so the startup copy is
-always one login behind; a ``oneshot`` systemd *user* unit ordered before the
-shell re-copies it at the start of every login to close that gap. The unit runs
-as the user, writes only to ``$HOME``, and needs no privileges.
+The extension ships as package data — ``extension.js``, the
+``extension-helpers.js`` it imports, and ``metadata.json`` — copied into the
+user's extensions dir as a set. On Wayland GNOME only loads extension code at
+login, so the startup copy is always one login behind; a ``oneshot`` systemd
+*user* unit ordered before the shell re-copies it at the start of every login to
+close that gap. The unit runs as the user, writes only to ``$HOME``, and needs
+no privileges.
 """
 
 import enum
@@ -22,6 +24,10 @@ PRE_SHELL_TARGET = "gnome-session-pre.target"  # reached before org.gnome.Shell@
 
 # Cap each helper subprocess so a wedged session/user bus can't hang startup.
 SUBPROCESS_TIMEOUT = 5.0
+
+# Bundled assets, installed as a set: extension.js imports extension-helpers.js,
+# so they must travel together or the extension fails to load.
+EXTENSION_ASSETS = ("extension.js", "extension-helpers.js", "metadata.json")
 
 
 class RefreshResult(enum.Enum):
@@ -48,44 +54,55 @@ def extension_dest_dir():
     )
 
 
-def refresh_extension_files(src_ext, src_meta, dest_dir):
-    """Copy the bundled extension into ``dest_dir`` when it differs from the
+def _staged_tmp(dest_dir, name):
+    return dest_dir / f".{name}.tmp"
+
+
+def _discard_staged(dest_dir):
+    """Remove any ``.<asset>.tmp`` files a previous refresh may have left."""
+    for name in EXTENSION_ASSETS:
+        try:
+            _staged_tmp(dest_dir, name).unlink()
+        except OSError:
+            pass
+
+
+def refresh_extension_files(src_dir, dest_dir):
+    """Copy the bundled assets into ``dest_dir`` when they differ from the
     installed copy. Best-effort: returns ``REFRESHED`` if written, ``UNCHANGED``
-    if already current, or ``ERROR`` (noted on stderr) when the sources are
-    missing or the copy fails. Both files are staged then moved into place, so a
-    failure leaves any working install untouched."""
-    if not (src_ext.is_file() and src_meta.is_file()):
+    if already current, or ``ERROR`` (noted on stderr) when a source is missing
+    or a copy fails. Assets are staged then moved into place (extension.js last),
+    so a failure leaves any working install untouched and never installs
+    extension.js without the helper it imports."""
+    srcs = {name: src_dir / name for name in EXTENSION_ASSETS}
+    if not all(s.is_file() for s in srcs.values()):
         print(
-            f"easyspeak: note: bundled GNOME extension sources missing at "
-            f"{src_ext.parent}",
+            f"easyspeak: note: bundled GNOME extension sources missing at {src_dir}",
             file=sys.stderr,
         )
         return RefreshResult.ERROR
-    dest_ext = dest_dir / "extension.js"
-    dest_meta = dest_dir / "metadata.json"
-    tmp_ext = dest_dir / ".extension.js.tmp"
-    tmp_meta = dest_dir / ".metadata.json.tmp"
+    # Clear temps an interrupted run may have left, so the dir self-heals even on
+    # the UNCHANGED path below.
+    _discard_staged(dest_dir)
     try:
-        unchanged = (
-            dest_ext.is_file()
-            and dest_meta.is_file()
-            and filecmp.cmp(src_ext, dest_ext, shallow=False)
-            and filecmp.cmp(src_meta, dest_meta, shallow=False)
+        unchanged = all(
+            (dest_dir / name).is_file()
+            and filecmp.cmp(src, dest_dir / name, shallow=False)
+            for name, src in srcs.items()
         )
         if unchanged:
             return RefreshResult.UNCHANGED
         dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src_ext, tmp_ext)
-        shutil.copy2(src_meta, tmp_meta)
-        tmp_meta.replace(dest_meta)
-        tmp_ext.replace(dest_ext)
+        staged = []
+        for name, src in srcs.items():
+            tmp = _staged_tmp(dest_dir, name)
+            shutil.copy2(src, tmp)
+            staged.append((tmp, dest_dir / name))
+        for tmp, dest in reversed(staged):  # extension.js leads EXTENSION_ASSETS
+            tmp.replace(dest)
         return RefreshResult.REFRESHED
     except OSError as e:
-        for tmp in (tmp_ext, tmp_meta):
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
+        _discard_staged(dest_dir)
         print(
             f"easyspeak: note: could not refresh GNOME extension in {dest_dir} ({e})",
             file=sys.stderr,
@@ -96,12 +113,7 @@ def refresh_extension_files(src_ext, src_meta, dest_dir):
 def refresh_installed_extension():
     """Refresh the installed extension from the bundled copy; run by the systemd
     unit at each login."""
-    root = extension_source_dir()
-    return refresh_extension_files(
-        root / "extension.js",
-        root / "metadata.json",
-        extension_dest_dir(),
-    )
+    return refresh_extension_files(extension_source_dir(), extension_dest_dir())
 
 
 def _unit_path():
@@ -228,13 +240,11 @@ def ensure_extension():
         and GRID_EXTENSION_UUID in listed_enabled.stdout.split()
     )
     dest_dir = extension_dest_dir()
-
     root = extension_source_dir()
-    src_ext = root / "extension.js"
-    src_meta = root / "metadata.json"
+    srcs = [root / name for name in EXTENSION_ASSETS]
 
     if installed and already_enabled:
-        result = refresh_extension_files(src_ext, src_meta, dest_dir)
+        result = refresh_extension_files(root, dest_dir)
         if result is RefreshResult.REFRESHED:
             print(
                 f"easyspeak: updated GNOME extension {GRID_EXTENSION_UUID} to "
@@ -252,7 +262,7 @@ def ensure_extension():
         return
 
     if not installed:
-        if not (src_ext.is_file() and src_meta.is_file()):
+        if not all(s.is_file() for s in srcs):
             print(
                 f"easyspeak: note: could not auto-install GNOME extension — "
                 f"source files not found at {root}. The panel indicator and "
@@ -262,14 +272,11 @@ def ensure_extension():
             )
             return
 
-        try:
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src_ext, dest_dir / "extension.js")
-            shutil.copy2(src_meta, dest_dir / "metadata.json")
-        except OSError as e:
+        refresh_extension_files(root, dest_dir)
+        if not all((dest_dir / name).is_file() for name in EXTENSION_ASSETS):
             print(
                 f"easyspeak: note: could not install GNOME extension to "
-                f"{dest_dir} ({e}). The panel indicator and grid commands will "
+                f"{dest_dir}. The panel indicator and grid commands will "
                 f"not work until it is installed manually.",
                 file=sys.stderr,
             )

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -104,7 +104,7 @@ def refresh_extension_files(src_dir, dest_dir):
     except OSError as e:
         _discard_staged(dest_dir)
         print(
-            f"easyspeak: note: could not refresh GNOME extension in {dest_dir} ({e})",
+            f"easyspeak: note: could not write GNOME extension to {dest_dir} ({e})",
             file=sys.stderr,
         )
         return RefreshResult.ERROR
@@ -241,7 +241,6 @@ def ensure_extension():
     )
     dest_dir = extension_dest_dir()
     root = extension_source_dir()
-    srcs = [root / name for name in EXTENSION_ASSETS]
 
     if installed and already_enabled:
         result = refresh_extension_files(root, dest_dir)
@@ -262,7 +261,7 @@ def ensure_extension():
         return
 
     if not installed:
-        if not all(s.is_file() for s in srcs):
+        if not all((root / name).is_file() for name in EXTENSION_ASSETS):
             print(
                 f"easyspeak: note: could not auto-install GNOME extension — "
                 f"source files not found at {root}. The panel indicator and "
@@ -272,12 +271,13 @@ def ensure_extension():
             )
             return
 
-        refresh_extension_files(root, dest_dir)
-        if not all((dest_dir / name).is_file() for name in EXTENSION_ASSETS):
+        if refresh_extension_files(root, dest_dir) is RefreshResult.ERROR:
+            # refresh_extension_files already reported the write error (with the
+            # OSError detail) on stderr; add only the consequence, not a second
+            # description of the same failure.
             print(
-                f"easyspeak: note: could not install GNOME extension to "
-                f"{dest_dir}. The panel indicator and grid commands will "
-                f"not work until it is installed manually.",
+                "easyspeak: note: the panel indicator and grid commands will "
+                "not work until the GNOME extension is installed manually.",
                 file=sys.stderr,
             )
             return

--- a/src/extension-helpers.js
+++ b/src/extension-helpers.js
@@ -1,0 +1,60 @@
+// Pure helpers for the GNOME Shell extension.
+//
+// Everything here is deliberately free of `gi://` / GNOME Shell imports so it
+// can be unit-tested with `node --test` outside a running shell (the rest of
+// extension.js can only run inside gnome-shell). Keep this file dependency-free.
+
+// Clamp a rectangle so it stays inside the work area. Mirrors the inverse-of-
+// nothing identity when there is no work area (e.g. before the grid is shown).
+export function clampToWorkArea(x, y, w, h, workArea) {
+    if (!workArea) return [x, y, w, h];
+    const wa = workArea;
+    const newX = Math.max(wa.x, Math.min(x, wa.x + wa.width - w));
+    const newY = Math.max(wa.y, Math.min(y, wa.y + wa.height - h));
+    return [newX, newY, w, h];
+}
+
+// Map a scroll direction to a continuous-scroll delta. Unknown directions are a
+// no-op (zero delta) rather than an error.
+export function scrollDirectionDelta(direction, amount = 1) {
+    switch (direction) {
+        case 'up': return { dx: 0, dy: -amount };
+        case 'down': return { dx: 0, dy: amount };
+        case 'left': return { dx: -amount, dy: 0 };
+        case 'right': return { dx: amount, dy: 0 };
+        default: return { dx: 0, dy: 0 };
+    }
+}
+
+// Compute the numeric layout of the 3x3 navigation grid for a bounds rectangle:
+// cell size, label font size, the top-left position of each numbered label, and
+// the centre crosshair. The drawing code consumes these to place actors.
+export function gridGeometry(bx, by, bw, bh) {
+    const cellW = Math.floor(bw / 3);
+    const cellH = Math.floor(bh / 3);
+    const fontSize = Math.max(24, Math.min(72, Math.floor(Math.min(cellW, cellH) / 3)));
+
+    const cells = [];
+    for (let num = 1; num <= 9; num++) {
+        const row = Math.floor((num - 1) / 3);
+        const col = (num - 1) % 3;
+        const zoneX = bx + col * cellW;
+        const zoneY = by + row * cellH;
+        cells.push({
+            num,
+            x: zoneX + cellW / 2 - fontSize / 2,
+            y: zoneY + cellH / 2 - fontSize / 2,
+        });
+    }
+
+    const center = { x: bx + Math.floor(bw / 2), y: by + Math.floor(bh / 2) };
+    const crossSize = Math.min(50, Math.floor(Math.min(bw, bh) / 3));
+
+    return { cellW, cellH, fontSize, cells, center, crossSize };
+}
+
+// The tray indicator is shown only while EasySpeak is deactivated ("muted").
+// Every running state (listening/active/thinking) hides it.
+export function indicatorVisibleForState(state) {
+    return state === 'muted';
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -8,6 +8,12 @@ import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import {
+    clampToWorkArea,
+    scrollDirectionDelta,
+    gridGeometry,
+    indicatorVisibleForState,
+} from './extension-helpers.js';
 
 const DBUS_INTERFACE = `
 <node>
@@ -131,11 +137,7 @@ class GridOverlay {
     }
 
     _clampToWorkArea(x, y, w, h) {
-        if (!this.workArea) return [x, y, w, h];
-        const wa = this.workArea;
-        let newX = Math.max(wa.x, Math.min(x, wa.x + wa.width - w));
-        let newY = Math.max(wa.y, Math.min(y, wa.y + wa.height - h));
-        return [newX, newY, w, h];
+        return clampToWorkArea(x, y, w, h, this.workArea);
     }
 
     show(width, height) {
@@ -248,14 +250,7 @@ class GridOverlay {
         const t = GLib.get_monotonic_time();
         pointer.notify_absolute_motion(t, x, y);
 
-        let dx = 0, dy = 0;
-        const scrollAmount = 1;
-        switch (direction) {
-            case 'up': dy = -scrollAmount; break;
-            case 'down': dy = scrollAmount; break;
-            case 'left': dx = -scrollAmount; break;
-            case 'right': dx = scrollAmount; break;
-        }
+        const { dx, dy } = scrollDirectionDelta(direction);
 
         for (let i = 0; i < clicks; i++) {
             pointer.notify_scroll_continuous(t + (i * 50000), dx, dy,
@@ -274,8 +269,8 @@ class GridOverlay {
         }));
 
         // Grid lines and labels
-        const cellW = Math.floor(bw / 3);
-        const cellH = Math.floor(bh / 3);
+        const { cellW, cellH, fontSize, cells, center, crossSize } =
+            gridGeometry(bx, by, bw, bh);
 
         // Vertical lines
         for (let i = 1; i < 3; i++) {
@@ -294,27 +289,20 @@ class GridOverlay {
         }
 
         // Number labels 1-9
-        const fontSize = Math.max(24, Math.min(72, Math.floor(Math.min(cellW, cellH) / 3)));
-        for (let num = 1; num <= 9; num++) {
-            const row = Math.floor((num - 1) / 3);
-            const col = (num - 1) % 3;
-            const zoneX = bx + col * cellW;
-            const zoneY = by + row * cellH;
-
+        for (const cell of cells) {
             const label = new St.Label({
-                text: String(num),
+                text: String(cell.num),
                 style: `font-size: ${fontSize}px; font-weight: bold; color: #ffe600; ` +
                     `background-color: rgba(0,0,0,0.8); border-radius: 8px; padding: 8px 16px;`
             });
 
-            label.set_position(zoneX + cellW / 2 - fontSize / 2, zoneY + cellH / 2 - fontSize / 2);
+            label.set_position(cell.x, cell.y);
             this.container.add_child(label);
         }
 
         // Crosshair at center
-        const centerX = bx + Math.floor(bw / 2);
-        const centerY = by + Math.floor(bh / 2);
-        const crossSize = Math.min(50, Math.floor(Math.min(bw, bh) / 3));
+        const centerX = center.x;
+        const centerY = center.y;
         const crossThick = 4;
 
         // White outline
@@ -577,7 +565,7 @@ class TrayIndicator extends PanelMenu.Button {
     // Pushed over D-Bus by the daemon. Only the deactivated state is visible;
     // every running state (listening/active/thinking) hides the indicator.
     setState(state) {
-        this.visible = state === 'muted';
+        this.visible = indicatorVisibleForState(state);
     }
 
     // Menu actions reach the daemon via a one-shot control file it polls each

--- a/tests/js/dbus-contract.test.js
+++ b/tests/js/dbus-contract.test.js
@@ -19,11 +19,14 @@ function declaredMethods(src) {
 
 // Handler keys in the object literal passed to wrapJSObject(DBUS_INTERFACE, {...}).
 function wiredHandlers(src) {
-    const start = src.indexOf('wrapJSObject(DBUS_INTERFACE, {');
-    assert.notEqual(start, -1, 'could not locate the wrapJSObject handler map');
+    // Tolerate incidental whitespace/newlines between the call's tokens so a
+    // reformat (e.g. prettier wrapping the args) doesn't break the contract test.
+    const match = /wrapJSObject\(\s*DBUS_INTERFACE\s*,\s*\{/.exec(src);
+    assert.notEqual(match, null, 'could not locate the wrapJSObject handler map');
 
-    // Walk braces from the map's opening `{` to its matching `}`.
-    const open = src.indexOf('{', start);
+    // Walk braces from the map's opening `{` (the last char the regex matched)
+    // to its matching `}`.
+    const open = match.index + match[0].length - 1;
     let depth = 0;
     let end = -1;
     for (let i = open; i < src.length; i++) {

--- a/tests/js/dbus-contract.test.js
+++ b/tests/js/dbus-contract.test.js
@@ -1,0 +1,65 @@
+// Contract test: every D-Bus method declared in extension.js's interface XML
+// must have a matching handler wired up in enable(), and vice versa. This
+// catches the easy "added the method to the XML but forgot to implement it"
+// (or the reverse) drift without needing a running gnome-shell.
+//
+// extension.js can't be imported here (its top-level `gi://` imports only
+// resolve inside the shell), so we read it as text and parse the two sides.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../../src/extension.js', import.meta.url), 'utf8');
+
+// Method names declared in the <interface> XML.
+function declaredMethods(src) {
+    return new Set([...src.matchAll(/<method name="(\w+)"/g)].map((m) => m[1]));
+}
+
+// Handler keys in the object literal passed to wrapJSObject(DBUS_INTERFACE, {...}).
+function wiredHandlers(src) {
+    const start = src.indexOf('wrapJSObject(DBUS_INTERFACE, {');
+    assert.notEqual(start, -1, 'could not locate the wrapJSObject handler map');
+
+    // Walk braces from the map's opening `{` to its matching `}`.
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < src.length; i++) {
+        if (src[i] === '{') depth++;
+        else if (src[i] === '}') {
+            depth--;
+            if (depth === 0) {
+                end = i;
+                break;
+            }
+        }
+    }
+    assert.notEqual(end, -1, 'unbalanced braces in the handler map');
+
+    const block = src.slice(open + 1, end);
+    // Each handler is `Name: (args) => ...` at the start of a line.
+    return new Set([...block.matchAll(/^\s*(\w+):\s*\(/gm)].map((m) => m[1]));
+}
+
+test('every declared D-Bus method has a handler and vice versa', () => {
+    const methods = declaredMethods(source);
+    const handlers = wiredHandlers(source);
+
+    assert.ok(methods.size > 0, 'no D-Bus methods found in the interface XML');
+
+    const missingHandlers = [...methods].filter((m) => !handlers.has(m)).sort();
+    const orphanHandlers = [...handlers].filter((h) => !methods.has(h)).sort();
+
+    assert.deepEqual(
+        missingHandlers,
+        [],
+        `D-Bus methods declared in XML but not wired in enable(): ${missingHandlers.join(', ')}`,
+    );
+    assert.deepEqual(
+        orphanHandlers,
+        [],
+        `handlers in enable() with no matching XML method: ${orphanHandlers.join(', ')}`,
+    );
+});

--- a/tests/js/extension-helpers.test.js
+++ b/tests/js/extension-helpers.test.js
@@ -1,0 +1,85 @@
+// Unit tests for the gi-free extension helpers, run with `node --test`.
+// These cover the pure computation extracted from extension.js; the
+// GNOME-Shell-bound code around them can only be exercised in a live shell.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    clampToWorkArea,
+    scrollDirectionDelta,
+    gridGeometry,
+    indicatorVisibleForState,
+} from '../../src/extension-helpers.js';
+
+test('clampToWorkArea returns the rectangle unchanged without a work area', () => {
+    assert.deepEqual(clampToWorkArea(10, 20, 30, 40, null), [10, 20, 30, 40]);
+});
+
+test('clampToWorkArea keeps a rectangle inside the work area', () => {
+    const wa = { x: 0, y: 0, width: 1000, height: 800 };
+    // Overflowing right/bottom: pinned so the far edge sits on the work area edge.
+    assert.deepEqual(clampToWorkArea(950, 790, 100, 50, wa), [900, 750, 100, 50]);
+    // Past the top-left origin: pinned to wa.x / wa.y.
+    assert.deepEqual(clampToWorkArea(-30, -30, 100, 50, wa), [0, 0, 100, 50]);
+    // Already inside: unchanged.
+    assert.deepEqual(clampToWorkArea(100, 100, 100, 50, wa), [100, 100, 100, 50]);
+});
+
+test('clampToWorkArea respects a non-zero work area origin', () => {
+    const wa = { x: 200, y: 100, width: 800, height: 600 };
+    assert.deepEqual(clampToWorkArea(0, 0, 100, 50, wa), [200, 100, 100, 50]);
+});
+
+test('scrollDirectionDelta maps each direction to a unit delta', () => {
+    assert.deepEqual(scrollDirectionDelta('up'), { dx: 0, dy: -1 });
+    assert.deepEqual(scrollDirectionDelta('down'), { dx: 0, dy: 1 });
+    assert.deepEqual(scrollDirectionDelta('left'), { dx: -1, dy: 0 });
+    assert.deepEqual(scrollDirectionDelta('right'), { dx: 1, dy: 0 });
+});
+
+test('scrollDirectionDelta is a no-op for unknown directions', () => {
+    assert.deepEqual(scrollDirectionDelta('sideways'), { dx: 0, dy: 0 });
+    assert.deepEqual(scrollDirectionDelta(undefined), { dx: 0, dy: 0 });
+});
+
+test('scrollDirectionDelta scales by the amount argument', () => {
+    assert.deepEqual(scrollDirectionDelta('down', 5), { dx: 0, dy: 5 });
+    assert.deepEqual(scrollDirectionDelta('left', 3), { dx: -3, dy: 0 });
+});
+
+test('gridGeometry computes cells, font and crosshair for a 1920x1080 grid', () => {
+    const g = gridGeometry(0, 0, 1920, 1080);
+    assert.equal(g.cellW, 640);
+    assert.equal(g.cellH, 360);
+    assert.equal(g.fontSize, 72); // clamped to the 72px ceiling
+    assert.equal(g.crossSize, 50); // clamped to the 50px ceiling
+    assert.deepEqual(g.center, { x: 960, y: 540 });
+
+    assert.equal(g.cells.length, 9);
+    assert.deepEqual(g.cells[0], { num: 1, x: 284, y: 144 });
+    assert.deepEqual(g.cells[4], { num: 5, x: 924, y: 504 });
+    assert.deepEqual(g.cells[8], { num: 9, x: 1564, y: 864 });
+});
+
+test('gridGeometry offsets every coordinate by the bounds origin', () => {
+    const base = gridGeometry(0, 0, 900, 600);
+    const moved = gridGeometry(100, 50, 900, 600);
+    assert.equal(moved.center.x, base.center.x + 100);
+    assert.equal(moved.center.y, base.center.y + 50);
+    assert.equal(moved.cells[0].x, base.cells[0].x + 100);
+    assert.equal(moved.cells[0].y, base.cells[0].y + 50);
+});
+
+test('gridGeometry floors the font size for small grids', () => {
+    // min(cellW, cellH)/3 below the 24px floor must clamp up to 24.
+    const g = gridGeometry(0, 0, 120, 120);
+    assert.equal(g.fontSize, 24);
+});
+
+test('indicatorVisibleForState shows the tray icon only when muted', () => {
+    assert.equal(indicatorVisibleForState('muted'), true);
+    for (const state of ['listening', 'active', 'thinking', '', undefined]) {
+        assert.equal(indicatorVisibleForState(state), false);
+    }
+});

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -695,6 +695,43 @@ class TestEnsureExtension:
         assert mock_run.call_count == 2
 
     @patch.object(
+        gnome_extension.subprocess, "run", return_value=Mock(returncode=0, stdout="")
+    )
+    @patch.object(
+        gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
+    )
+    def test_install_failure_leaves_no_partial_extension(
+        self, mock_which, mock_run, tmp_path, monkeypatch
+    ):
+        """A failed first install leaves nothing half-applied and never enables."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        real_copy = gnome_extension.shutil.copy2
+        calls = {"n": 0}
+
+        def flaky_copy(s, d, *a, **k):
+            calls["n"] += 1
+            if calls["n"] == 2:  # fail the second asset, mid-install
+                raise OSError("disk full")
+            return real_copy(s, d, *a, **k)
+
+        with patch.object(gnome_extension.shutil, "copy2", side_effect=flaky_copy):
+            gnome_extension.ensure_extension()
+
+        dest = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "gnome-shell"
+            / "extensions"
+            / "easyspeak-grid@local"
+        )
+        for name in gnome_extension.EXTENSION_ASSETS:
+            assert not (dest / name).is_file()
+        assert not list(dest.glob(".*.tmp"))
+        assert mock_run.call_count == 2  # probes only, no enable
+
+    @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
     def test_install_and_enable_success(

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -119,7 +119,7 @@ def test_refresh_extension_files_write_failure_returns_error(
 
     assert refreshed is gnome_extension.RefreshResult.ERROR
     assert (dest / "extension.js").read_text() == "old"
-    assert "could not refresh GNOME extension" in capsys.readouterr().err
+    assert "could not write GNOME extension" in capsys.readouterr().err
 
 
 def test_refresh_extension_files_no_partial_overwrite_on_midway_failure(tmp_path):
@@ -689,7 +689,10 @@ class TestEnsureExtension:
 
         captured = capsys.readouterr()
         assert "easyspeak: note:" in captured.err
-        assert "could not install GNOME extension" in captured.err
+        # The write failure itself is described once, by refresh_extension_files,
+        # with the OSError detail; ensure_extension adds only the consequence.
+        assert "could not write GNOME extension" in captured.err
+        assert "installed manually" in captured.err
         # Only the two probe calls (`list` and `list --enabled`); no `enable`
         # attempt after copy failure.
         assert mock_run.call_count == 2

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -13,55 +13,95 @@ UNIT_NAME = "easyspeak-extension-refresh.service"
 # --- refresh_extension_files -------------------------------------------------
 
 
+def _write_assets(directory, **overrides):
+    """Create every bundled asset under ``directory``, with per-file contents
+    overridable by name (dots and hyphens in filenames map to underscores, e.g.
+    ``extension_helpers_js`` for ``extension-helpers.js``)."""
+    directory.mkdir(parents=True, exist_ok=True)
+    for name in gnome_extension.EXTENSION_ASSETS:
+        key = name.replace(".", "_").replace("-", "_")
+        directory.joinpath(name).write_text(overrides.get(key, "x"))
+
+
 def test_refresh_extension_files_installs_when_dest_missing(tmp_path):
     src = tmp_path / "src"
-    src.mkdir()
-    (src / "extension.js").write_text("new")
-    (src / "metadata.json").write_text("{}")
+    _write_assets(src, extension_js="new", metadata_json="{}")
     dest = tmp_path / "dest"  # does not exist yet
 
-    refreshed = gnome_extension.refresh_extension_files(
-        src / "extension.js", src / "metadata.json", dest
-    )
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
 
     assert refreshed is gnome_extension.RefreshResult.REFRESHED
+    for name in gnome_extension.EXTENSION_ASSETS:
+        assert (dest / name).is_file()
     assert (dest / "extension.js").read_text() == "new"
-    assert (dest / "metadata.json").read_text() == "{}"
 
 
 def test_refresh_extension_files_overwrites_when_changed(tmp_path):
     src = tmp_path / "src"
-    src.mkdir()
-    (src / "extension.js").write_text("new")
-    (src / "metadata.json").write_text("{}")
+    _write_assets(src, extension_js="new")
     dest = tmp_path / "dest"
-    dest.mkdir()
-    (dest / "extension.js").write_text("old")
-    (dest / "metadata.json").write_text("{}")
+    _write_assets(dest, extension_js="old")
 
-    refreshed = gnome_extension.refresh_extension_files(
-        src / "extension.js", src / "metadata.json", dest
-    )
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
 
     assert refreshed is gnome_extension.RefreshResult.REFRESHED
     assert (dest / "extension.js").read_text() == "new"
 
 
-def test_refresh_extension_files_noop_when_identical(tmp_path):
+def test_refresh_extension_files_refreshes_when_helper_changed(tmp_path):
+    """A changed helper alone triggers a re-copy: extension.js must never be
+    left in step with a stale extension-helpers.js."""
     src = tmp_path / "src"
-    src.mkdir()
-    (src / "extension.js").write_text("same")
-    (src / "metadata.json").write_text("{}")
+    _write_assets(src, extension_helpers_js="new-helper")
+    dest = tmp_path / "dest"
+    _write_assets(dest, extension_helpers_js="old-helper")
+
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
+
+    assert refreshed is gnome_extension.RefreshResult.REFRESHED
+    assert (dest / "extension-helpers.js").read_text() == "new-helper"
+
+
+def test_refresh_extension_files_installs_helper_missing_from_old_dest(tmp_path):
+    """An install predating the helper is brought up to date."""
+    src = tmp_path / "src"
+    _write_assets(src)
     dest = tmp_path / "dest"
     dest.mkdir()
-    (dest / "extension.js").write_text("same")
-    (dest / "metadata.json").write_text("{}")
+    (dest / "extension.js").write_text("x")
+    (dest / "metadata.json").write_text("x")  # no extension-helpers.js
 
-    refreshed = gnome_extension.refresh_extension_files(
-        src / "extension.js", src / "metadata.json", dest
-    )
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
+
+    assert refreshed is gnome_extension.RefreshResult.REFRESHED
+    assert (dest / "extension-helpers.js").is_file()
+
+
+def test_refresh_extension_files_noop_when_identical(tmp_path):
+    src = tmp_path / "src"
+    _write_assets(src, extension_js="same")
+    dest = tmp_path / "dest"
+    _write_assets(dest, extension_js="same")
+
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
 
     assert refreshed is gnome_extension.RefreshResult.UNCHANGED
+
+
+def test_refresh_extension_files_discards_stale_temp_up_front(tmp_path):
+    """A temp left by an interrupted earlier run is cleared even when nothing
+    needs copying, so the dir self-heals."""
+    src = tmp_path / "src"
+    _write_assets(src, extension_js="same")
+    dest = tmp_path / "dest"
+    _write_assets(dest, extension_js="same")
+    stale = dest / ".extension.js.tmp"
+    stale.write_text("orphan")
+
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
+
+    assert refreshed is gnome_extension.RefreshResult.UNCHANGED
+    assert not stale.exists()
 
 
 @patch.object(gnome_extension.shutil, "copy2", side_effect=PermissionError("ro"))
@@ -71,17 +111,11 @@ def test_refresh_extension_files_write_failure_returns_error(
     """A write error (e.g. read-only dest) is swallowed and noted on stderr,
     leaving the existing install untouched rather than crashing startup."""
     src = tmp_path / "src"
-    src.mkdir()
-    (src / "extension.js").write_text("new")
-    (src / "metadata.json").write_text("{}")
+    _write_assets(src, extension_js="new")
     dest = tmp_path / "dest"
-    dest.mkdir()
-    (dest / "extension.js").write_text("old")
-    (dest / "metadata.json").write_text("{}")
+    _write_assets(dest, extension_js="old")
 
-    refreshed = gnome_extension.refresh_extension_files(
-        src / "extension.js", src / "metadata.json", dest
-    )
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
 
     assert refreshed is gnome_extension.RefreshResult.ERROR
     assert (dest / "extension.js").read_text() == "old"
@@ -92,13 +126,9 @@ def test_refresh_extension_files_no_partial_overwrite_on_midway_failure(tmp_path
     """A copy failing partway through leaves the existing install untouched and
     no temp files behind, since files are staged then moved."""
     src = tmp_path / "src"
-    src.mkdir()
-    (src / "extension.js").write_text("new")
-    (src / "metadata.json").write_text("new")
+    _write_assets(src, extension_js="new", extension_helpers_js="new")
     dest = tmp_path / "dest"
-    dest.mkdir()
-    (dest / "extension.js").write_text("old")
-    (dest / "metadata.json").write_text("old")
+    _write_assets(dest, extension_js="old", extension_helpers_js="old")
 
     real_copy = gnome_extension.shutil.copy2
     calls = {"n": 0}
@@ -110,13 +140,11 @@ def test_refresh_extension_files_no_partial_overwrite_on_midway_failure(tmp_path
         return real_copy(s, d, *a, **k)
 
     with patch.object(gnome_extension.shutil, "copy2", side_effect=flaky_copy):
-        refreshed = gnome_extension.refresh_extension_files(
-            src / "extension.js", src / "metadata.json", dest
-        )
+        refreshed = gnome_extension.refresh_extension_files(src, dest)
 
     assert refreshed is gnome_extension.RefreshResult.ERROR
     assert (dest / "extension.js").read_text() == "old"
-    assert (dest / "metadata.json").read_text() == "old"
+    assert (dest / "extension-helpers.js").read_text() == "old"
     assert not list(dest.glob(".*.tmp"))
 
 
@@ -124,13 +152,25 @@ def test_refresh_extension_files_missing_source(tmp_path, capsys):
     src = tmp_path / "src"  # no files created
     dest = tmp_path / "dest"
 
-    refreshed = gnome_extension.refresh_extension_files(
-        src / "extension.js", src / "metadata.json", dest
-    )
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
 
     assert refreshed is gnome_extension.RefreshResult.ERROR
     assert not dest.exists()
     assert "sources missing" in capsys.readouterr().err
+
+
+def test_refresh_extension_files_partial_source_missing_helper(tmp_path):
+    """A bundle missing the helper installs nothing rather than a half-extension."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "extension.js").write_text("x")
+    (src / "metadata.json").write_text("x")  # no extension-helpers.js
+    dest = tmp_path / "dest"
+
+    refreshed = gnome_extension.refresh_extension_files(src, dest)
+
+    assert refreshed is gnome_extension.RefreshResult.ERROR
+    assert not dest.exists()
 
 
 # --- path helpers ------------------------------------------------------------
@@ -139,8 +179,8 @@ def test_refresh_extension_files_missing_source(tmp_path, capsys):
 def test_extension_source_dir_holds_bundled_assets():
     src = gnome_extension.extension_source_dir()
     # Assets are package data in src/ (the easyspeak package), next to core/.
-    assert (src / "extension.js").is_file()
-    assert (src / "metadata.json").is_file()
+    for name in gnome_extension.EXTENSION_ASSETS:
+        assert (src / name).is_file()
     assert (src / "core" / "gnome_extension.py").is_file()
 
 
@@ -175,9 +215,8 @@ def test_refresh_installed_extension_delegates():
 
     assert result is gnome_extension.RefreshResult.REFRESHED
     args = mock_refresh.call_args.args
-    assert args[0].name == "extension.js"
-    assert args[1].name == "metadata.json"
-    assert str(args[2]) == "/dest"
+    assert str(args[0]) == "/repo"
+    assert str(args[1]) == "/dest"
 
 
 # --- unit rendering ----------------------------------------------------------


### PR DESCRIPTION
> **Stacked on #59** (base = `feat/gnome-tray-icon`). Review/merge #59 first; this PR's base will retarget to `dev` once #59 lands. Rebased onto current #59, so the extension now lives under `src/` as package data.

## Why

`extension.js` runs inside gnome-shell and its top-level `gi://` imports only resolve there, so it can't be unit-tested directly. This pulls the pure computation out so it can.

## What

**Refactor + multi-file install** — extract the gi-free logic into `src/extension-helpers.js`:
- `clampToWorkArea`, `scrollDirectionDelta`, `gridGeometry` (the 3×3 grid math), `indicatorVisibleForState` (tray rule).
- `src/extension.js` imports them; behavior unchanged. Linted via the new file in `eslint.config.mjs` / `just lint-js`.
- The extension is now **multi-file**: `extension.js` won't load without the helper it imports, so the two must ship together. `core.gnome_extension` now models the bundle as a set (`EXTENSION_ASSETS`) — it installs/refreshes every asset together, a stale *or missing* helper triggers a full re-copy (so installs predating the helper self-heal), and the helper ships as package data alongside `extension.js` (`pyproject.toml`), with a `just gate` check keeping it in both wheel and sdist.

**Tests**
- `tests/js/extension-helpers.test.js` — 10 `node --test` unit tests for the helpers.
- `tests/js/dbus-contract.test.js` — parses `src/extension.js` and asserts the interface-XML methods and the `enable()` handler map stay in sync. Catches "declared a method but forgot to wire it" with no running shell.
- `just test-js` (`node >= 21`), run in the `lint-js` CI job; `nodejs` added to the dev shell.
- `tests/unit/core/test_gnome_extension.py` — updated for the asset-set API, plus regression tests for the helper specifically (changed helper alone re-copies; helper missing from an old dest is added; partial source missing the helper installs nothing).

## Tested
- `just test-js` → 11 passing. `just lint-js` clean (0 errors).
- `pytest tests/unit` → all green, incl. 37 `gnome_extension` tests.
- `uv build` → `extension-helpers.js` present in both wheel and sdist.
