### PR TITLE
Improve voice interaction: friendlier feedback, parallel replies, richer commands, hands-free chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ easyspeak                              # the project execution script
 
 Activate the venv each time you open a new terminal.
 
-Say "Hey Jarvis" followed by a command.
+Say "Hey Jarvis" followed by a command. After a command that gives no spoken
+reply (such as volume changes), EasySpeak keeps listening for a few seconds so
+you can chain commands — say "louder", "louder", "louder" without repeating the
+wake word each time.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -274,9 +274,10 @@ Built-in bookmarks: youtube, google, gmail, github, reddit, twitter, facebook, a
 | close [app] | Close application |
 
 Default apps in `plugins/apps.py` (edit to match your system):
-- firefox, steam, spotify, calculator, settings, files, terminal, browser
+- firefox, steam, spotify, calculator, settings, files, terminal, browser, music player
 
-These are just examples. Edit `apps.py` to add your own apps.
+These are just examples. Edit `apps.py` to add your own apps. Some accept
+spoken aliases — e.g. "open music app" works the same as "open music player".
 
 ### Files
 
@@ -287,6 +288,7 @@ These are just examples. Edit `apps.py` to add your own apps.
 | open pictures | Open Pictures folder |
 | open music | Open Music folder |
 | open videos | Open Videos folder |
+| open projects | Open Projects folder |
 | open home | Open home folder |
 | open desktop | Open Desktop folder |
 
@@ -295,7 +297,7 @@ These are just examples. Edit `apps.py` to add your own apps.
 | Command | Action |
 |---------|--------|
 | play | Resume playback |
-| pause | Pause playback |
+| pause / stop the music | Pause playback |
 | next / skip | Next track |
 | previous / back | Previous track |
 
@@ -303,10 +305,13 @@ These are just examples. Edit `apps.py` to add your own apps.
 
 | Command | Action |
 |---------|--------|
-| volume up/down | Adjust volume |
+| volume up/down (or louder / quieter) | Adjust volume one step (repeat to keep going) |
+| very loud / very silent | Jump straight to near-max (85%) / low (15%, not muted) |
 | mute | Toggle mute |
 | brightness up/down | Adjust brightness |
 | do not disturb on/off | Toggle notifications |
+
+Volume changes are silent — GNOME's own on-screen display and chime acknowledge them.
 
 ### General
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ These are just examples. Edit `apps.py` to add your own apps.
 | Command | Action |
 |---------|--------|
 | help | List all commands |
+| go to sleep / stop listening | Release the mic (reactivate from the tray icon) |
 | stop / exit / quit | Exit EasySpeak |
 
 ## File Structure

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Volume changes are silent — GNOME's own on-screen display and chime acknowledg
 |---------|--------|
 | help | List all commands |
 | go to sleep / stop listening | Release the mic (reactivate from the tray icon) |
-| stop / exit / quit | Exit EasySpeak |
+| quit / exit / goodbye | Exit EasySpeak |
 
 ## File Structure
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -19,6 +19,7 @@ SILENCE_THRESHOLD = 300
 SILENCE_DURATION = 0.3
 
 MISUNDERSTAND_GRACE = 4.0  # Seconds to ignore repeat misses after feedback
