### PR TITLE
feat(system): native OSD for volume and brightness via media keys

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ readme = "README.md"
 requires-python = ">=3.10, <3.14"
 dependencies = [
   "faster-whisper>=1.2.1",
+  "jeepney>=0.9",
   "numpy>=2.2.6",
   # "openwakeword",  # requires Python <3.13 for speexdsp-ns (missing wheels)
   "onnxruntime>=1.23.2",

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -64,6 +64,21 @@ class EasySpeak:
         """Speak a phrase. Stable plugin-facing API; delegates to the pipeline."""
         self.speech.speak(text)
 
+    def tap_key(self, keycode):
+        """Replay a multimedia key so the desktop renders its native feedback.
+
+        Returns True if the key was injected, False if unavailable (e.g. a
+        non-GNOME session) so the caller can fall back to a silent change.
+        jeepney is imported lazily so the dependency isn't needed to load.
+        """
+        try:
+            from . import mediakeys
+
+            mediakeys.tap_key(keycode)
+            return True
+        except Exception:
+            return False
+
     # --- Plugin management ---
 
     def load_plugins(self):

--- a/src/core/mediakeys.py
+++ b/src/core/mediakeys.py
@@ -1,0 +1,52 @@
+"""Replay multimedia keys through GNOME (Mutter) so the desktop renders its own
+native feedback — the volume OSD and the chime — rather than imitating them.
+
+Pressing a volume key does not run any command: gnome-settings-daemon grabs the
+raw evdev key and handles the volume change, OSD and chime itself. The only way
+to reproduce that exactly is to replay the key. We inject it through Mutter's
+RemoteDesktop interface, which needs no special privileges. A RemoteDesktop
+session lives only as long as the D-Bus connection that created it, so the whole
+CreateSession -> Start -> NotifyKeyboardKeycode -> Stop sequence runs on one
+connection.
+"""
+
+from jeepney import DBusAddress, new_method_call
+from jeepney.io.blocking import open_dbus_connection
+
+_BUS = "org.gnome.Mutter.RemoteDesktop"
+
+_REMOTE_DESKTOP = DBusAddress(
+    "/org/gnome/Mutter/RemoteDesktop",
+    bus_name=_BUS,
+    interface=_BUS,
+)
+
+
+def tap_key(keycode):
+    """Press and release one evdev keycode via Mutter RemoteDesktop.
+
+    Raises if RemoteDesktop is unavailable (e.g. a non-GNOME session) so the
+    caller can fall back to a silent change.
+    """
+    conn = open_dbus_connection(bus="SESSION")
+    try:
+        reply = conn.send_and_get_reply(
+            new_method_call(_REMOTE_DESKTOP, "CreateSession")
+        )
+        session = DBusAddress(
+            reply.body[0],
+            bus_name=_BUS,
+            interface=f"{_BUS}.Session",
+        )
+        conn.send_and_get_reply(new_method_call(session, "Start"))
+        # Synchronous replies guarantee Mutter has processed each event before
+        # we move on, so no settling delay is needed before Stop.
+        for pressed in (True, False):
+            conn.send_and_get_reply(
+                new_method_call(
+                    session, "NotifyKeyboardKeycode", "ub", (keycode, pressed)
+                )
+            )
+        conn.send_and_get_reply(new_method_call(session, "Stop"))
+    finally:
+        conn.close()

--- a/src/plugins/system.py
+++ b/src/plugins/system.py
@@ -15,52 +15,72 @@ COMMANDS = [
 core = None
 
 
+# evdev keycodes for the multimedia keys (stable Linux input ABI). Replaying these
+# lets gnome-settings-daemon produce its own change and native OSD (plus the chime
+# for volume) -- identical to pressing the keys, because it *is* the keys.
+KEY_MUTE = 113
+KEY_VOLUME_DOWN = 114
+KEY_VOLUME_UP = 115
+KEY_BRIGHTNESS_DOWN = 224
+KEY_BRIGHTNESS_UP = 225
+
+# gdbus invocation for org.gnome.SettingsDaemon.Power.Screen, minus the method name.
+_POWER_SCREEN = [
+    "gdbus",
+    "call",
+    "--session",
+    "--dest",
+    "org.gnome.SettingsDaemon.Power",
+    "--object-path",
+    "/org/gnome/SettingsDaemon/Power",
+    "--method",
+]
+
+
 def setup(c):
     global core
     core = c
 
 
+def _media_key(core, keycode, fallback):
+    """Replay a multimedia key for the desktop's native OSD (and chime for volume).
+
+    Falls back to the given command if key injection is unavailable (e.g. a
+    non-GNOME session); the setting still changes, just without the feedback.
+    """
+    if not core.tap_key(keycode):
+        core.host_run(fallback)
+
+
 def volume_up(core):
-    core.host_run(["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%+"])
+    _media_key(
+        core, KEY_VOLUME_UP, ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%+"]
+    )
 
 
 def volume_down(core):
-    core.host_run(["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%-"])
+    _media_key(
+        core, KEY_VOLUME_DOWN, ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%-"]
+    )
 
 
 def volume_mute(core):
-    core.host_run(["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"])
+    _media_key(core, KEY_MUTE, ["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"])
 
 
 def brightness_up(core):
-    core.host_run(
-        [
-            "gdbus",
-            "call",
-            "--session",
-            "--dest",
-            "org.gnome.SettingsDaemon.Power",
-            "--object-path",
-            "/org/gnome/SettingsDaemon/Power",
-            "--method",
-            "org.gnome.SettingsDaemon.Power.Screen.StepUp",
-        ]
+    _media_key(
+        core,
+        KEY_BRIGHTNESS_UP,
+        [*_POWER_SCREEN, "org.gnome.SettingsDaemon.Power.Screen.StepUp"],
     )
 
 
 def brightness_down(core):
-    core.host_run(
-        [
-            "gdbus",
-            "call",
-            "--session",
-            "--dest",
-            "org.gnome.SettingsDaemon.Power",
-            "--object-path",
-            "/org/gnome/SettingsDaemon/Power",
-            "--method",
-            "org.gnome.SettingsDaemon.Power.Screen.StepDown",
-        ]
+    _media_key(
+        core,
+        KEY_BRIGHTNESS_DOWN,
+        [*_POWER_SCREEN, "org.gnome.SettingsDaemon.Power.Screen.StepDown"],
     )
 
 
@@ -77,13 +97,17 @@ def dnd_off(core):
 
 
 def handle(cmd, core):
-    # Volume
-    if "volume" in cmd or "sound" in cmd:
-        if "up" in cmd or "louder" in cmd:
+    # Volume -- "louder"/"quieter" etc. work on their own, without "volume"/"sound".
+    # Match whole words so "silent" doesn't fire on "silently", "softer" on "softest"...
+    words = cmd.split()
+    louder = "louder" in words
+    quieter = any(word in words for word in ("quieter", "softer", "silent"))
+    if "volume" in cmd or "sound" in cmd or louder or quieter:
+        if "up" in cmd or louder:
             volume_up(core)
             core.speak("Volume up.")
             return True
-        elif "down" in cmd or "quieter" in cmd or "softer" in cmd:
+        elif "down" in cmd or quieter:
             volume_down(core)
             core.speak("Volume down.")
             return True

--- a/tests/core/test_main.py
+++ b/tests/core/test_main.py
@@ -74,6 +74,25 @@ class TestEasySpeakUtilities:
 
         easy.speech.speak.assert_called_once_with("hello")
 
+    def test_tap_key_returns_true_on_injection(self):
+        """tap_key delegates to mediakeys and reports success."""
+        easy = EasySpeak()
+
+        with patch("easyspeak.core.mediakeys.tap_key") as mock_tap:
+            result = easy.tap_key(115)
+
+        assert result is True
+        mock_tap.assert_called_once_with(115)
+
+    def test_tap_key_returns_false_when_unavailable(self):
+        """tap_key reports failure when injection raises (e.g. non-GNOME session)."""
+        easy = EasySpeak()
+
+        with patch("easyspeak.core.mediakeys.tap_key", side_effect=Exception):
+            result = easy.tap_key(115)
+
+        assert result is False
+
 
 class TestEasySpeakPlugins:
     """Tests for EasySpeak plugin management."""

--- a/tests/core/test_mediakeys.py
+++ b/tests/core/test_mediakeys.py
@@ -1,0 +1,54 @@
+"""Tests for the mediakeys module."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from easyspeak.core import mediakeys
+
+
+@patch("easyspeak.core.mediakeys.open_dbus_connection")
+def test_tap_key_replays_press_and_release(mock_open):
+    """tap_key drives one RemoteDesktop session, pressing then releasing the key."""
+    conn = Mock()
+    create_reply = Mock()
+    create_reply.body = ["/org/gnome/Mutter/RemoteDesktop/Session/u0"]
+    conn.send_and_get_reply.return_value = create_reply
+    mock_open.return_value = conn
+
+    with patch("easyspeak.core.mediakeys.new_method_call") as mock_call:
+        mediakeys.tap_key(115)
+
+    mock_open.assert_called_once_with(bus="SESSION")
+
+    # CreateSession -> Start -> key press -> key release -> Stop, in order.
+    methods = [call.args[1] for call in mock_call.call_args_list]
+    assert methods == [
+        "CreateSession",
+        "Start",
+        "NotifyKeyboardKeycode",
+        "NotifyKeyboardKeycode",
+        "Stop",
+    ]
+
+    # The two key events carry (keycode, pressed) with press before release.
+    key_events = [
+        call.args[3]
+        for call in mock_call.call_args_list
+        if call.args[1] == "NotifyKeyboardKeycode"
+    ]
+    assert key_events == [(115, True), (115, False)]
+
+    conn.close.assert_called_once()
+
+
+@patch("easyspeak.core.mediakeys.open_dbus_connection")
+def test_tap_key_closes_connection_on_error(mock_open):
+    """The connection is closed even when a D-Bus call fails."""
+    conn = Mock()
+    conn.send_and_get_reply.side_effect = RuntimeError("no RemoteDesktop")
+    mock_open.return_value = conn
+
+    with pytest.raises(RuntimeError):
+        mediakeys.tap_key(115)
+
+    conn.close.assert_called_once()

--- a/tests/plugins/test_system.py
+++ b/tests/plugins/test_system.py
@@ -13,68 +13,63 @@ def test_setup(mock_core):
     assert system.core is mock_core
 
 
-@pytest.mark.parametrize(
-    ["func", "expected_command"],
-    [
-        (
-            system.volume_up,
-            ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%+"],
-        ),
-        (
-            system.volume_down,
-            ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%-"],
-        ),
-        (
-            system.volume_mute,
-            ["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"],
-        ),
-    ],
-)
-def test_volume_functions(func, expected_command, mock_core):
-    """When volume control functions are called, host_run is called with correct commands."""
+_STEP_UP = "org.gnome.SettingsDaemon.Power.Screen.StepUp"
+_STEP_DOWN = "org.gnome.SettingsDaemon.Power.Screen.StepDown"
+
+# (function, replayed keycode, command it falls back to when injection is unavailable).
+MEDIA_KEYS = [
+    (
+        system.volume_up,
+        system.KEY_VOLUME_UP,
+        ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%+"],
+    ),
+    (
+        system.volume_down,
+        system.KEY_VOLUME_DOWN,
+        ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%-"],
+    ),
+    (
+        system.volume_mute,
+        system.KEY_MUTE,
+        ["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"],
+    ),
+    (system.brightness_up, system.KEY_BRIGHTNESS_UP, [*system._POWER_SCREEN, _STEP_UP]),
+    (
+        system.brightness_down,
+        system.KEY_BRIGHTNESS_DOWN,
+        [*system._POWER_SCREEN, _STEP_DOWN],
+    ),
+]
+
+
+@pytest.mark.parametrize(["func", "expected_keycode", "fallback"], MEDIA_KEYS)
+def test_replays_media_key(func, expected_keycode, fallback, mock_core):
+    """Volume and brightness controls replay the real key for GNOME's native feedback."""
+    mock_core.tap_key.return_value = True
+
     func(mock_core)
 
-    assert mock_core.host_run.call_args.args[0] == expected_command
+    assert mock_core.tap_key.call_args.args[0] == expected_keycode
 
 
-@pytest.mark.parametrize(
-    ["func", "expected_command"],
-    [
-        (
-            system.brightness_up,
-            [
-                "gdbus",
-                "call",
-                "--session",
-                "--dest",
-                "org.gnome.SettingsDaemon.Power",
-                "--object-path",
-                "/org/gnome/SettingsDaemon/Power",
-                "--method",
-                "org.gnome.SettingsDaemon.Power.Screen.StepUp",
-            ],
-        ),
-        (
-            system.brightness_down,
-            [
-                "gdbus",
-                "call",
-                "--session",
-                "--dest",
-                "org.gnome.SettingsDaemon.Power",
-                "--object-path",
-                "/org/gnome/SettingsDaemon/Power",
-                "--method",
-                "org.gnome.SettingsDaemon.Power.Screen.StepDown",
-            ],
-        ),
-    ],
-)
-def test_brightness_functions(func, expected_command, mock_core):
-    """When brightness control functions are called, host_run is called with correct commands."""
+@pytest.mark.parametrize(["func", "expected_keycode", "fallback"], MEDIA_KEYS)
+def test_no_fallback_when_key_injected(func, expected_keycode, fallback, mock_core):
+    """When the key injection succeeds, no fallback command is issued."""
+    mock_core.tap_key.return_value = True
+
     func(mock_core)
 
-    assert mock_core.host_run.call_args.args[0] == expected_command
+    assert not mock_core.host_run.called
+
+
+@pytest.mark.parametrize(["func", "expected_keycode", "fallback"], MEDIA_KEYS)
+def test_falls_back_when_key_unavailable(func, expected_keycode, fallback, mock_core):
+    """When key injection is unavailable, fall back to the silent command."""
+    mock_core.tap_key.return_value = False
+
+    func(mock_core)
+
+    assert mock_core.host_run.call_args.args[0] == fallback
 
 
 @pytest.mark.parametrize(
@@ -114,10 +109,14 @@ def test_dnd_functions(func, expected_command, mock_core):
     [
         ("volume up", "Volume up.", "volume_up"),
         ("volume louder", "Volume up.", "volume_up"),
+        ("louder", "Volume up.", "volume_up"),
+        ("make it louder", "Volume up.", "volume_up"),
         ("sound up", "Volume up.", "volume_up"),
         ("volume down", "Volume down.", "volume_down"),
         ("volume quieter", "Volume down.", "volume_down"),
         ("volume softer", "Volume down.", "volume_down"),
+        ("more silent", "Volume down.", "volume_down"),
+        ("make it quieter", "Volume down.", "volume_down"),
         ("sound down", "Volume down.", "volume_down"),
         ("volume mute", "Toggled mute.", "volume_mute"),
         ("volume unmute", "Toggled mute.", "volume_mute"),
@@ -212,6 +211,15 @@ def test_handle_dnd_commands(
     assert result is True
     assert mock_core.speak.call_args.args[0] == expected_speech
     assert func_map[expected_func].call_args.args[0] == mock_core
+
+
+@pytest.mark.parametrize("command", ["wait silently", "the softest blanket"])
+def test_handle_volume_word_match_not_substring(command, mock_core):
+    """Volume synonyms match whole words, so 'silently'/'softest' don't trigger it."""
+    result = system.handle(command, mock_core)
+
+    assert result is None
+    assert not mock_core.speak.called
 
 
 def test_handle_unrecognized_command(mock_core):

--- a/uv.lock
+++ b/uv.lock
@@ -460,6 +460,7 @@ name = "easyspeak-linux"
 source = { editable = "." }
 dependencies = [
     { name = "faster-whisper" },
+    { name = "jeepney" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -496,6 +497,7 @@ unittest = [
 requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'unittest'", specifier = ">=7.14" },
     { name = "faster-whisper", specifier = ">=1.2.1" },
+    { name = "jeepney", specifier = ">=0.9" },
     { name = "mypy", marker = "extra == 'mypy'", specifier = ">=1.19.1" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "onnxruntime", specifier = ">=1.23.2" },
@@ -728,6 +730,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Gives voice volume **and brightness** commands native GNOME feedback — the on-screen display (and, for volume, the chime) — by **replaying the real multimedia keys**. gnome-settings-daemon grabs the raw evdev key and produces the change and OSD itself, so the result is identical to pressing the keys, because it *is* the keys.

- `src/core/mediakeys.py` (new) — injects an evdev keycode through Mutter's `RemoteDesktop` interface (`CreateSession` → `Start` → `NotifyKeyboardKeycode` press/release → `Stop`, all on one D-Bus connection, since a RemoteDesktop session lives only as long as its connection). Needs no special privileges; uses `jeepney` for the D-Bus calls.
- `src/core/main.py` — `EasySpeak.tap_key(keycode)` exposes this to plugins; lazily imports `mediakeys` and returns `True` if the key was injected, `False` if unavailable (e.g. a non-GNOME session).
- `src/plugins/system.py` — `volume_up`/`volume_down`/`volume_mute` and `brightness_up`/`brightness_down` replay their respective keys, falling back to a silent `wpctl` / `gdbus` change when injection is unavailable, so the setting still changes even without a GNOME session.
- `jeepney` added as a dependency for the D-Bus calls.

## Tested

| Unit | Test scope |
|--------|--------|
| `tests/core/test_main.py` | `EasySpeak.tap_key` returns `True` when the key is injected and `False` when injection raises (e.g. a non-GNOME session) |
| `tests/core/test_mediakeys.py` | `mediakeys` drives the RemoteDesktop session (press then release, in order) and closes the connection even on error |
| `tests/plugins/test_system.py` | each volume/brightness control replays the right keycode, issues no fallback when injection succeeds, and falls back to the correct `wpctl`/`gdbus` command when unavailable; command routing maps spoken phrases — including bare "louder" / "more silent" — to the right action |

### Manual checklist (Wayland — not CI-testable)
- [ ] "Hey Jarvis, volume up/down/mute" shows GNOME's native OSD at the new level **and** plays the chime — matching the multimedia keys side by side.
- [ ] "Hey Jarvis, brightness up/down" shows GNOME's native brightness OSD — matching the brightness keys.
- [ ] On a non-GNOME session, volume and brightness still change silently via `wpctl` / `gdbus`.

Fixes #2