+FOLLOWUP_IDLE_ROUNDS = 2  # Quiet listens tolerated before a command session ends
 
 # --- Models ---
 PIPER_MODEL = os.environ.get(

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -18,6 +18,8 @@ WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
 SILENCE_THRESHOLD = 300
 SILENCE_DURATION = 0.3
 
+MISUNDERSTAND_GRACE = 4.0  # Seconds to ignore repeat misses after feedback
+
 # --- Models ---
 PIPER_MODEL = os.environ.get(
     "EASYSPEAK_PIPER_MODEL",

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -21,6 +21,7 @@ from openwakeword.model import Model as WakeWordModel
 
 from .config import (
     COMMAND_PROMPT,
+    MISUNDERSTAND_GRACE,
     SILENCE_DURATION,
     SILENCE_THRESHOLD,
     WAKE_COOLDOWN,
@@ -48,6 +49,11 @@ class EasySpeak:
         self.audio = None
         self.stream = None
         self.last_wake_time = 0
+        self.misunderstand_count = 0
+        self.help_shown = False
+        self.keep_listening = False
+        self.unrecognized = False
+        self.last_misunderstand_time = 0
         # Persistent text-to-speech pipeline (piper -> audio player) so the
         # voice model is loaded only once.
         self.speech = SpeechPipeline()
@@ -141,6 +147,7 @@ class EasySpeak:
         ]:
             cmd = cmd.replace(wake, "").strip()
         cmd = cmd.strip(".,!? ")
+        self.unrecognized = False
 
         if not cmd:
             return True
@@ -149,14 +156,53 @@ class EasySpeak:
             try:
                 result = plugin.handle(cmd, self)
                 if result is True:
+                    self.misunderstand_count = 0
+                    self.help_shown = False
                     return True
                 elif result is False:
                     return False
             except Exception as e:
                 print(f"Plugin error ({plugin.NAME}): {e}")
 
-        self.speak("I didn't understand. Say help for commands.")
+        self._report_not_understood()
         return True
+
+    def _report_not_understood(self):
+        """Give gentle spoken feedback that no plugin matched the command.
+
+        Misses within MISUNDERSTAND_GRACE of the last one are dropped: that
+        burst is almost always the open mic transcribing this very feedback, and
+        reacting would cascade into the help screen with no one having spoken; a
+        real retry lands after the feedback plays out, past the window. The
+        first real miss apologises, the next escalates to the command list
+        (shown once per streak), and further misses keep the mic open without
+        repeating it. The feedback never says "help" — the open mic would
+        transcribe it and fire the help command in a loop.
+        """
+        now = time.time()
+        if now - self.last_misunderstand_time < MISUNDERSTAND_GRACE:
+            return
+        self.last_misunderstand_time = now
+
+        self.unrecognized = True
+        self.misunderstand_count += 1
+        if self.misunderstand_count == 1:
+            self.speak("Sorry, I didn't understand.")
+            return
+
+        self.speak("I didn't understand.")
+        if not self.help_shown:
+            self._show_help()
+            self.help_shown = True
+        self.keep_listening = True
+
+    def _show_help(self):
+        """Display the command list via the plugin that owns it (the base
+        plugin's ``show_help``), so the help text isn't duplicated here."""
+        for plugin in self.plugins:
+            if hasattr(plugin, "show_help"):
+                plugin.show_help(self)
+                return
 
     # --- Audio ---
 
@@ -246,6 +292,59 @@ class EasySpeak:
 
     # --- Main loop ---
 
+    def _reset_detector(self):
+        """Clear the wake detector's feature buffer and drop buffered mic audio,
+        so stale or half-primed state can't fire a spurious wake."""
+        self.wakeword.reset()
+        self.flush_stream()
+
+    def _play_wake_chime(self):
+        """Play the wake acknowledgement sound, then flush the audio it bled
+        into the mic so it isn't mistaken for the user speaking."""
+        subprocess.run(
+            ["paplay", "/usr/share/sounds/freedesktop/stereo/message.oga"],
+            capture_output=True,
+        )
+        self.flush_stream()
+
+    def _drain_feedback(self):
+        """Wait for the spoken "didn't understand" feedback to finish playing,
+        then flush the mic. speak() is non-blocking, so flushing alone leaves the
+        still-playing tail for the open mic to transcribe into the next
+        escalation (e.g. opening help) with no one having spoken."""
+        self.speech.drain()
+        self.flush_stream()
+
+    def _capture_command_session(self):
+        """Capture and route commands after a wake until none is pending.
+
+        Usually one command, but a repeated misunderstanding shows help and
+        re-arms keep_listening so the user can retry without the wake word.
+        After any "didn't understand" the feedback is drained before listening
+        again. Returns True if a command asked the daemon to exit.
+        """
+        self.keep_listening = True
+        while self.keep_listening:
+            self.keep_listening = False
+            self.unrecognized = False
+
+            first = self.wait_for_speech(timeout=5)
+            if first:
+                audio = first + self.record_until_silence()
+                cmd = self.transcribe(audio)
+                if cmd:
+                    print(f"👂 {cmd}")
+                    if not self.route_command(cmd.lower().strip(".,!? ")):
+                        return True
+                    self.wakeword.reset()
+                    self.flush_stream()
+            else:
+                self.speak("I didn't hear anything.")
+
+            if self.unrecognized:
+                self._drain_feedback()
+        return False
+
     def run(self):
         print("Loading OpenWakeWord...")
         self.wakeword = WakeWordModel()
@@ -305,6 +404,7 @@ class EasySpeak:
                 if action is TrayAction.QUIT:
                     break
                 if action is TrayAction.RESUME:
+                    self._reset_detector()
                     audio_buffer = []
                     print("Listening for wake word...")
                     continue
@@ -320,7 +420,6 @@ class EasySpeak:
                 score = prediction.get(WAKE_WORD, 0)
 
                 if score > WAKE_THRESHOLD:
-                    # Cooldown check - ignore if triggered recently
                     now = time.time()
                     if now - self.last_wake_time < WAKE_COOLDOWN:
                         continue
@@ -328,35 +427,12 @@ class EasySpeak:
 
                     print(f"🎤 Wake! (confidence: {score:.2f})")
 
-                    # Reset everything
-                    self.wakeword.reset()
+                    self._reset_detector()
                     audio_buffer = []
-                    self.flush_stream()
+                    self._play_wake_chime()
 
-                    # Audio feedback first
-                    subprocess.run(
-                        ["paplay", "/usr/share/sounds/freedesktop/stereo/message.oga"],
-                        capture_output=True,
-                    )
-
-                    # Flush any audio captured during beep
-                    self.flush_stream()
-
-                    # Wait for user to start speaking (up to 5 seconds)
-                    first = self.wait_for_speech(timeout=5)
-
-                    if first:
-                        # User started speaking, record until they stop
-                        audio = first + self.record_until_silence()
-                        cmd = self.transcribe(audio)
-                        if cmd:
-                            print(f"👂 {cmd}")
-                            if not self.route_command(cmd.lower().strip(".,!? ")):
-                                break
-                            self.wakeword.reset()
-                            self.flush_stream()
-                    else:
-                        self.speak("I didn't hear anything.")
+                    if self._capture_command_session():
+                        break
 
                     audio_buffer = []
                     print("Listening for wake word...")

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -348,8 +348,7 @@ class EasySpeak:
                     print(f"👂 {cmd}")
                     if not self.route_command(cmd.lower().strip(".,!? ")):
                         return True
-                    self.wakeword.reset()
-                    self.flush_stream()
+                    self._reset_detector()
                     if not self.unrecognized and not self.spoke:
                         quiet = 0
                         self.keep_listening = True

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -21,6 +21,7 @@ from openwakeword.model import Model as WakeWordModel
 
 from .config import (
     COMMAND_PROMPT,
+    FOLLOWUP_IDLE_ROUNDS,
     MISUNDERSTAND_GRACE,
     SILENCE_DURATION,
     SILENCE_THRESHOLD,
@@ -53,6 +54,7 @@ class EasySpeak:
         self.help_shown = False
         self.keep_listening = False
         self.unrecognized = False
+        self.spoke = False
         self.last_misunderstand_time = 0
         # Persistent text-to-speech pipeline (piper -> audio player) so the
         # voice model is loaded only once.
@@ -72,6 +74,7 @@ class EasySpeak:
 
     def speak(self, text):
         """Speak a phrase. Stable plugin-facing API; delegates to the pipeline."""
+        self.spoke = True
         self.speech.speak(text)
 
     def tap_key(self, keycode):
@@ -316,31 +319,45 @@ class EasySpeak:
         self.flush_stream()
 
     def _capture_command_session(self):
-        """Capture and route commands after a wake until none is pending.
+        """Capture and route commands after a wake, staying open for follow-ups.
 
-        Usually one command, but a repeated misunderstanding shows help and
-        re-arms keep_listening so the user can retry without the wake word.
-        After any "didn't understand" the feedback is drained before listening
-        again. Returns True if a command asked the daemon to exit.
+        After a recognized command that gave no spoken reply (e.g. volume), the
+        mic stays open so the user can chain commands ("louder", "louder") at
+        their own pace without repeating the wake word; the session ends once a
+        couple of quiet listens (FOLLOWUP_IDLE_ROUNDS) pass, the wake-time
+        silence times out, or a command speaks (whose reply the open mic would
+        otherwise hear). A repeated misunderstanding still re-arms keep_listening
+        for the help retry, and its feedback is drained before listening again.
+        Returns True if a command asked the daemon to exit.
         """
         self.keep_listening = True
+        awake = True
+        quiet = 0
         while self.keep_listening:
             self.keep_listening = False
             self.unrecognized = False
+            self.spoke = False
 
-            first = self.wait_for_speech(timeout=5)
-            if first:
-                audio = first + self.record_until_silence()
-                cmd = self.transcribe(audio)
+            heard = self.wait_for_speech(timeout=5)
+            if heard is None:
+                if awake:
+                    self.speak("I didn't hear anything.")
+            else:
+                cmd = self.transcribe(heard + self.record_until_silence())
                 if cmd:
                     print(f"👂 {cmd}")
                     if not self.route_command(cmd.lower().strip(".,!? ")):
                         return True
                     self.wakeword.reset()
                     self.flush_stream()
-            else:
-                self.speak("I didn't hear anything.")
+                    if not self.unrecognized and not self.spoke:
+                        quiet = 0
+                        self.keep_listening = True
+                elif not awake:
+                    quiet += 1
+                    self.keep_listening = quiet < FOLLOWUP_IDLE_ROUNDS
 
+            awake = False
             if self.unrecognized:
                 self._drain_feedback()
         return False

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -41,6 +41,7 @@ LOCAL_APPS = {
     "inkscape": "inkscape",
     "logs": "gnome-logs",
     "maps": "gnome-maps",
+    "music app": "gnome-music",
     "music player": "gnome-music",
     "nautilus": "nautilus",
     "radio": "shortwave",

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -376,8 +376,9 @@ def listen_for_hint(core):
 # routed before them (filename order), and qb() would spawn a fresh qutebrowser
 # window for each — e.g. "stop" -> :stop, "go to sleep" -> :quickmark-load
 # sleep. Decline them so they fall through to the plugin that actually owns
-# them (deactivate / quit). Exact-matched quit words mirror zz_base; the sleep
-# phrases are substring-matched to match sleep.py.
+# them (deactivate / quit). Exact-matched quit words mirror zz_base, plus a
+# bare "stop" — no longer a quit word, but it still must not reach qb, which
+# would open qutebrowser. The sleep phrases are substring-matched per sleep.py.
 RESERVED_GLOBAL_EXACT = ("stop", "exit", "quit", "goodbye", "bye")
 RESERVED_GLOBAL_SUBSTR = ("go to sleep", "goto sleep", "stop listening")
 

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -602,8 +602,8 @@ def handle_browser_command(cmd_lower, core):
     ) and " as " in cmd_lower:
         name = cmd_lower.split(" as ")[-1].strip()
         if name:
-            qb(f"quickmark-save {name}")
             core.speak(f"Saved as {name}.")
+            qb(f"quickmark-save {name}")
             return True
 
     # Load quickmark (user-saved)
@@ -613,15 +613,15 @@ def handle_browser_command(cmd_lower, core):
         # Check predefined bookmarks first
         for site, url in BOOKMARKS.items():
             if site == target:
-                qb_open(url)
                 core.speak(f"Opening {site}.")
+                qb_open(url)
                 return True
 
         # Try as spoken URL (contains "dot")
         if "dot" in target or "." in target:
             url = parse_spoken_url(target)
-            qb_open(url)
             core.speak(f"Opening {url}.")
+            qb_open(url)
             return True
 
         # Don't catch generic "open X" - let other plugins handle it
@@ -637,8 +637,8 @@ def handle_browser_command(cmd_lower, core):
         query = cmd_lower.replace("search for ", "").replace("search ", "").strip()
         if query:
             url = f"https://duckduckgo.com/?q={query.replace(' ', '+')}"
-            qb_open(url)
             core.speak(f"Searching for {query}.")
+            qb_open(url)
             return True
 
     # --- Phonetic hint selection (LAST - only if nothing else matched) ---

--- a/src/plugins/files.py
+++ b/src/plugins/files.py
@@ -9,7 +9,7 @@ DESCRIPTION = "Folder navigation"
 
 COMMANDS = [
     "open [folder] - open folder in file manager",
-    "Folders: documents, downloads, pictures, music, videos, home, desktop",
+    "Folders: documents, downloads, pictures, music, videos, projects, home, desktop",
 ]
 
 FOLDERS = {
@@ -18,6 +18,7 @@ FOLDERS = {
     "pictures": "~/Pictures",
     "music": "~/Music",
     "videos": "~/Videos",
+    "projects": "~/Projects",
     "home": "~",
     "desktop": "~/Desktop",
 }

--- a/src/plugins/media.py
+++ b/src/plugins/media.py
@@ -69,12 +69,19 @@ def media_control(action, core):
 
 
 def handle(cmd, core):
+    # "stop the music" means pause; bare "stop" is left for the exit command.
+    # Whole-word match so "stop tracking" (eye tracking) isn't caught by "track".
+    words = cmd.split()
+    stop_music = "stop" in words and any(
+        word in words for word in ("music", "song", "playback", "track", "player")
+    )
+
     if "play" in cmd and "pause" not in cmd:
         core.speak("Playing.")
         media_control("play", core)
         return True
 
-    if "pause" in cmd:
+    if "pause" in cmd or stop_music:
         core.speak("Paused.")
         media_control("pause", core)
         return True

--- a/src/plugins/media.py
+++ b/src/plugins/media.py
@@ -69,7 +69,7 @@ def media_control(action, core):
 
 
 def handle(cmd, core):
-    # "stop the music" means pause; bare "stop" is left for the exit command.
+    # "stop the music"/"stop playing" mean pause; bare "stop" isn't a media command.
     # Whole-word match so "stop tracking" (eye tracking) isn't caught by "track".
     words = cmd.split()
     stop_music = "stop" in words and any(

--- a/src/plugins/media.py
+++ b/src/plugins/media.py
@@ -70,23 +70,23 @@ def media_control(action, core):
 
 def handle(cmd, core):
     if "play" in cmd and "pause" not in cmd:
-        media_control("play", core)
         core.speak("Playing.")
+        media_control("play", core)
         return True
 
     if "pause" in cmd:
-        media_control("pause", core)
         core.speak("Paused.")
+        media_control("pause", core)
         return True
 
     if "next" in cmd or "skip" in cmd:
-        media_control("next", core)
         core.speak("Next.")
+        media_control("next", core)
         return True
 
     if "previous" in cmd or "back" in cmd:
-        media_control("previous", core)
         core.speak("Previous.")
+        media_control("previous", core)
         return True
 
     return None  # Not handled

--- a/src/plugins/media.py
+++ b/src/plugins/media.py
@@ -73,17 +73,18 @@ def handle(cmd, core):
     # Whole-word match so "stop tracking" (eye tracking) isn't caught by "track".
     words = cmd.split()
     stop_music = "stop" in words and any(
-        word in words for word in ("music", "song", "playback", "track", "player")
+        word in words
+        for word in ("music", "song", "playback", "track", "player", "playing", "play")
     )
-
-    if "play" in cmd and "pause" not in cmd:
-        core.speak("Playing.")
-        media_control("play", core)
-        return True
 
     if "pause" in cmd or stop_music:
         core.speak("Paused.")
         media_control("pause", core)
+        return True
+
+    if "play" in cmd and "pause" not in cmd:
+        core.speak("Playing.")
+        media_control("play", core)
         return True
 
     if "next" in cmd or "skip" in cmd:

--- a/src/plugins/sleep.py
+++ b/src/plugins/sleep.py
@@ -11,7 +11,7 @@ NAME = "sleep"
 DESCRIPTION = "Deactivate (sleep) until reactivated from the tray"
 
 COMMANDS = [
-    "go to sleep / stop listening - release the mic; reactivate from the tray icon",
+    "go to sleep / stop listening - release the mic (reactivate from the tray icon)",
 ]
 
 # Matched as substrings against the wake-stripped command. Kept tight so they

--- a/src/plugins/sleep.py
+++ b/src/plugins/sleep.py
@@ -17,7 +17,7 @@ COMMANDS = [
 # Matched as substrings against the wake-stripped command. Kept tight so they
 # don't swallow unrelated phrases; "goto" covers a common transcription of
 # "go to", and "stop listening" also covers "stop listening now". Bare "stop"
-# is deliberately excluded — it means quit (handled by the base plugin).
+# is deliberately excluded — too ambiguous to mean sleep.
 SLEEP_PHRASES = ("go to sleep", "goto sleep", "stop listening")
 
 

--- a/src/plugins/system.py
+++ b/src/plugins/system.py
@@ -68,6 +68,16 @@ def volume_mute(core):
     _media_key(core, KEY_MUTE, ["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"])
 
 
+def volume_max(core):
+    """Jump near the top (85%, not a blast). No media key does this, so set it directly."""
+    core.host_run(["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "85%"])
+
+
+def volume_min(core):
+    """Drop low (15%, still audible — not a mute), set directly like volume_max."""
+    core.host_run(["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "15%"])
+
+
 def brightness_up(core):
     _media_key(
         core,
@@ -100,6 +110,13 @@ def handle(cmd, core):
     # Volume -- "louder"/"quieter" etc. work on their own, without "volume"/"sound".
     # Match whole words so "silent" doesn't fire on "silently", "softer" on "softest"...
     words = cmd.split()
+    if "very" in words:
+        if "loud" in words or "louder" in words:
+            volume_max(core)
+            return True
+        if any(w in words for w in ("silent", "quiet", "quieter", "soft", "softer")):
+            volume_min(core)
+            return True
     louder = "louder" in words
     quieter = any(word in words for word in ("quieter", "softer", "silent"))
     # No spoken feedback for volume/mute: GNOME's native OSD and chime already

--- a/src/plugins/system.py
+++ b/src/plugins/system.py
@@ -102,45 +102,43 @@ def handle(cmd, core):
     words = cmd.split()
     louder = "louder" in words
     quieter = any(word in words for word in ("quieter", "softer", "silent"))
+    # No spoken feedback for volume/mute: GNOME's native OSD and chime already
+    # acknowledge the change (and a spoken reply would be inaudible once muted).
     if "volume" in cmd or "sound" in cmd or louder or quieter:
         if "up" in cmd or louder:
             volume_up(core)
-            core.speak("Volume up.")
             return True
         elif "down" in cmd or quieter:
             volume_down(core)
-            core.speak("Volume down.")
             return True
         elif "mute" in cmd or "unmute" in cmd:
             volume_mute(core)
-            core.speak("Toggled mute.")
             return True
 
     if "mute" in cmd:
         volume_mute(core)
-        core.speak("Toggled mute.")
         return True
 
     # Brightness
     if "brightness" in cmd or "screen" in cmd:
         if "up" in cmd or "brighter" in cmd:
-            brightness_up(core)
             core.speak("Brighter.")
+            brightness_up(core)
             return True
         elif "down" in cmd or "dimmer" in cmd or "darker" in cmd:
-            brightness_down(core)
             core.speak("Dimmer.")
+            brightness_down(core)
             return True
 
     # Do Not Disturb
     if "do not disturb" in cmd or "dnd" in cmd or "notifications" in cmd:
         if "on" in cmd or "enable" in cmd:
-            dnd_on(core)
             core.speak("Do not disturb on.")
+            dnd_on(core)
             return True
         elif "off" in cmd or "disable" in cmd:
-            dnd_off(core)
             core.speak("Do not disturb off.")
+            dnd_off(core)
             return True
 
     return None  # Not handled

--- a/src/plugins/zz_base.py
+++ b/src/plugins/zz_base.py
@@ -7,7 +7,7 @@ DESCRIPTION = "Help and exit commands"
 
 COMMANDS = [
     "help - list all commands",
-    "stop/exit/quit - exit EasySpeak",
+    "quit/exit/goodbye - exit EasySpeak",
 ]
 
 core = None
@@ -21,13 +21,13 @@ def setup(c):
 def handle(cmd, core):
     cmd_lower = cmd.lower().strip()
 
-    # Exit - but NOT if it's "stop tracking" etc
+    # Exit - but NOT if it's "quit tracking" etc
     if "tracking" not in cmd_lower:
-        if cmd_lower in ["stop", "exit", "quit", "goodbye", "bye"]:
+        if cmd_lower in ["exit", "quit", "goodbye", "bye"]:
             core.speak("Goodbye.")
             return False  # Signal to exit
-        # Also match "jarvis stop" etc
-        if any(cmd_lower.endswith(x) for x in [" stop", " exit", " quit"]):
+        # Also match "jarvis quit" etc
+        if any(cmd_lower.endswith(x) for x in [" exit", " quit"]):
             core.speak("Goodbye.")
             return False
 

--- a/tests/acceptance/features/command_recognition.feature
+++ b/tests/acceptance/features/command_recognition.feature
@@ -1,0 +1,51 @@
+Feature: Friendly feedback when a command isn't understood
+  As someone controlling my Linux desktop by voice
+  I want unrecognised speech handled gently and only nudged toward help once
+  So that I'm guided without being nagged or talked over by my own assistant
+
+  (**Note:** These drive route_command directly with stub plugins; the spoken
+  replies are read back off the stubbed speech pipeline.)
+
+  Background:
+    Given a fresh EasySpeak that understands only "help" and "open files"
+
+  Scenario: The first unrecognised command gets a soft apology
+    When I say "flibbertigibbet"
+    Then EasySpeak's last reply is "Sorry, I didn't understand."
+    And the command list is not shown
+
+  Scenario: A second miss shows help once and keeps the mic open
+    When I say "flibbertigibbet"
+    And I say "wibble wobble"
+    Then EasySpeak says "I didn't understand."
+    And the command list is shown
+    And EasySpeak keeps listening for another command
+
+  Scenario: Repeated misses stop re-showing the command list
+    When I say "flibbertigibbet"
+    And I say "wibble wobble"
+    And I say "more nonsense"
+    Then the command list is shown exactly once
+    And EasySpeak's last reply is "I didn't understand."
+
+  Scenario: A successful command (including "help") resets the gentle flow
+    When I say "flibbertigibbet"
+    And I say "wibble wobble"
+    And I say "help"
+    And I say "more nonsense"
+    Then EasySpeak's last reply is "Sorry, I didn't understand."
+
+  # Regression: speak() is non-blocking, so the soft apology is still playing
+  # when the loop resumes. An immediate flush only clears the buffer up to that
+  # instant, so without draining first the open mic transcribes the assistant's
+  # own "Sorry, I didn't understand." and escalates to help with no one speaking.
+  Scenario: The soft apology finishes before the mic listens again
+    When the wake word fires and EasySpeak hears one unrecognised command
+    Then EasySpeak drains its speech before listening again
+    And the command list is not shown
+
+  Scenario: A self-heard echo within the grace window can't open help
+    When I say "flibbertigibbet"
+    And the mic mishears "sorry i didn't understand" a moment later
+    Then EasySpeak said "Sorry, I didn't understand." only once
+    And the command list is not shown

--- a/tests/acceptance/features/volume_control.feature
+++ b/tests/acceptance/features/volume_control.feature
@@ -1,0 +1,26 @@
+Feature: Volume control by voice
+  As someone controlling my Linux desktop by voice
+  I want volume commands to react every time and to have instant extremes
+  So that I can nudge the volume repeatedly or jump to loud/silent at once
+
+  Background:
+    Given a fresh EasySpeak with the system plugin
+
+  Scenario: Saying "louder" repeatedly raises the volume each time
+    When I say "louder"
+    And I say "louder"
+    And I say "louder"
+    Then the volume was raised 3 times
+
+  Scenario: Saying "more silent" repeatedly lowers the volume each time
+    When I say "more silent"
+    And I say "more silent"
+    Then the volume was lowered 2 times
+
+  Scenario: "very loud" jumps to maximum volume instantly
+    When I say "very loud"
+    Then the volume is set to maximum
+
+  Scenario: "very silent" drops to minimum volume instantly
+    When I say "very silent"
+    Then the volume is set to minimum

--- a/tests/acceptance/test_command_recognition.py
+++ b/tests/acceptance/test_command_recognition.py
@@ -1,0 +1,183 @@
+"""Step definitions binding command_recognition.feature to EasySpeak.
+
+The misunderstanding flow lives in route_command: a soft apology on the first
+miss, an escalation to the command list on the next, then no more help until a
+command succeeds. These steps drive route_command with stub plugins and read
+the spoken replies back off the stubbed speech pipeline.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import Mock, patch
+
+import pytest
+from easyspeak.core.config import MISUNDERSTAND_GRACE
+from easyspeak.core.main import EasySpeak
+from easyspeak.core.tray import TrayAction
+from pytest_bdd import given, parsers, scenarios, then, when
+
+scenarios("features/command_recognition.feature")
+
+
+def _live_proc():
+    """A subprocess mock that reports itself as still running."""
+    proc = Mock()
+    proc.poll.return_value = None
+    return proc
+
+
+class _StubPlugins:
+    """A minimal plugin that understands only "open files" and "help".
+
+    Mirrors the real base plugin: handling "help" displays the command list,
+    so a successful "help" both resets the streak and shows help — exactly the
+    behaviour the feature pins down. ``show_help`` is the single place the list
+    is "shown", whether reached via the help command or core's escalation.
+    """
+
+    NAME = "stub"
+
+    def __init__(self):
+        self.help_shown_count = 0
+
+    def handle(self, cmd, core):
+        if cmd == "open files":
+            return True
+        if cmd == "help":
+            self.show_help(core)
+            return True
+        return None  # anything else is not understood
+
+    def show_help(self, core):
+        self.help_shown_count += 1
+        core.speak("Check the terminal for available commands.")
+
+
+@pytest.fixture
+def ctx():
+    """Patch the subprocess boundary and a controllable clock, and carry
+    per-scenario state between steps. The clock lets a step place an utterance
+    inside or outside the misunderstanding grace window deterministically."""
+    state = {"clock": [1000.0]}
+    with patch("subprocess.Popen") as popen, ExitStack() as stack:
+        stack.enter_context(patch("time.time", side_effect=lambda: state["clock"][0]))
+        state["popen"] = popen
+        state["stack"] = stack
+        yield state
+
+
+@given('a fresh EasySpeak that understands only "help" and "open files"')
+def fresh_easyspeak(ctx):
+    player, piper = _live_proc(), _live_proc()
+    ctx["popen"].side_effect = [player, piper]
+    ctx["easy"] = EasySpeak()
+    ctx["piper"] = piper
+    ctx["plugin"] = _StubPlugins()
+    ctx["easy"].plugins = [ctx["plugin"]]
+
+
+def _route(ctx, phrase):
+    """Route one deliberate utterance, mirroring the loop's per-iteration reset
+    of keep_listening so each turn's assertion reflects only this command."""
+    ctx["easy"].keep_listening = False
+    ctx["easy"].route_command(phrase)
+
+
+@when(parsers.parse('I say "{phrase}"'))
+def say_phrase(ctx, phrase):
+    ctx["clock"][0] += MISUNDERSTAND_GRACE + 1  # a deliberate, spaced-out utterance
+    _route(ctx, phrase)
+
+
+@when(parsers.parse('the mic mishears "{phrase}" a moment later'))
+def mic_mishears(ctx, phrase):
+    ctx["clock"][0] += 1.0  # an immediate echo, inside the grace window
+    _route(ctx, phrase)
+
+
+@when("the wake word fires and EasySpeak hears one unrecognised command")
+def run_one_unrecognised_command(ctx):
+    """Drive the real run() loop through a single wake → unrecognised command.
+
+    The model/audio layer is stubbed so the loop exercises its own
+    orchestration: wake fires once, one gibberish transcript is heard, then a
+    KeyboardInterrupt ends the loop. route_command stays real, so the soft
+    apology and the post-miss drain happen exactly as in production.
+    """
+    easy = ctx["easy"]
+    easy.speech = Mock()  # count drains; speak becomes a no-op
+    easy.tray = Mock()
+    easy.tray.poll.return_value = TrayAction.CONTINUE
+
+    # Keep only the stub plugin (skip the real plugin scan) and short-circuit
+    # the audio helpers so nothing touches a real mic.
+    easy.load_plugins = Mock()
+    easy.wait_for_speech = Mock(return_value=b"heard-something")
+    easy.record_until_silence = Mock(return_value=b"")
+    easy.transcribe = Mock(return_value="flibbertigibbet")
+    easy.flush_stream = Mock()  # don't consume the scripted stream reads
+
+    stream = Mock()
+    pcm = b"\x00\x00" * 1280
+    stream.read.side_effect = [pcm, KeyboardInterrupt()]  # wake once, then stop
+
+    stack = ctx["stack"]
+    stack.enter_context(patch("easyspeak.core.main.load_whisper_model"))
+    stack.enter_context(patch("easyspeak.core.main.ensure_extension"))
+    stack.enter_context(patch("subprocess.run"))  # silence the wake beep
+    pyaudio = stack.enter_context(patch("easyspeak.core.main.pyaudio"))
+    pyaudio.PyAudio.return_value.open.return_value = stream
+    wake = stack.enter_context(patch("easyspeak.core.main.WakeWordModel"))
+    wake.return_value.predict.return_value = {"hey_jarvis": 0.9}  # above threshold
+
+    easy.run()
+
+
+def _spoken(ctx):
+    """Every phrase handed to piper this scenario, in order, decoded."""
+    return [
+        call.args[0].decode().strip()
+        for call in ctx["piper"].stdin.write.call_args_list
+    ]
+
+
+@then(parsers.parse('EasySpeak says "{reply}"'))
+def easyspeak_says(ctx, reply):
+    assert reply in _spoken(ctx)
+
+
+@then(parsers.parse('EasySpeak\'s last reply is "{reply}"'))
+def easyspeak_last_reply(ctx, reply):
+    assert _spoken(ctx)[-1] == reply
+
+
+@then(parsers.parse('EasySpeak said "{reply}" only once'))
+def easyspeak_said_only_once(ctx, reply):
+    assert _spoken(ctx).count(reply) == 1
+
+
+@then("the command list is not shown")
+def command_list_not_shown(ctx):
+    assert ctx["plugin"].help_shown_count == 0
+
+
+@then("the command list is shown")
+def command_list_shown(ctx):
+    assert ctx["plugin"].help_shown_count >= 1
+
+
+@then("the command list is shown exactly once")
+def command_list_shown_once(ctx):
+    assert ctx["plugin"].help_shown_count == 1
+
+
+@then("EasySpeak keeps listening for another command")
+def easyspeak_keeps_listening(ctx):
+    assert ctx["easy"].keep_listening is True
+
+
+@then("EasySpeak drains its speech before listening again")
+def drains_before_listening(ctx):
+    # Drained twice: once right after the misunderstanding (so its still-playing
+    # apology can't be misheard into the next escalation), once on shutdown.
+    # Without the fix only the shutdown drain happens (call_count == 1).
+    assert ctx["easy"].speech.drain.call_count == 2

--- a/tests/acceptance/test_volume_control.py
+++ b/tests/acceptance/test_volume_control.py
@@ -1,0 +1,63 @@
+"""Step definitions binding volume_control.feature to the system plugin.
+
+These drive the real EasySpeak.route_command with the system plugin loaded and
+the host boundary (tap_key / host_run) stubbed, then count how the volume was
+driven — repeated nudges fire every time, and the extremes set it directly.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from easyspeak.core.main import EasySpeak
+from easyspeak.plugins import system
+from pytest_bdd import given, parsers, scenarios, then, when
+
+scenarios("features/volume_control.feature")
+
+
+@pytest.fixture
+def ctx():
+    return {}
+
+
+@given("a fresh EasySpeak with the system plugin")
+def fresh_easyspeak(ctx):
+    easy = EasySpeak()
+    easy.tap_key = Mock(return_value=True)
+    easy.host_run = Mock(return_value=Mock(returncode=0))
+    easy.plugins = [system]
+    system.setup(easy)
+    ctx["easy"] = easy
+
+
+@when(parsers.parse('I say "{phrase}"'))
+def say_phrase(ctx, phrase):
+    ctx["easy"].route_command(phrase)
+
+
+def _key_presses(ctx, keycode):
+    return [c for c in ctx["easy"].tap_key.call_args_list if c.args[0] == keycode]
+
+
+@then(parsers.parse("the volume was raised {count:d} times"))
+def volume_raised(ctx, count):
+    assert len(_key_presses(ctx, system.KEY_VOLUME_UP)) == count
+
+
+@then(parsers.parse("the volume was lowered {count:d} times"))
+def volume_lowered(ctx, count):
+    assert len(_key_presses(ctx, system.KEY_VOLUME_DOWN)) == count
+
+
+@then("the volume is set to maximum")
+def volume_maxed(ctx):
+    ctx["easy"].host_run.assert_any_call(
+        ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "85%"]
+    )
+
+
+@then("the volume is set to minimum")
+def volume_minned(ctx):
+    ctx["easy"].host_run.assert_any_call(
+        ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "15%"]
+    )

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -913,8 +913,8 @@ class TestEasySpeakRun:
         mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
         mock_wakeword_model.return_value = mock_wakeword_instance
 
-        # Mock speech detection and transcription
-        mock_wait.return_value = b"audio_data"
+        # Speech once (handled), then silence ends the follow-up window.
+        mock_wait.side_effect = [b"audio_data", None]
         mock_record.return_value = b"more_audio"
         mock_transcribe.return_value = "test command"
         mock_route_command.return_value = True
@@ -927,7 +927,7 @@ class TestEasySpeakRun:
         assert "test command" in captured.out
 
         # Check that methods were called
-        mock_wait.assert_called_once_with(timeout=5)
+        mock_wait.assert_called_with(timeout=5)
         mock_record.assert_called_once()
         mock_transcribe.assert_called_once()
         mock_route_command.assert_called_once()
@@ -990,10 +990,13 @@ class TestEasySpeakRun:
         mock_transcribe.return_value = "gibberish"
 
         def route(_cmd):
-            """First call mimics a help-miss (re-arms the loop); the rest pass."""
+            """First call mimics a help-miss (re-arms the loop); the second
+            speaks a reply, which ends the session rather than keeping the mic."""
             if mock_route_command.call_count == 1:
                 easy.unrecognized = True
                 easy.keep_listening = True
+            else:
+                easy.speak("done")
             return True
 
         mock_route_command.side_effect = route
@@ -1066,6 +1069,63 @@ class TestEasySpeakRun:
         assert easy.keep_listening is False
         # Once after the miss, once on shutdown — though we never kept listening.
         assert easy.speech.drain.call_count == 2
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "record_until_silence")
+    @patch.object(EasySpeak, "transcribe")
+    @patch.object(EasySpeak, "route_command")
+    @patch.object(EasySpeak, "flush_stream")
+    def test_run_follow_up_pumps_silent_commands_then_idles_out(
+        self,
+        mock_flush_stream,
+        mock_route_command,
+        mock_transcribe,
+        mock_record,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_plugin,
+    ):
+        """A silent recognized command keeps the mic open; an empty follow-up
+        (e.g. the volume chime) is tolerated, and the session ends once the
+        quiet rounds reach the idle limit — no new wake word in between."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin]
+        mock_time.return_value = 100.0
+
+        mock_audio = Mock()
+        mock_stream = Mock()
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.side_effect = [pcm_data, KeyboardInterrupt()]
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        # "louder" (handled) then two empty rounds (chime / quiet) end it.
+        mock_wait.return_value = b"audio_data"
+        mock_record.return_value = b"more_audio"
+        mock_transcribe.side_effect = ["louder", "", ""]
+        mock_route_command.return_value = True  # silent: never calls speak
+
+        easy.run()
+
+        # The command fired once; the empty rounds drove the idle-out, no wake.
+        mock_route_command.assert_called_once()
+        assert mock_transcribe.call_count == 3
+        assert easy.keep_listening is False
 
     @patch("subprocess.run")
     @patch("time.time")
@@ -1190,8 +1250,8 @@ class TestEasySpeakRun:
         mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
         mock_wakeword_model.return_value = mock_wakeword_instance
 
-        # Mock speech detection and transcription
-        mock_wait.return_value = b"audio_data"
+        # Speech once (handled), then silence ends the follow-up window.
+        mock_wait.side_effect = [b"audio_data", None]
         mock_record.return_value = b"more_audio"
         mock_transcribe.return_value = "test command"
         mock_route_command.return_value = True

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -337,9 +337,8 @@ class TestEasySpeakRouteCommand:
         result = easy.route_command("unknown command")
 
         assert result is True
-        mock_speak.assert_called_once_with(
-            "I didn't understand. Say help for commands."
-        )
+        mock_speak.assert_called_once_with("Sorry, I didn't understand.")
+        assert easy.keep_listening is False
 
     @patch.object(EasySpeak, "speak")
     def test_route_command_plugin_error(
@@ -365,6 +364,109 @@ class TestEasySpeakRouteCommand:
         assert result is True
         mock_multiple_plugins[0].handle.assert_called_once()
         mock_multiple_plugins[1].handle.assert_called_once()
+
+    @patch.object(EasySpeak, "_show_help")
+    @patch.object(EasySpeak, "speak")
+    @patch("time.time")
+    def test_route_command_second_miss_shows_help_and_keeps_listening(
+        self, mock_time, mock_speak, mock_show_help, mock_plugin_no_handle
+    ):
+        """A second miss (spaced past the grace window) escalates to help and
+        re-arms listening."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin_no_handle]
+        mock_time.side_effect = [100.0, 200.0]
+
+        easy.route_command("first gibberish")
+        result = easy.route_command("second gibberish")
+
+        assert result is True
+        assert mock_speak.call_args_list == [
+            (("Sorry, I didn't understand.",),),
+            (("I didn't understand.",),),
+        ]
+        mock_show_help.assert_called_once_with()
+        assert easy.keep_listening is True
+        assert easy.help_shown is True
+
+    @patch.object(EasySpeak, "_show_help")
+    @patch.object(EasySpeak, "speak")
+    @patch("time.time")
+    def test_route_command_does_not_repeat_help_after_first_escalation(
+        self, mock_time, mock_speak, mock_show_help, mock_plugin_no_handle
+    ):
+        """Once help has been shown, further misses only apologise (no repeat)
+        but still keep the mic open for another try."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin_no_handle]
+        mock_time.side_effect = [100.0, 200.0, 300.0]
+
+        easy.route_command("miss one")
+        easy.route_command("miss two")
+        easy.keep_listening = False
+        easy.route_command("miss three")
+
+        mock_show_help.assert_called_once_with()
+        assert mock_speak.call_args_list == [
+            (("Sorry, I didn't understand.",),),
+            (("I didn't understand.",),),
+            (("I didn't understand.",),),
+        ]
+        assert easy.keep_listening is True
+
+    @patch.object(EasySpeak, "speak")
+    @patch("time.time")
+    def test_route_command_drops_misses_inside_the_grace_window(
+        self, mock_time, mock_speak, mock_plugin_no_handle
+    ):
+        """A miss arriving within the grace window of the last one (e.g. the mic
+        hearing our own apology) is silently dropped — no feedback, no escalation."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin_no_handle]
+        mock_time.side_effect = [100.0, 101.0]  # 1s apart, inside the grace window
+
+        easy.route_command("real miss")
+        easy.route_command("sorry i didn't understand")
+
+        mock_speak.assert_called_once_with("Sorry, I didn't understand.")
+        assert easy.misunderstand_count == 1
+        assert easy.help_shown is False
+        assert easy.keep_listening is False
+        assert easy.unrecognized is False
+
+    @patch.object(EasySpeak, "_show_help")
+    @patch.object(EasySpeak, "speak")
+    @patch("time.time")
+    def test_route_command_understood_resets_streak_and_help(
+        self, mock_time, mock_speak, mock_show_help, mock_plugin_no_handle, mock_plugin
+    ):
+        """An understood command clears the streak and re-arms help for next
+        time (a successful 'help' command therefore lets it show again)."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin_no_handle]
+        mock_time.side_effect = [100.0, 200.0]
+
+        easy.route_command("miss one")
+        easy.route_command("miss two")
+        assert easy.misunderstand_count == 2
+        assert easy.help_shown is True
+
+        easy.plugins = [mock_plugin]  # this one handles it
+        easy.route_command("good command")
+
+        assert easy.misunderstand_count == 0
+        assert easy.help_shown is False
+
+    def test_show_help_delegates_to_plugin_that_provides_it(self):
+        """_show_help calls show_help on the first plugin that exposes it."""
+        easy = EasySpeak()
+        without = Mock(spec=[])  # no show_help attribute
+        with_help = Mock(spec=["show_help"])
+        easy.plugins = [without, with_help]
+
+        easy._show_help()
+
+        with_help.show_help.assert_called_once_with(easy)
 
 
 class TestEasySpeakAudio:
@@ -845,6 +947,133 @@ class TestEasySpeakRun:
     @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "record_until_silence")
+    @patch.object(EasySpeak, "transcribe")
+    @patch.object(EasySpeak, "route_command")
+    @patch.object(EasySpeak, "flush_stream")
+    def test_run_keeps_listening_after_help(
+        self,
+        mock_flush_stream,
+        mock_route_command,
+        mock_transcribe,
+        mock_record,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_plugin,
+    ):
+        """When route_command re-arms keep_listening (help shown), the loop
+        drains speech and listens for a follow-up command without a new wake
+        word."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin]
+        easy.speech = Mock()
+        mock_time.return_value = 100.0
+
+        mock_audio = Mock()
+        mock_stream = Mock()
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.side_effect = [pcm_data, KeyboardInterrupt()]
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        mock_wait.return_value = b"audio_data"
+        mock_record.return_value = b"more_audio"
+        mock_transcribe.return_value = "gibberish"
+
+        def route(_cmd):
+            """First call mimics a help-miss (re-arms the loop); the rest pass."""
+            if mock_route_command.call_count == 1:
+                easy.unrecognized = True
+                easy.keep_listening = True
+            return True
+
+        mock_route_command.side_effect = route
+
+        easy.run()
+
+        assert mock_route_command.call_count == 2
+        assert mock_wait.call_count == 2
+        # Once between the two captures, once on shutdown.
+        assert easy.speech.drain.call_count == 2
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
+    @patch.object(EasySpeak, "record_until_silence")
+    @patch.object(EasySpeak, "transcribe")
+    @patch.object(EasySpeak, "route_command")
+    @patch.object(EasySpeak, "flush_stream")
+    def test_run_drains_after_an_unrecognised_command(
+        self,
+        mock_flush_stream,
+        mock_route_command,
+        mock_transcribe,
+        mock_record,
+        mock_wait,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_time,
+        mock_subprocess_run,
+        mock_plugin,
+    ):
+        """A single unrecognised command drains speech before resuming the wake
+        word, so the still-playing apology can't be misheard into an escalation.
+        """
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin]
+        easy.speech = Mock()
+        mock_time.return_value = 100.0
+
+        mock_audio = Mock()
+        mock_stream = Mock()
+        pcm_data = b"\x00\x00" * 1280
+        mock_stream.read.side_effect = [pcm_data, KeyboardInterrupt()]
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        mock_wakeword_instance = Mock()
+        mock_wakeword_instance.predict.return_value = {"hey_jarvis": 0.8}
+        mock_wakeword_model.return_value = mock_wakeword_instance
+
+        mock_wait.return_value = b"audio_data"
+        mock_record.return_value = b"more_audio"
+        mock_transcribe.return_value = "gibberish"
+
+        def route(_cmd):
+            """A soft-apology miss: sets unrecognized but never keep_listening."""
+            easy.unrecognized = True
+            return True
+
+        mock_route_command.side_effect = route
+
+        easy.run()
+
+        assert easy.keep_listening is False
+        # Once after the miss, once on shutdown — though we never kept listening.
+        assert easy.speech.drain.call_count == 2
+
+    @patch("subprocess.run")
+    @patch("time.time")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "wait_for_speech")
     @patch.object(EasySpeak, "speak")
     @patch.object(EasySpeak, "flush_stream")
     def test_run_wake_word_detected_no_speech(
@@ -1126,6 +1355,7 @@ class TestEasySpeakRun:
         mock_stream.close.assert_called_once()
         mock_audio.terminate.assert_called_once()
 
+    @patch.object(EasySpeak, "flush_stream")
     @patch("easyspeak.core.main.pyaudio")
     @patch("easyspeak.core.main.WakeWordModel")
     @patch("easyspeak.core.main.load_whisper_model")
@@ -1136,10 +1366,12 @@ class TestEasySpeakRun:
         mock_whisper_model,
         mock_wakeword_model,
         mock_pyaudio,
+        mock_flush_stream,
         mock_plugin,
     ):
-        """A RESUME (woke from sleep) skips the audio read and loops again; the
-        next CONTINUE proceeds to read."""
+        """A RESUME (woke from sleep) resets the detector and flushes the mic so
+        it starts fresh, skips the audio read, and loops again; the next
+        CONTINUE proceeds to read."""
         easy = EasySpeak()
         easy.plugins = [mock_plugin]
         easy.tray = Mock()
@@ -1150,11 +1382,15 @@ class TestEasySpeakRun:
         mock_audio = Mock()
         mock_audio.open.return_value = mock_stream
         mock_pyaudio.PyAudio.return_value = mock_audio
-        mock_wakeword_model.return_value = Mock()
+        mock_wakeword_instance = Mock()
+        mock_wakeword_model.return_value = mock_wakeword_instance
 
         easy.run()
 
-        # RESUME read nothing; only the CONTINUE iteration reached the mic.
+        # Resume behaves like a fresh start: detector reset and mic flushed,
+        # without consuming the main-loop read (only CONTINUE reaches the mic).
+        mock_wakeword_instance.reset.assert_called_once()
+        mock_flush_stream.assert_called_once()
         mock_stream.read.assert_called_once()
 
     @patch("easyspeak.core.main.pyaudio")

--- a/tests/unit/plugins/test_apps.py
+++ b/tests/unit/plugins/test_apps.py
@@ -439,6 +439,8 @@ def test_close_registered_terminal(mock_core):
         ["open spotify", "spotify"],
         ["launch files", "files"],
         ["open calculator", "calculator"],
+        ["open music player", "music player"],
+        ["open music app", "music app"],
     ],
 )
 def test_handle_open_installed_app(mock_launch_app, mock_core, command, app_name):

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -613,7 +613,7 @@ def test_handle_browser_command_enters_mode(
 @pytest.mark.parametrize(
     "command",
     [
-        "stop",  # quit word — owned by the base plugin
+        "stop",  # declined defensively so qb can't open on a bare "stop"
         "quit",
         "go to sleep",  # sleep phrases — owned by the sleep plugin
         "goto sleep",

--- a/tests/unit/plugins/test_files.py
+++ b/tests/unit/plugins/test_files.py
@@ -77,6 +77,7 @@ def test_open_folder_returns_false_when_no_file_manager_found(
         ("open pictures", "pictures", "Opening pictures."),
         ("open music", "music", "Opening music."),
         ("open videos", "videos", "Opening videos."),
+        ("open projects", "projects", "Opening projects."),
         ("open home", "home", "Opening home."),
         ("open desktop", "desktop", "Opening desktop."),
     ],

--- a/tests/unit/plugins/test_media.py
+++ b/tests/unit/plugins/test_media.py
@@ -129,19 +129,31 @@ def test_handle_play_commands(
     [
         ("pause", "pause", "Paused."),
         ("pause music", "pause", "Paused."),
+        ("pause the music", "pause", "Paused."),
         ("pause the song", "pause", "Paused."),
+        ("stop the music", "pause", "Paused."),
+        ("stop music", "pause", "Paused."),
+        ("stop the song", "pause", "Paused."),
     ],
 )
 @patch.object(media, "media_control", return_value=True)
 def test_handle_pause_commands(
     mock_media_control, command, expected_action, expected_speech, mock_core
 ):
-    """When handle receives a pause command then it calls media_control and speaks."""
+    """Pause and "stop the music" both pause playback and speak."""
     result = media.handle(command, mock_core)
 
     assert result is True
     assert mock_media_control.call_args.args == (expected_action, mock_core)
     assert mock_core.speak.call_args.args[0] == expected_speech
+
+
+@pytest.mark.parametrize("command", ["stop", "stop tracking", "stop it"])
+@patch.object(media, "media_control", return_value=True)
+def test_handle_ignores_bare_stop(mock_media_control, command, mock_core):
+    """A bare "stop" is not a media command — it's left for the exit command."""
+    assert media.handle(command, mock_core) is None
+    assert not mock_media_control.called
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/plugins/test_media.py
+++ b/tests/unit/plugins/test_media.py
@@ -134,6 +134,8 @@ def test_handle_play_commands(
         ("stop the music", "pause", "Paused."),
         ("stop music", "pause", "Paused."),
         ("stop the song", "pause", "Paused."),
+        ("stop playing music", "pause", "Paused."),
+        ("stop playing", "pause", "Paused."),
     ],
 )
 @patch.object(media, "media_control", return_value=True)

--- a/tests/unit/plugins/test_media.py
+++ b/tests/unit/plugins/test_media.py
@@ -153,7 +153,7 @@ def test_handle_pause_commands(
 @pytest.mark.parametrize("command", ["stop", "stop tracking", "stop it"])
 @patch.object(media, "media_control", return_value=True)
 def test_handle_ignores_bare_stop(mock_media_control, command, mock_core):
-    """A bare "stop" is not a media command — it's left for the exit command."""
+    """A bare "stop" is not a media command."""
     assert media.handle(command, mock_core) is None
     assert not mock_media_control.called
 

--- a/tests/unit/plugins/test_system.py
+++ b/tests/unit/plugins/test_system.py
@@ -150,6 +150,50 @@ def test_handle_volume_commands(
 
 
 @pytest.mark.parametrize(
+    ["command", "expected_func"],
+    [
+        ("very loud", "volume_max"),
+        ("make it very loud", "volume_max"),
+        ("very louder", "volume_max"),
+        ("very silent", "volume_min"),
+        ("very quiet", "volume_min"),
+        ("very soft", "volume_min"),
+    ],
+)
+@patch.object(system, "volume_max")
+@patch.object(system, "volume_min")
+def test_handle_extreme_volume_commands(
+    mock_volume_min, mock_volume_max, command, expected_func, mock_core
+):
+    """ "very loud"/"very silent" jump straight to max/min volume, silently."""
+    func_map = {"volume_max": mock_volume_max, "volume_min": mock_volume_min}
+
+    result = system.handle(command, mock_core)
+
+    assert result is True
+    assert not mock_core.speak.called
+    assert func_map[expected_func].call_args.args[0] == mock_core
+
+
+def test_volume_max_sets_near_full_volume(mock_core):
+    """volume_max sets the default sink to 85% directly (no media key for it)."""
+    system.volume_max(mock_core)
+
+    mock_core.host_run.assert_called_once_with(
+        ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "85%"]
+    )
+
+
+def test_volume_min_sets_very_low_volume(mock_core):
+    """volume_min drops the default sink to 15% — quiet but not muted."""
+    system.volume_min(mock_core)
+
+    mock_core.host_run.assert_called_once_with(
+        ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "15%"]
+    )
+
+
+@pytest.mark.parametrize(
     ["command", "expected_speech", "expected_func"],
     [
         ("brightness up", "Brighter.", "brightness_up"),

--- a/tests/unit/plugins/test_system.py
+++ b/tests/unit/plugins/test_system.py
@@ -105,22 +105,22 @@ def test_dnd_functions(func, expected_command, mock_core):
 
 
 @pytest.mark.parametrize(
-    ["command", "expected_speech", "expected_func"],
+    ["command", "expected_func"],
     [
-        ("volume up", "Volume up.", "volume_up"),
-        ("volume louder", "Volume up.", "volume_up"),
-        ("louder", "Volume up.", "volume_up"),
-        ("make it louder", "Volume up.", "volume_up"),
-        ("sound up", "Volume up.", "volume_up"),
-        ("volume down", "Volume down.", "volume_down"),
-        ("volume quieter", "Volume down.", "volume_down"),
-        ("volume softer", "Volume down.", "volume_down"),
-        ("more silent", "Volume down.", "volume_down"),
-        ("make it quieter", "Volume down.", "volume_down"),
-        ("sound down", "Volume down.", "volume_down"),
-        ("volume mute", "Toggled mute.", "volume_mute"),
-        ("volume unmute", "Toggled mute.", "volume_mute"),
-        ("mute", "Toggled mute.", "volume_mute"),
+        ("volume up", "volume_up"),
+        ("volume louder", "volume_up"),
+        ("louder", "volume_up"),
+        ("make it louder", "volume_up"),
+        ("sound up", "volume_up"),
+        ("volume down", "volume_down"),
+        ("volume quieter", "volume_down"),
+        ("volume softer", "volume_down"),
+        ("more silent", "volume_down"),
+        ("make it quieter", "volume_down"),
+        ("sound down", "volume_down"),
+        ("volume mute", "volume_mute"),
+        ("volume unmute", "volume_mute"),
+        ("mute", "volume_mute"),
     ],
 )
 @patch.object(system, "volume_up")
@@ -131,11 +131,11 @@ def test_handle_volume_commands(
     mock_volume_down,
     mock_volume_up,
     command,
-    expected_speech,
     expected_func,
     mock_core,
 ):
-    """When volume commands are handled, the correct function is called and speech is produced."""
+    """Volume commands call the right function and stay silent — GNOME's native
+    OSD and chime acknowledge the change."""
     func_map = {
         "volume_up": mock_volume_up,
         "volume_down": mock_volume_down,
@@ -145,7 +145,7 @@ def test_handle_volume_commands(
     result = system.handle(command, mock_core)
 
     assert result is True
-    assert mock_core.speak.call_args.args[0] == expected_speech
+    assert not mock_core.speak.called
     assert func_map[expected_func].call_args.args[0] == mock_core
 
 

--- a/tests/unit/plugins/test_zz_base.py
+++ b/tests/unit/plugins/test_zz_base.py
@@ -16,12 +16,10 @@ def test_setup(mock_core):
 @pytest.mark.parametrize(
     ["command", "expected_return"],
     [
-        ["stop", False],
         ["exit", False],
         ["quit", False],
         ["goodbye", False],
         ["bye", False],
-        ["STOP", False],
         ["EXIT", False],
         ["QUIT", False],
     ],
@@ -37,12 +35,10 @@ def test_handle_exit_commands(mock_core, command, expected_return):
 @pytest.mark.parametrize(
     ["command", "expected_return"],
     [
-        ["jarvis stop", False],
         ["jarvis exit", False],
         ["jarvis quit", False],
-        ["computer stop", False],
         ["computer exit", False],
-        ["hey stop", False],
+        ["computer quit", False],
     ],
 )
 def test_handle_exit_commands_with_prefix(mock_core, command, expected_return):
@@ -97,6 +93,8 @@ def test_handle_help_commands(mock_show_help, mock_core, command, expected_retur
         ["volume up"],
         ["grid"],
         ["some random command"],
+        ["stop"],
+        ["jarvis stop"],
     ],
 )
 def test_handle_unrecognized_commands(mock_core, command):


### PR DESCRIPTION
Polishes EasySpeak's voice interaction end to end — how it listens, when it speaks, and what it understands — across six focused commits.

- **Make misunderstanding feedback friendlier and reactivation quiet** — soft apology on the first miss, help on the second (shown once), a grace window so the open mic can't mishear its own feedback into the help screen, and tray reactivation that waits for the wake word instead of listening immediately.
- **Speak command feedback in parallel with execution** — the confirmation is spoken before the action runs, so the reply plays while it executes; volume/mute go silent since GNOME's OSD and chime already acknowledge them.
- **Add volume extremes, media/app synonyms, and Projects folder** — "very loud"/"very silent" jump to 85%/15%, "stop the music" pauses, "open music app" aliases "open music player", and "open projects" opens the `~/Projects` folder.
- **Keep listening after a silent command** — after a silent command (e.g. volume) the mic stays open so you can chain "louder, louder" without repeating the wake word.
- **Pause on "stop playing"** — "stop playing" and "stop playing music" now pause instead of matching the loose "play" rule and resuming; a small refactor reuses the wake-detector reset.
- **Stop quitting EasySpeak on a bare "stop"** — "stop" no longer exits the app. It was overloaded across pausing media, sleeping, and eye-tracking, so a misheard "stop" could kill the daemon; quitting now requires "quit"/"exit"/"goodbye"/"bye", and a bare "stop" is simply unrecognised.
