### PR TITLE
Switch terminal output from print() to logging (#64)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,6 @@ ignore = [
 
   # --- Intentional project policy ---
   "ANN",     # type annotations not enforced project-wide; mypy covers used types
-  "T201",    # print() is legitimate terminal output for this CLI app
   "S603",    # subprocess use is how a desktop voice controller works, by design
   "S607",    # binaries (piper, wl-copy, ...) resolved via PATH for portability
   "PLC0415", # imports inside functions lazily load optional deps (cv2, ...)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ unittest = [
 ]
 
 [project.scripts]
-easyspeak = "easyspeak.core.main:run"
+easyspeak = "easyspeak.core.cli:run"
 
 [project.urls]
 "Source Code" = "https://github.com/ctsdownloads/easyspeak"

--- a/src/core/__main__.py
+++ b/src/core/__main__.py
@@ -6,7 +6,7 @@ Application entry point when executed as a module, e.g.
     python -m easyspeak.core
 """
 
-from .main import run
+from .cli import run
 
 if __name__ == "__main__":
     run()

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -1,0 +1,28 @@
+"""Command-line entry point: parse arguments, set up logging, run the app."""
+
+import argparse
+
+from . import log
+from .main import EasySpeak
+
+
+def parse_args(argv=None):
+    """Parse EasySpeak's command-line arguments."""
+    parser = argparse.ArgumentParser(
+        prog="easyspeak", description="Voice control for Linux desktops."
+    )
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "-v", "--verbose", action="store_true", help="show debug output"
+    )
+    verbosity.add_argument(
+        "-q", "--quiet", action="store_true", help="show only warnings and errors"
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv=None):
+    """Start the application."""
+    args = parse_args(argv)
+    log.configure(log.resolve_level(verbose=args.verbose, quiet=args.quiet))
+    EasySpeak().run()

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -14,10 +14,13 @@ no privileges.
 import contextlib
 import enum
 import filecmp
+import logging
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 GRID_EXTENSION_UUID = "easyspeak-grid@local"
 REFRESH_UNIT_NAME = "easyspeak-extension-refresh.service"
@@ -75,10 +78,7 @@ def refresh_extension_files(src_dir, dest_dir):
     extension.js without the helper it imports."""
     srcs = {name: src_dir / name for name in EXTENSION_ASSETS}
     if not all(s.is_file() for s in srcs.values()):
-        print(
-            f"easyspeak: note: bundled GNOME extension sources missing at {src_dir}",
-            file=sys.stderr,
-        )
+        logger.warning("bundled GNOME extension sources missing at %s", src_dir)
         return RefreshResult.ERROR
     # Clear temps an interrupted run may have left, so the dir self-heals even on
     # the UNCHANGED path below.
@@ -102,10 +102,7 @@ def refresh_extension_files(src_dir, dest_dir):
         return RefreshResult.REFRESHED
     except OSError as e:
         _discard_staged(dest_dir)
-        print(
-            f"easyspeak: note: could not write GNOME extension to {dest_dir} ({e})",
-            file=sys.stderr,
-        )
+        logger.warning("could not write GNOME extension to %s (%s)", dest_dir, e)
         return RefreshResult.ERROR
 
 
@@ -211,7 +208,7 @@ def ensure_extension():
 
     unit_status = install_refresh_unit()
     if unit_status:
-        print(f"easyspeak: {unit_status}", file=sys.stderr)
+        logger.info("%s", unit_status)
 
     try:
         listed = subprocess.run(
@@ -246,16 +243,15 @@ def ensure_extension():
     if installed and already_enabled:
         result = refresh_extension_files(root, dest_dir)
         if result is RefreshResult.REFRESHED:
-            print(
-                f"easyspeak: updated GNOME extension {GRID_EXTENSION_UUID} to "
-                f"the bundled version — log out and back in to load it",
-                file=sys.stderr,
+            logger.info(
+                "updated GNOME extension %s to the bundled version — "
+                "log out and back in to load it",
+                GRID_EXTENSION_UUID,
             )
         elif result is RefreshResult.UNCHANGED:
-            print(
-                f"easyspeak: GNOME extension {GRID_EXTENSION_UUID} "
-                f"already installed and enabled",
-                file=sys.stderr,
+            logger.info(
+                "GNOME extension %s already installed and enabled",
+                GRID_EXTENSION_UUID,
             )
         # ERROR was already noted by refresh_extension_files; stay quiet rather
         # than claim a healthy install.
@@ -263,12 +259,11 @@ def ensure_extension():
 
     if not installed:
         if not all((root / name).is_file() for name in EXTENSION_ASSETS):
-            print(
-                f"easyspeak: note: could not auto-install GNOME extension — "
-                f"source files not found at {root}. The panel indicator and "
-                f"grid commands will not work until the extension is installed "
-                f"manually.",
-                file=sys.stderr,
+            logger.warning(
+                "could not auto-install GNOME extension — source files not "
+                "found at %s. The panel indicator and grid commands will not "
+                "work until the extension is installed manually.",
+                root,
             )
             return
 
@@ -276,10 +271,9 @@ def ensure_extension():
             # refresh_extension_files already reported the write error (with the
             # OSError detail) on stderr; add only the consequence, not a second
             # description of the same failure.
-            print(
-                "easyspeak: note: the panel indicator and grid commands will "
-                "not work until the GNOME extension is installed manually.",
-                file=sys.stderr,
+            logger.warning(
+                "the panel indicator and grid commands will not work until "
+                "the GNOME extension is installed manually."
             )
             return
 
@@ -299,31 +293,30 @@ def ensure_extension():
 
     if installed:
         if ok:
-            print(
-                f"easyspeak: enabled GNOME extension {GRID_EXTENSION_UUID} "
-                f"(was installed but disabled)",
-                file=sys.stderr,
+            logger.info(
+                "enabled GNOME extension %s (was installed but disabled)",
+                GRID_EXTENSION_UUID,
             )
         else:
-            print(
-                f"easyspeak: note: GNOME extension {GRID_EXTENSION_UUID} is "
-                f"installed but disabled, and could not be enabled. Try: "
-                f"gnome-extensions enable {GRID_EXTENSION_UUID}",
-                file=sys.stderr,
+            logger.warning(
+                "GNOME extension %s is installed but disabled, and could not "
+                "be enabled. Try: gnome-extensions enable %s",
+                GRID_EXTENSION_UUID,
+                GRID_EXTENSION_UUID,
             )
         return
 
     if ok:
-        print(
-            f"easyspeak: installed and enabled GNOME extension "
-            f"{GRID_EXTENSION_UUID} at {dest_dir}",
-            file=sys.stderr,
+        logger.info(
+            "installed and enabled GNOME extension %s at %s",
+            GRID_EXTENSION_UUID,
+            dest_dir,
         )
     else:
-        print(
-            f"easyspeak: installed GNOME extension to {dest_dir} — "
-            f"log out and back in to finish enabling it.",
-            file=sys.stderr,
+        logger.info(
+            "installed GNOME extension to %s — "
+            "log out and back in to finish enabling it.",
+            dest_dir,
         )
 
 

--- a/src/core/log.py
+++ b/src/core/log.py
@@ -9,6 +9,10 @@ importing the package as a library leaves the root logger untouched.
 import logging
 import os
 
+logger = logging.getLogger(__name__)
+
+_PACKAGE_LOGGERS = ("easyspeak", "plugins")
+
 
 def resolve_level(*, verbose=False, quiet=False):
     """Pick the log level: CLI flags win, then EASYSPEAK_LOG_LEVEL, else INFO."""
@@ -23,11 +27,19 @@ def resolve_level(*, verbose=False, quiet=False):
 
 def configure(level):
     """Attach a message-only stderr handler to the package loggers."""
+    # Plain message-only output keeps the normal CLI clean; at DEBUG, prefix
+    # each line with its level since that mode is for diagnosing.
+    fmt = "%(levelname)s %(message)s" if level <= logging.DEBUG else "%(message)s"
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    for name in ("easyspeak", "plugins"):
+    handler.setFormatter(logging.Formatter(fmt))
+    for name in _PACKAGE_LOGGERS:
         log = logging.getLogger(name)
         log.handlers.clear()
         log.addHandler(handler)
         log.setLevel(level)
         log.propagate = False
+    logger.debug(
+        "logging configured: level=%s, stderr, message-only, loggers=%s",
+        logging.getLevelName(level),
+        ", ".join(_PACKAGE_LOGGERS),
+    )

--- a/src/core/log.py
+++ b/src/core/log.py
@@ -39,7 +39,8 @@ def configure(level):
         log.setLevel(level)
         log.propagate = False
     logger.debug(
-        "logging configured: level=%s, stderr, message-only, loggers=%s",
+        "logging configured: level=%s, stderr, format=%r, loggers=%s",
         logging.getLevelName(level),
+        fmt,
         ", ".join(_PACKAGE_LOGGERS),
     )

--- a/src/core/log.py
+++ b/src/core/log.py
@@ -1,0 +1,33 @@
+"""Logging setup for EasySpeak's terminal output.
+
+Output is message-only (no level or timestamp prefixes) so the CLI reads
+nicely for humans; the level only gates which lines appear. Only the
+``easyspeak`` and ``plugins`` logger hierarchies are configured, so
+importing the package as a library leaves the root logger untouched.
+"""
+
+import logging
+import os
+
+
+def resolve_level(*, verbose=False, quiet=False):
+    """Pick the log level: CLI flags win, then EASYSPEAK_LOG_LEVEL, else INFO."""
+    if verbose:
+        return logging.DEBUG
+    if quiet:
+        return logging.WARNING
+    name = os.environ.get("EASYSPEAK_LOG_LEVEL", "INFO").upper()
+    level = logging.getLevelName(name)
+    return level if isinstance(level, int) else logging.INFO
+
+
+def configure(level):
+    """Attach a message-only stderr handler to the package loggers."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    for name in ("easyspeak", "plugins"):
+        log = logging.getLogger(name)
+        log.handlers.clear()
+        log.addHandler(handler)
+        log.setLevel(level)
+        log.propagate = False

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -5,8 +5,10 @@ Loads plugins from plugins/ folder automatically.
 Uses OpenWakeWord for fast wake detection.
 """
 
+import argparse
 import contextlib
 import importlib
+import logging
 import os
 import subprocess
 import sys
@@ -36,6 +38,8 @@ from .config import (
 from .gnome_extension import ensure_extension
 from .speech import SpeechPipeline, suppressed_c_stderr
 from .tray import Tray, TrayAction
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # CORE CLASS
@@ -104,7 +108,7 @@ class EasySpeak:
     def load_plugins(self):
         plugins_dir = Path(__file__).parent.parent / "plugins"
         if not plugins_dir.exists():
-            print("No plugins directory found")
+            logger.warning("No plugins directory found")
             return
 
         sys.path.insert(0, str(plugins_dir.parent))
@@ -122,11 +126,13 @@ class EasySpeak:
                         module.setup(self)
 
                     self.plugins.append(module)
-                    print(f"  ✓ Loaded: {module.NAME}")
+                    logger.info("  ✓ Loaded: %s", module.NAME)
                 else:
-                    print(f"  ✗ Invalid plugin: {file.name} (missing NAME or handle)")
+                    logger.warning(
+                        "  ✗ Invalid plugin: %s (missing NAME or handle)", file.name
+                    )
             except Exception as e:
-                print(f"  ✗ Failed to load {file.name}: {e}")
+                logger.warning("  ✗ Failed to load %s: %s", file.name, e)
 
     def get_all_commands(self):
         """Get all commands from all plugins for help text"""
@@ -164,8 +170,8 @@ class EasySpeak:
                     return True
                 if result is False:
                     return False
-            except Exception as e:
-                print(f"Plugin error ({plugin.NAME}): {e}")
+            except Exception:
+                logger.exception("Plugin error (%s)", plugin.NAME)
 
         self._report_not_understood()
         return True
@@ -341,7 +347,7 @@ class EasySpeak:
             else:
                 cmd = self.transcribe(heard + self.record_until_silence())
                 if cmd:
-                    print(f"👂 {cmd}")
+                    logger.info("👂 %s", cmd)
                     if not self.route_command(cmd.lower().strip(".,!? ")):
                         return True
                     self._reset_detector()
@@ -358,12 +364,14 @@ class EasySpeak:
         return False
 
     def run(self):
-        print("Loading OpenWakeWord...")
+        logger.info("Loading OpenWakeWord...")
         self.wakeword = WakeWordModel()
 
-        print(
-            f"Loading Whisper ({WHISPER_MODEL}, {WHISPER_COMPUTE_TYPE}, "
-            f"cpu_threads={WHISPER_CPU_THREADS or 'auto'})..."
+        logger.info(
+            "Loading Whisper (%s, %s, cpu_threads=%s)...",
+            WHISPER_MODEL,
+            WHISPER_COMPUTE_TYPE,
+            WHISPER_CPU_THREADS or "auto",
         )
         self.whisper = load_whisper_model()
 
@@ -372,22 +380,22 @@ class EasySpeak:
         # it before anything starts driving it over D-Bus.
         ensure_extension()
 
-        print("\nLoading plugins...")
+        logger.info("\nLoading plugins...")
         self.load_plugins()
 
         if not self.plugins:
-            print("No plugins loaded. Exiting.")
+            logger.error("No plugins loaded. Exiting.")
             return
 
         # Warm up the text-to-speech pipeline now so the piper model is loaded
         # during startup, not on the first spoken response.
-        print("Warming up speech...")
+        logger.info("Warming up speech...")
         try:
             self.speech.ensure()
         except OSError:
-            print("Speech unavailable; continuing without it.")
+            logger.warning("Speech unavailable; continuing without it.")
 
-        print("""
+        logger.info("""
 ╔══════════════════════════════════════════╗
 ║            EasySpeak                     ║
 ╠══════════════════════════════════════════╣
@@ -406,7 +414,7 @@ class EasySpeak:
             self._open_stream()
 
             self.tray.started()
-            print("Listening for wake word...")
+            logger.info("Listening for wake word...")
             audio_buffer = []
 
             while True:
@@ -418,7 +426,7 @@ class EasySpeak:
                 if action is TrayAction.RESUME:
                     self._reset_detector()
                     audio_buffer = []
-                    print("Listening for wake word...")
+                    logger.info("Listening for wake word...")
                     continue
 
                 pcm = self.stream.read(1280, exception_on_overflow=False)
@@ -437,7 +445,7 @@ class EasySpeak:
                         continue
                     self.last_wake_time = now
 
-                    print(f"🎤 Wake! (confidence: {score:.2f})")
+                    logger.info("🎤 Wake! (confidence: %.2f)", score)
 
                     self._reset_detector()
                     audio_buffer = []
@@ -447,10 +455,10 @@ class EasySpeak:
                         break
 
                     audio_buffer = []
-                    print("Listening for wake word...")
+                    logger.info("Listening for wake word...")
 
         except KeyboardInterrupt:
-            print("\nBye!")
+            logger.info("\nBye!")
         finally:
             # Hide the indicator so the daemon's exit doesn't leave a stale icon.
             self.tray.stopped()
@@ -462,7 +470,49 @@ class EasySpeak:
                 self.audio.terminate()
 
 
-def run():
+def _resolve_log_level(args):
+    """Pick the log level: CLI flags win, then EASYSPEAK_LOG_LEVEL, else INFO."""
+    if args.verbose:
+        return logging.DEBUG
+    if args.quiet:
+        return logging.WARNING
+    name = os.environ.get("EASYSPEAK_LOG_LEVEL", "INFO").upper()
+    level = logging.getLevelName(name)
+    return level if isinstance(level, int) else logging.INFO
+
+
+def configure_logging(level):
+    """Route EasySpeak's own loggers to stderr, message-only.
+
+    Output stays as terse as the previous print()-based UI (no level or
+    timestamp prefixes); the level only gates which messages appear. Only the
+    "easyspeak" and "plugins" hierarchies are configured, so importing the
+    package as a library leaves the root logger untouched.
+    """
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    for name in ("easyspeak", "plugins"):
+        log = logging.getLogger(name)
+        log.handlers.clear()
+        log.addHandler(handler)
+        log.setLevel(level)
+        log.propagate = False
+
+
+def run(argv=None):
     """Start the application."""
+    parser = argparse.ArgumentParser(
+        prog="easyspeak", description="Voice control for Linux desktops."
+    )
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument(
+        "-v", "--verbose", action="store_true", help="show debug output"
+    )
+    verbosity.add_argument(
+        "-q", "--quiet", action="store_true", help="show only warnings and errors"
+    )
+    args = parser.parse_args(argv)
+
+    configure_logging(_resolve_log_level(args))
     app = EasySpeak()
     app.run()

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -5,7 +5,6 @@ Loads plugins from plugins/ folder automatically.
 Uses OpenWakeWord for fast wake detection.
 """
 
-import argparse
 import contextlib
 import importlib
 import logging
@@ -468,51 +467,3 @@ class EasySpeak:
                 self.stream.close()
             if self.audio is not None:
                 self.audio.terminate()
-
-
-def _resolve_log_level(args):
-    """Pick the log level: CLI flags win, then EASYSPEAK_LOG_LEVEL, else INFO."""
-    if args.verbose:
-        return logging.DEBUG
-    if args.quiet:
-        return logging.WARNING
-    name = os.environ.get("EASYSPEAK_LOG_LEVEL", "INFO").upper()
-    level = logging.getLevelName(name)
-    return level if isinstance(level, int) else logging.INFO
-
-
-def configure_logging(level):
-    """Route EasySpeak's own loggers to stderr, message-only.
-
-    Output stays as terse as the previous print()-based UI (no level or
-    timestamp prefixes); the level only gates which messages appear. Only the
-    "easyspeak" and "plugins" hierarchies are configured, so importing the
-    package as a library leaves the root logger untouched.
-    """
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("%(message)s"))
-    for name in ("easyspeak", "plugins"):
-        log = logging.getLogger(name)
-        log.handlers.clear()
-        log.addHandler(handler)
-        log.setLevel(level)
-        log.propagate = False
-
-
-def run(argv=None):
-    """Start the application."""
-    parser = argparse.ArgumentParser(
-        prog="easyspeak", description="Voice control for Linux desktops."
-    )
-    verbosity = parser.add_mutually_exclusive_group()
-    verbosity.add_argument(
-        "-v", "--verbose", action="store_true", help="show debug output"
-    )
-    verbosity.add_argument(
-        "-q", "--quiet", action="store_true", help="show only warnings and errors"
-    )
-    args = parser.parse_args(argv)
-
-    configure_logging(_resolve_log_level(args))
-    app = EasySpeak()
-    app.run()

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -8,6 +8,7 @@ ALSA/JACK probe spew PortAudio emits when the input side (PyAudio) starts up.
 
 import contextlib
 import json
+import logging
 import os
 import shutil
 import subprocess
@@ -16,6 +17,8 @@ import time
 from subprocess import TimeoutExpired
 
 from .config import PIPER_MODEL
+
+logger = logging.getLogger(__name__)
 
 # Seconds to wait after spawning the piper -> player pipeline before trusting
 # it: long enough for an immediate failure (bad model, bad flag) to surface,
@@ -178,7 +181,7 @@ class SpeechPipeline:
         text = text.strip()
         if not text:
             return
-        print(f"💬 {text}")
+        logger.info("💬 %s", text)
         for _ in range(2):
             try:
                 self.ensure()

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -19,9 +19,12 @@ signals the open mic.
 
 import contextlib
 import enum
+import logging
 import subprocess
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Display states pushed to the indicator. The extension owns the icon/label
 # mapping; it shows the indicator only for "muted" and hides it otherwise.
@@ -125,7 +128,7 @@ class Tray:
         OS-level 'not listening' cue alongside our own muted glyph.
         """
         if not self.set_state(STATE_MUTED):
-            print(
+            logger.warning(
                 "Tray indicator unavailable; staying awake so you keep a way to "
                 "reactivate."
             )
@@ -134,7 +137,7 @@ class Tray:
             )
             return TrayAction.CONTINUE
         release_mic()
-        print("Muted; microphone released. Waiting for reactivation...")
+        logger.info("Muted; microphone released. Waiting for reactivation...")
         self._speak("Reactivate me from the tray when you need me.")
         next_repush = time.monotonic() + MUTED_REPUSH_INTERVAL
         while True:

--- a/src/plugins/00_eyetrack.py
+++ b/src/plugins/00_eyetrack.py
@@ -4,10 +4,13 @@ Uses 6D rotation representation for smooth head pose estimation
 """
 
 import contextlib
+import logging
 import math
 import subprocess
 import threading
 import time
+
+logger = logging.getLogger(__name__)
 
 NAME = "headtrack"
 DESCRIPTION = "Head tracking for cursor control"
@@ -137,11 +140,11 @@ def run_tracking():
     import cv2
     from sixdrepnet import SixDRepNet
 
-    print("Loading SixDRepNet model...")
+    logger.info("Loading SixDRepNet model...")
     model = SixDRepNet(gpu_id=-1)  # CPU mode
 
     SCREEN_W, SCREEN_H = get_screen_size()
-    print(f"Screen: {SCREEN_W}x{SCREEN_H}")
+    logger.debug("Screen: %sx%s", SCREEN_W, SCREEN_H)
 
     cap = cv2.VideoCapture(1)  # Integrated webcam
     cap.set(cv2.CAP_PROP_FRAME_WIDTH, 640)
@@ -149,7 +152,7 @@ def run_tracking():
     cap.set(cv2.CAP_PROP_FPS, 30)
 
     if not cap.isOpened():
-        print("Cannot open webcam!")
+        logger.error("Cannot open webcam!")
         tracking_active = False
         return
 
@@ -182,8 +185,8 @@ def run_tracking():
     cursor_x = SCREEN_W // 2
     cursor_y = SCREEN_H // 2
 
-    print("Head tracking started. Look at center of screen...")
-    print("Say 'recalibrate' to reset center, 'stop tracking' to end")
+    logger.info("Head tracking started. Look at center of screen...")
+    logger.info("Say 'recalibrate' to reset center, 'stop tracking' to end")
 
     calibration_frames = 0
     calibration_yaw = 0.0
@@ -213,7 +216,7 @@ def run_tracking():
             if calibration_frames >= 10:
                 center_yaw = calibration_yaw / 10
                 center_pitch = calibration_pitch / 10
-                print(f"Calibrated: center=({center_yaw:.1f}, {center_pitch:.1f})")
+                logger.info("Calibrated: center=(%.1f, %.1f)", center_yaw, center_pitch)
             continue
 
         # Apply one-euro filter to raw values
@@ -335,7 +338,7 @@ def run_tracking():
 
     cap.release()
     tracking_active = False
-    print("Tracking stopped.")
+    logger.info("Tracking stopped.")
 
 
 def start_tracking():
@@ -417,7 +420,7 @@ def listen_for_tracking_commands(core):
 
     SCREEN_W, SCREEN_H = get_screen_size()
 
-    print("Tracking mode: freeze, nudge, click, or stop tracking")
+    logger.info("Tracking mode: freeze, nudge, click, or stop tracking")
 
     while tracking_active:
         with contextlib.suppress(Exception):
@@ -441,7 +444,7 @@ def listen_for_tracking_commands(core):
             continue
 
         cmd_lower = cmd.lower().strip()
-        print(f"  ← {cmd_lower}")
+        logger.debug("  ← %s", cmd_lower)
 
         # Exit commands
         if any(
@@ -466,12 +469,12 @@ def listen_for_tracking_commands(core):
         # Freeze/Go
         if any(w in cmd_lower for w in ["freeze", "free", "rees", "frees"]):
             frozen = True
-            print(f"  → Frozen at ({int(cursor_x)}, {int(cursor_y)})")
+            logger.debug("  → Frozen at (%d, %d)", int(cursor_x), int(cursor_y))
             continue
 
         if cmd_lower in ["go", "go go", "unfreeze", "resume", "track"]:
             frozen = False
-            print("  → Resumed")
+            logger.debug("  → Resumed")
             continue
 
         # Nudge (only when frozen)

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -9,8 +9,11 @@ Features:
 
 import atexit
 import contextlib
+import logging
 import re
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 NAME = "mousegrid"
 DESCRIPTION = "Voice-controlled mouse grid"
@@ -226,9 +229,9 @@ def show_grid():
     if dbus_call("Show", screen_size[0], screen_size[1]):
         grid_active = True
         core.speak("Grid")
-        print(f"Grid shown ({screen_size[0]}x{screen_size[1]})")
+        logger.info("Grid shown (%sx%s)", screen_size[0], screen_size[1])
     else:
-        print("Failed to show grid - is extension enabled?")
+        logger.warning("Failed to show grid - is extension enabled?")
 
 
 def close_grid():
@@ -278,7 +281,7 @@ def update_grid(zone):
     grid_bounds = (new_x, new_y, zone_w, zone_h)
 
     cx, cy = get_center()
-    print(f"  → Zone {zone}: {zone_w}x{zone_h} center=({cx}, {cy})")
+    logger.debug("  → Zone %s: %sx%s center=(%s, %s)", zone, zone_w, zone_h, cx, cy)
     return dbus_call("Update", new_x, new_y, zone_w, zone_h)
 
 
@@ -325,7 +328,7 @@ def do_scroll(direction, count=1):
     grid_active = False
     grid_bounds = None
 
-    print(f"  → Scroll {direction} x{count}")
+    logger.debug("  → Scroll %s x%s", direction, count)
     return dbus_call("Scroll", cx, cy, direction, count)
 
 
@@ -349,7 +352,7 @@ def nudge_grid(direction, count=1):
 
     grid_bounds = (x, y, w, h)
     cx, cy = get_center()
-    print(f"  → Nudge {direction} x{count}: center=({cx}, {cy})")
+    logger.debug("  → Nudge %s x%s: center=(%s, %s)", direction, count, cx, cy)
     return dbus_call("Update", x, y, w, h)
 
 
@@ -359,25 +362,25 @@ def start_drag():
     if not center:
         return False
     drag_start = center
-    print(f"  → Drag start: {center}")
+    logger.debug("  → Drag start: %s", center)
     dbus_call("StartDrag", center[0], center[1])
 
     # Reset grid to full screen so user can navigate to destination
     grid_bounds = (0, 0, screen_size[0], screen_size[1])
     dbus_call("Update", 0, 0, screen_size[0], screen_size[1])
-    print("  → Grid reset - navigate to drop location")
+    logger.debug("  → Grid reset - navigate to drop location")
     return True
 
 
 def end_drag():
     global drag_start, grid_bounds, grid_active, last_bounds
     if not drag_start:
-        print("  → No drag in progress")
+        logger.debug("  → No drag in progress")
         return False
     center = get_center()
     if not center:
         return False
-    print(f"  → Drag end: {center}")
+    logger.debug("  → Drag end: %s", center)
     dbus_call("EndDrag", center[0], center[1])
     last_bounds = grid_bounds
     grid_active = False
@@ -402,7 +405,7 @@ def handle(cmd, core):
         dbus_call("Show", screen_size[0], screen_size[1])
         dbus_call("Update", *last_bounds)
         core.speak("Grid")
-        print("Grid reopened at last position")
+        logger.info("Grid reopened at last position")
         listen_for_grid_commands(core)
         return True
 
@@ -423,7 +426,7 @@ def listen_for_grid_commands(core):
     """Continuous listening while grid active"""
     global grid_active, drag_start
 
-    print("Grid mode: say numbers (e.g. '3 7 5'), nudge, scroll, click, close")
+    logger.info("Grid mode: say numbers (e.g. '3 7 5'), nudge, scroll, click, close")
 
     while grid_active:
         with contextlib.suppress(Exception):
@@ -447,7 +450,7 @@ def listen_for_grid_commands(core):
             continue
 
         cmd_lower = cmd.lower().strip()
-        print(f"  ← {cmd_lower}")
+        logger.debug("  ← %s", cmd_lower)
 
         # === Exit ===
         if any(
@@ -464,7 +467,7 @@ def listen_for_grid_commands(core):
             ]
         ):
             close_grid()
-            print("Grid closed")
+            logger.info("Grid closed")
             return
 
         # === Drag ===
@@ -510,6 +513,6 @@ def listen_for_grid_commands(core):
         # === Zone numbers (chained) ===
         zones = parse_number_sequence(cmd_lower)
         if zones:
-            print(f"  → Zones: {zones}")
+            logger.debug("  → Zones: %s", zones)
             process_zones(zones)
             continue

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -3,10 +3,12 @@ Browser Plugin - Qutebrowser voice control via IPC
 """
 
 import contextlib
+import logging
 import re
-import sys
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 NAME = "browser"
 DESCRIPTION = "Qutebrowser voice control"
@@ -200,16 +202,17 @@ def ensure_qutebrowser_config():
 
     verb = "wrote" if not existing else "updated"
     added = "; ".join(missing)
-    print(f"browser: {verb} {cfg} (added: {added})", file=sys.stderr)
+    logger.debug("%s %s (added: %s)", verb, cfg, added)
 
 
 def _note_missing_qb_lines(cfg, lines, reason):
     """Politely tell the user to add missing qutebrowser config lines."""
     body = "\n".join(f"  {line}" for line in lines)
-    print(
-        f"browser: note: {cfg} {reason}. "
-        f"Please make sure your qutebrowser config includes:\n{body}",
-        file=sys.stderr,
+    logger.warning(
+        "%s %s. Please make sure your qutebrowser config includes:\n%s",
+        cfg,
+        reason,
+        body,
     )
 
 
@@ -221,7 +224,7 @@ def setup(c):
 
 def qb(command):
     """Send command to qutebrowser via IPC"""
-    print(f"  🌐 qutebrowser :{command}")
+    logger.debug("  🌐 qutebrowser :%s", command)
     core.host_run(["qutebrowser", f":{command}"])
 
 
@@ -339,7 +342,7 @@ def parse_spoken_url(spoken):
 
 def listen_for_hint(core):
     """Listen for hint number after showing hints"""
-    print("  🔢 Say hint number (e.g. 'zero two'), 'exit links' to cancel")
+    logger.info("  🔢 Say hint number (e.g. 'zero two'), 'exit links' to cancel")
 
     # Small delay to let hints render
     time.sleep(0.3)
@@ -351,9 +354,9 @@ def listen_for_hint(core):
     # Wait for speech
     first = core.wait_for_speech(timeout=10)
     if not first:
-        print("  ⏱ Timeout - hints cancelled")
+        logger.info("  ⏱ Timeout - hints cancelled")
         qb("mode-leave")
-        print("  [listen_for_hint returning - timeout]")
+        logger.debug("  [listen_for_hint returning - timeout]")
         return
 
     audio = first + core.record_until_silence()
@@ -362,7 +365,7 @@ def listen_for_hint(core):
     )
 
     if not cmd:
-        print("  [listen_for_hint - no transcription, waiting again]")
+        logger.debug("  [listen_for_hint - no transcription, waiting again]")
         # Try one more time
         first = core.wait_for_speech(timeout=5)
         if first:
@@ -372,11 +375,11 @@ def listen_for_hint(core):
             )
         if not cmd:
             qb("mode-leave")
-            print("  [listen_for_hint returning - no transcription]")
+            logger.debug("  [listen_for_hint returning - no transcription]")
             return
 
     cmd_lower = cmd.lower().strip(".,!? ")
-    print(f"  ← {cmd_lower}")
+    logger.debug("  ← %s", cmd_lower)
 
     # Cancel
     if cmd_lower in [
@@ -389,15 +392,15 @@ def listen_for_hint(core):
         "exit",
     ]:
         qb("mode-leave")
-        print("  ✗ Hints cancelled")
-        print("  [listen_for_hint returning - cancelled]")
+        logger.info("  ✗ Hints cancelled")
+        logger.debug("  [listen_for_hint returning - cancelled]")
         return
 
     # Parse hint number
     hint = parse_hint_number(cmd_lower)
 
     if hint:
-        print(f"  🔤 Hint: '{cmd_lower}' → '{hint}'")
+        logger.debug("  🔤 Hint: '%s' → '%s'", cmd_lower, hint)
         qb(f"hint-follow {hint}")
         # Wait for page to load, then clear any stuck state
         time.sleep(1.0)
@@ -406,18 +409,18 @@ def listen_for_hint(core):
         # Try phonetic fallback
         hint = parse_hint_numbers(cmd_lower)
         if hint:
-            print(f"  🔤 Phonetic: '{cmd_lower}' → '{hint}'")
+            logger.debug("  🔤 Phonetic: '%s' → '%s'", cmd_lower, hint)
             qb(f"hint-follow {hint}")
             # Wait for page to load, then clear any stuck state
             time.sleep(1.0)
             qb("fake-key <Escape>")
         else:
             # Not a hint - might be a browser command, pass it through
-            print(f"  ↪ Not a hint, trying as command: '{cmd_lower}'")
+            logger.debug("  ↪ Not a hint, trying as command: '%s'", cmd_lower)
             qb("mode-leave")
             handle_browser_command(cmd_lower, core)
 
-    print("  [listen_for_hint returning - complete]")
+    logger.debug("  [listen_for_hint returning - complete]")
 
 
 # Global control phrases owned by the sleep and base plugins. This plugin is
@@ -455,11 +458,11 @@ def handle(cmd, core):
     try:
         result = handle_browser_command(cmd_lower, core)
         if result:
-            print("  → Entering browser mode...")
+            logger.info("  → Entering browser mode...")
             browser_mode(core)
             return True
-    except Exception as e:
-        print(f"  ! Browser error: {e}")
+    except Exception:
+        logger.exception("  ! Browser error")
         return True
 
     return None
@@ -468,8 +471,8 @@ def handle(cmd, core):
 def browser_mode(core):
     """Continuous listening for browser commands"""
     core.speak("Browser")
-    print("=== BROWSER MODE ACTIVE ===")
-    print("Say commands directly. 'exit browser' to leave.")
+    logger.info("=== BROWSER MODE ACTIVE ===")
+    logger.info("Say commands directly. 'exit browser' to leave.")
 
     while True:
         with contextlib.suppress(Exception):
@@ -488,7 +491,7 @@ def browser_mode(core):
             continue
 
         cmd_lower = cmd.lower().strip(".,!? ")
-        print(f"  [browser] {cmd_lower}")
+        logger.debug("  [browser] %s", cmd_lower)
 
         # Exit browser mode - require explicit phrase
         if cmd_lower in [
@@ -498,19 +501,19 @@ def browser_mode(core):
             "quit browser",
             "close browser",
         ]:
-            print("=== BROWSER MODE EXIT ===")
+            logger.info("=== BROWSER MODE EXIT ===")
             return
 
         # Grid triggers - escape to grid mode
         grid_triggers = {"grid", "grit", "grip", "mouse", "pointer", "cursor"}
         if any(w in cmd_lower for w in grid_triggers):
-            print("=== BROWSER MODE EXIT → GRID ===")
+            logger.info("=== BROWSER MODE EXIT → GRID ===")
             core.route_command(cmd_lower)
             return
 
         # Handle browser command
         if not handle_browser_command(cmd_lower, core):
-            print(f"  ? Unknown: {cmd_lower}")
+            logger.debug("  ? Unknown: %s", cmd_lower)
 
 
 def handle_browser_command(cmd_lower, core):
@@ -695,14 +698,14 @@ def handle_browser_command(cmd_lower, core):
         stripped = re.sub(r"[^0-9a-z]", "", cmd_lower)
         if stripped.replace("o", "0").isdigit():
             hint = stripped.replace("o", "0")
-            print(f"  🔤 Direct digits: '{cmd_lower}' → '{hint}'")
+            logger.debug("  🔤 Direct digits: '%s' → '%s'", cmd_lower, hint)
             qb(f"hint-follow {hint}")
             return True
 
         # Try phonetic parsing
         hint = parse_hint_numbers(cmd_lower)
         if hint and hint.isdigit():
-            print(f"  🔤 Phonetic parsed: '{cmd_lower}' → '{hint}'")
+            logger.debug("  🔤 Phonetic parsed: '%s' → '%s'", cmd_lower, hint)
             qb(f"hint-follow {hint}")
             return True
 

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -2,10 +2,12 @@
 Dictation Plugin - Voice to text via AT-SPI
 """
 
+import logging
 import re
 import shutil
 import subprocess
-import sys
+
+logger = logging.getLogger(__name__)
 
 NAME = "dictation"
 DESCRIPTION = "Voice dictation into any text field"
@@ -56,16 +58,13 @@ def ensure_gnome_accessibility():
             check=False,
         )
         if result.returncode == 0:
-            print(
-                "dictation: enabled GNOME toolkit-accessibility — "
-                "log out and back in for dictation to work",
-                file=sys.stderr,
+            logger.info(
+                "enabled GNOME toolkit-accessibility — "
+                "log out and back in for dictation to work"
             )
         else:
-            print(
-                "dictation: WARNING could not enable GNOME "
-                "toolkit-accessibility; dictation will not work",
-                file=sys.stderr,
+            logger.warning(
+                "could not enable GNOME toolkit-accessibility; dictation will not work"
             )
     except OSError:
         pass
@@ -232,7 +231,7 @@ def handle(cmd, core):
     if ("notes" in cmd or "note" in cmd) and "stop" not in cmd:
         core.speak("Dictation")
 
-        print("🎙️ Dictation mode - say 'stop notes' to end")
+        logger.info("🎙️ Dictation mode - say 'stop notes' to end")
 
         while True:
             # Clear buffer and wait for speech
@@ -242,7 +241,7 @@ def handle(cmd, core):
             first = core.wait_for_speech(timeout=30)
 
             if not first:
-                print("   (waiting...)")
+                logger.debug("   (waiting...)")
                 continue
 
             audio = first + core.record_until_silence()
@@ -252,7 +251,7 @@ def handle(cmd, core):
                 continue
 
             text = text.strip().lower()
-            print(f"   Raw: {text}")
+            logger.debug("   Raw: %s", text)
 
             # Check for exit - include mishearings
             if any(
@@ -277,7 +276,7 @@ def handle(cmd, core):
 
             # Format and insert
             formatted = format_text(text)
-            print(f"📝 {formatted}")
+            logger.info("📝 %s", formatted)
 
             if formatted:
                 # Add space before words, not before punctuation

--- a/src/plugins/zz_base.py
+++ b/src/plugins/zz_base.py
@@ -40,11 +40,17 @@ def handle(cmd, core):
 
 
 def show_help(core):
-    print("\n=== Available Commands ===")
+    """List every plugin's commands on the terminal.
+
+    Printed rather than logged: it is the direct reply to an explicit "help"
+    request (the spoken reply tells the user to read the terminal), so it must
+    appear regardless of the configured log verbosity.
+    """
+    print("\n=== Available Commands ===")  # noqa: T201
     for plugin in core.plugins:
         if hasattr(plugin, "COMMANDS"):
-            print(f"\n{plugin.NAME}:")
+            print(f"\n{plugin.NAME}:")  # noqa: T201
             for cmd in plugin.COMMANDS:
-                print(f"  • {cmd}")
-    print()
+                print(f"  • {cmd}")  # noqa: T201
+    print()  # noqa: T201
     core.speak("Check the terminal for available commands.")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,7 +22,7 @@ class CapturedLog:
 def _restore_easyspeak_loggers():
     """Snapshot and restore the package loggers around each test.
 
-    ``main.configure_logging`` mutates the ``easyspeak`` and ``plugins`` loggers
+    ``log.configure`` mutates the ``easyspeak`` and ``plugins`` loggers
     (handlers, level, ``propagate``); restoring them keeps a test that calls it
     from leaking that state into later tests that rely on ``caplog``.
     """

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,60 @@
+"""Shared fixtures for the unit suite."""
+
+import logging
+
+import pytest
+
+
+class CapturedLog:
+    """A capsys-style view over captured log text.
+
+    EasySpeak's terminal output goes through ``logging`` rather than ``print``,
+    so ``.out`` and ``.err`` both return the captured log text and existing
+    output assertions can keep reading from a single place.
+    """
+
+    def __init__(self, text):
+        self.out = text
+        self.err = text
+
+
+@pytest.fixture(autouse=True)
+def _restore_easyspeak_loggers():
+    """Snapshot and restore the package loggers around each test.
+
+    ``main.configure_logging`` mutates the ``easyspeak`` and ``plugins`` loggers
+    (handlers, level, ``propagate``); restoring them keeps a test that calls it
+    from leaking that state into later tests that rely on ``caplog``.
+    """
+    names = ("easyspeak", "plugins")
+    saved = [
+        (
+            logging.getLogger(n),
+            logging.getLogger(n).handlers[:],
+            logging.getLogger(n).level,
+            logging.getLogger(n).propagate,
+        )
+        for n in names
+    ]
+    yield
+    for log, handlers, level, propagate in saved:
+        log.handlers[:] = handlers
+        log.setLevel(level)
+        log.propagate = propagate
+
+
+@pytest.fixture
+def readlog(caplog):
+    """Return a reader yielding captured log output, capsys-style.
+
+    Mirrors ``capsys.readouterr()``: each call returns the text logged since the
+    previous call, then clears the buffer.
+    """
+    caplog.set_level(logging.DEBUG)
+
+    def _read():
+        captured = CapturedLog(caplog.text)
+        caplog.clear()
+        return captured
+
+    return _read

--- a/tests/unit/core/test_cli.py
+++ b/tests/unit/core/test_cli.py
@@ -1,9 +1,13 @@
 """Tests for the core main module."""
 
+import argparse
+import logging
 import shutil
 import sys
 from importlib import import_module
 from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 
 def test_dunder_main_module():
@@ -22,6 +26,29 @@ def test_main_run(mock_easyspeak):
     sys.modules["pyaudio"] = MagicMock()
     from easyspeak.core import main
 
-    main.run()
+    main.run([])
 
     assert mock_easyspeak.mock_calls == [call(), call().run()]
+
+
+@pytest.mark.parametrize(
+    ("flags", "env", "expected"),
+    [
+        ({"verbose": True, "quiet": False}, None, logging.DEBUG),
+        ({"verbose": False, "quiet": True}, None, logging.WARNING),
+        ({"verbose": False, "quiet": False}, "WARNING", logging.WARNING),
+        ({"verbose": False, "quiet": False}, None, logging.INFO),
+        ({"verbose": False, "quiet": False}, "bogus", logging.INFO),
+    ],
+)
+def test_resolve_log_level(flags, env, expected, monkeypatch):
+    """CLI flags win, then EASYSPEAK_LOG_LEVEL, then INFO (invalid -> INFO)."""
+    sys.modules["pyaudio"] = MagicMock()
+    from easyspeak.core import main
+
+    if env is None:
+        monkeypatch.delenv("EASYSPEAK_LOG_LEVEL", raising=False)
+    else:
+        monkeypatch.setenv("EASYSPEAK_LOG_LEVEL", env)
+
+    assert main._resolve_log_level(argparse.Namespace(**flags)) == expected

--- a/tests/unit/core/test_cli.py
+++ b/tests/unit/core/test_cli.py
@@ -1,13 +1,9 @@
-"""Tests for the core main module."""
+"""Tests for the core CLI entry point."""
 
-import argparse
-import logging
 import shutil
 import sys
 from importlib import import_module
 from unittest.mock import MagicMock, call, patch
-
-import pytest
 
 
 def test_dunder_main_module():
@@ -20,35 +16,12 @@ def test_entrypoint():
     assert shutil.which("easyspeak")
 
 
-@patch("easyspeak.core.main.EasySpeak")
-def test_main_run(mock_easyspeak):
-    """Does main:run instantiate the EasySpeak class and run its method?"""
+@patch("easyspeak.core.cli.EasySpeak")
+def test_run(mock_easyspeak):
+    """cli.run parses args, configures logging, and runs the app."""
     sys.modules["pyaudio"] = MagicMock()
-    from easyspeak.core import main
+    from easyspeak.core import cli
 
-    main.run([])
+    cli.run([])
 
     assert mock_easyspeak.mock_calls == [call(), call().run()]
-
-
-@pytest.mark.parametrize(
-    ("flags", "env", "expected"),
-    [
-        ({"verbose": True, "quiet": False}, None, logging.DEBUG),
-        ({"verbose": False, "quiet": True}, None, logging.WARNING),
-        ({"verbose": False, "quiet": False}, "WARNING", logging.WARNING),
-        ({"verbose": False, "quiet": False}, None, logging.INFO),
-        ({"verbose": False, "quiet": False}, "bogus", logging.INFO),
-    ],
-)
-def test_resolve_log_level(flags, env, expected, monkeypatch):
-    """CLI flags win, then EASYSPEAK_LOG_LEVEL, then INFO (invalid -> INFO)."""
-    sys.modules["pyaudio"] = MagicMock()
-    from easyspeak.core import main
-
-    if env is None:
-        monkeypatch.delenv("EASYSPEAK_LOG_LEVEL", raising=False)
-    else:
-        monkeypatch.setenv("EASYSPEAK_LOG_LEVEL", env)
-
-    assert main._resolve_log_level(argparse.Namespace(**flags)) == expected

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -106,7 +106,7 @@ def test_refresh_extension_files_discards_stale_temp_up_front(tmp_path):
 
 @patch.object(gnome_extension.shutil, "copy2", side_effect=PermissionError("ro"))
 def test_refresh_extension_files_write_failure_returns_error(
-    mock_copy, tmp_path, capsys
+    mock_copy, tmp_path, readlog
 ):
     """A write error (e.g. read-only dest) is swallowed and noted on stderr,
     leaving the existing install untouched rather than crashing startup."""
@@ -119,7 +119,7 @@ def test_refresh_extension_files_write_failure_returns_error(
 
     assert refreshed is gnome_extension.RefreshResult.ERROR
     assert (dest / "extension.js").read_text() == "old"
-    assert "could not write GNOME extension" in capsys.readouterr().err
+    assert "could not write GNOME extension" in readlog().err
 
 
 def test_refresh_extension_files_no_partial_overwrite_on_midway_failure(tmp_path):
@@ -148,7 +148,7 @@ def test_refresh_extension_files_no_partial_overwrite_on_midway_failure(tmp_path
     assert not list(dest.glob(".*.tmp"))
 
 
-def test_refresh_extension_files_missing_source(tmp_path, capsys):
+def test_refresh_extension_files_missing_source(tmp_path, readlog):
     src = tmp_path / "src"  # no files created
     dest = tmp_path / "dest"
 
@@ -156,7 +156,7 @@ def test_refresh_extension_files_missing_source(tmp_path, capsys):
 
     assert refreshed is gnome_extension.RefreshResult.ERROR
     assert not dest.exists()
-    assert "sources missing" in capsys.readouterr().err
+    assert "sources missing" in readlog().err
 
 
 def test_refresh_extension_files_partial_source_missing_helper(tmp_path):
@@ -481,21 +481,21 @@ class TestEnsureExtension:
             yield
 
     @patch.object(gnome_extension.shutil, "which", return_value=None)
-    def test_no_gnome_cli(self, mock_which, capsys):
+    def test_no_gnome_cli(self, mock_which, readlog):
         """No gnome-extensions on PATH (non-GNOME): silent no-op."""
         gnome_extension.ensure_extension()
 
-        assert capsys.readouterr().err == ""
+        assert readlog().err == ""
 
     @patch.object(gnome_extension.subprocess, "run", side_effect=OSError("nope"))
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_list_oserror(self, mock_which, mock_run, capsys):
+    def test_list_oserror(self, mock_which, mock_run, readlog):
         """`gnome-extensions list` raising OSError is swallowed silently."""
         gnome_extension.ensure_extension()
 
-        assert capsys.readouterr().err == ""
+        assert readlog().err == ""
 
     @patch.object(
         gnome_extension.subprocess,
@@ -505,11 +505,11 @@ class TestEnsureExtension:
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_list_timeout(self, mock_which, mock_run, capsys):
+    def test_list_timeout(self, mock_which, mock_run, readlog):
         """A wedged `gnome-extensions` probe times out instead of hanging."""
         gnome_extension.ensure_extension()
 
-        assert capsys.readouterr().err == ""
+        assert readlog().err == ""
 
     @patch.object(
         gnome_extension.subprocess, "run", return_value=Mock(returncode=1, stdout="")
@@ -517,16 +517,16 @@ class TestEnsureExtension:
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_list_returncode_nonzero(self, mock_which, mock_run, capsys):
+    def test_list_returncode_nonzero(self, mock_which, mock_run, readlog):
         """`gnome-extensions list` returning non-zero: silent no-op."""
         gnome_extension.ensure_extension()
 
-        assert capsys.readouterr().err == ""
+        assert readlog().err == ""
 
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_already_installed_and_enabled(self, mock_which, capsys):
+    def test_already_installed_and_enabled(self, mock_which, readlog):
         """UUID in both `list` and `list --enabled`, bundle unchanged: announce."""
         listed = Mock(
             returncode=0, stdout="other@one.com\neasyspeak-grid@local\nthird@two.org\n"
@@ -548,7 +548,7 @@ class TestEnsureExtension:
         ):
             gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "already installed and enabled" in captured.err
         assert "easyspeak-grid@local" in captured.err
         # No `enable` call needed — only the two probe calls.
@@ -557,7 +557,7 @@ class TestEnsureExtension:
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_already_installed_refreshes_changed_bundle(self, mock_which, capsys):
+    def test_already_installed_refreshes_changed_bundle(self, mock_which, readlog):
         """Installed+enabled but the bundled extension changed: refresh and tell
         the user to re-login so GNOME loads the new code."""
         listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
@@ -576,7 +576,7 @@ class TestEnsureExtension:
         ):
             gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "updated GNOME extension easyspeak-grid@local" in captured.err
         assert "log out and back in" in captured.err
         # Still only the two probe calls — refresh is file I/O, not a subprocess.
@@ -585,7 +585,7 @@ class TestEnsureExtension:
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_reports_unit_install(self, mock_which, capsys):
+    def test_reports_unit_install(self, mock_which, readlog):
         """ensure_extension surfaces whatever install_refresh_unit reports."""
         listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
         listed_enabled = Mock(returncode=0, stdout="easyspeak-grid@local\n")
@@ -609,12 +609,12 @@ class TestEnsureExtension:
             gnome_extension.ensure_extension()
 
         mock_unit.assert_called_once_with()
-        assert f"installed systemd user unit {UNIT_NAME}" in capsys.readouterr().err
+        assert f"installed systemd user unit {UNIT_NAME}" in readlog().err
 
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_installed_but_disabled_enable_succeeds(self, mock_which, capsys):
+    def test_installed_but_disabled_enable_succeeds(self, mock_which, readlog):
         """UUID in `list` but not in `list --enabled`: flip it on and announce."""
         listed = Mock(returncode=0, stdout="other@one.com\neasyspeak-grid@local\n")
         listed_enabled = Mock(returncode=0, stdout="other-on@two.org\n")
@@ -626,7 +626,7 @@ class TestEnsureExtension:
         ) as mock_run:
             gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "enabled GNOME extension easyspeak-grid@local" in captured.err
         assert "was installed but disabled" in captured.err
         assert mock_run.call_count == 3
@@ -639,7 +639,7 @@ class TestEnsureExtension:
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_installed_but_disabled_enable_fails(self, mock_which, capsys):
+    def test_installed_but_disabled_enable_fails(self, mock_which, readlog):
         """Installed-but-disabled and `enable` fails: hint, no log-out wording."""
         listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
         listed_enabled = Mock(returncode=0, stdout="")
@@ -651,7 +651,7 @@ class TestEnsureExtension:
         ):
             gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "installed but disabled, and could not be enabled" in captured.err
         assert "gnome-extensions enable easyspeak-grid@local" in captured.err
         # The "log out and back in" hint is only for fresh installs.
@@ -664,12 +664,12 @@ class TestEnsureExtension:
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
-    def test_source_files_missing(self, mock_which, mock_run, mock_is_file, capsys):
+    def test_source_files_missing(self, mock_which, mock_run, mock_is_file, readlog):
         """When extension source files aren't at the project root: polite note."""
         gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
-        assert "easyspeak: note:" in captured.err
+        captured = readlog()
+        assert "could not auto-install GNOME extension" in captured.err
         assert "source files not found" in captured.err
 
     @patch.object(
@@ -680,15 +680,15 @@ class TestEnsureExtension:
     )
     @patch.object(gnome_extension.shutil, "copy2", side_effect=PermissionError("ro"))
     def test_copy_fails(
-        self, mock_copy, mock_which, mock_run, tmp_path, monkeypatch, capsys
+        self, mock_copy, mock_which, mock_run, tmp_path, monkeypatch, readlog
     ):
         """copy2 raising OSError: polite note, no enable attempt."""
         monkeypatch.setenv("HOME", str(tmp_path))
 
         gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
-        assert "easyspeak: note:" in captured.err
+        captured = readlog()
+        assert "installed manually" in captured.err
         # The write failure itself is described once, by refresh_extension_files,
         # with the OSError detail; ensure_extension adds only the consequence.
         assert "could not write GNOME extension" in captured.err
@@ -738,7 +738,7 @@ class TestEnsureExtension:
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
     def test_install_and_enable_success(
-        self, mock_which, tmp_path, monkeypatch, capsys
+        self, mock_which, tmp_path, monkeypatch, readlog
     ):
         """Happy path: copies files and enables, prints success message."""
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -764,14 +764,14 @@ class TestEnsureExtension:
         assert (dest / "extension.js").is_file()
         assert (dest / "metadata.json").is_file()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "installed and enabled" in captured.err
 
     @patch.object(
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
     def test_install_succeeds_enable_returncode_nonzero(
-        self, mock_which, tmp_path, monkeypatch, capsys
+        self, mock_which, tmp_path, monkeypatch, readlog
     ):
         """Install succeeds, but `enable` returns non-zero: log-out hint."""
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -786,7 +786,7 @@ class TestEnsureExtension:
         ):
             gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "log out and back in" in captured.err
         # No manual `gnome-extensions enable` instruction — next startup
         # picks it up via the installed-but-disabled branch.
@@ -796,7 +796,7 @@ class TestEnsureExtension:
         gnome_extension.shutil, "which", return_value="/usr/bin/gnome-extensions"
     )
     def test_install_succeeds_enable_oserror(
-        self, mock_which, tmp_path, monkeypatch, capsys
+        self, mock_which, tmp_path, monkeypatch, readlog
     ):
         """Install succeeds, but `enable` raises OSError: log-out hint."""
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -810,5 +810,5 @@ class TestEnsureExtension:
         ):
             gnome_extension.ensure_extension()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "log out and back in" in captured.err

--- a/tests/unit/core/test_log.py
+++ b/tests/unit/core/test_log.py
@@ -1,0 +1,42 @@
+"""Tests for the core.log module."""
+
+import logging
+import sys
+
+import pytest
+from easyspeak.core import log
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "env", "expected"),
+    [
+        ({"verbose": True}, None, logging.DEBUG),
+        ({"quiet": True}, None, logging.WARNING),
+        ({}, "WARNING", logging.WARNING),
+        ({}, None, logging.INFO),
+        ({}, "bogus", logging.INFO),
+    ],
+)
+def test_resolve_level(kwargs, env, expected, monkeypatch):
+    """CLI flags win, then EASYSPEAK_LOG_LEVEL, then INFO (invalid -> INFO)."""
+    if env is None:
+        monkeypatch.delenv("EASYSPEAK_LOG_LEVEL", raising=False)
+    else:
+        monkeypatch.setenv("EASYSPEAK_LOG_LEVEL", env)
+
+    assert log.resolve_level(**kwargs) == expected
+
+
+def test_configure_sets_message_only_stderr_handler():
+    """configure attaches one message-only handler and isolates the loggers."""
+    log.configure(logging.DEBUG)
+
+    pkg = logging.getLogger("easyspeak")
+    assert pkg.level == logging.DEBUG
+    assert pkg.propagate is False
+    assert len(pkg.handlers) == 1
+
+    handler = pkg.handlers[0]
+    assert handler.stream is sys.stderr
+    record = logging.LogRecord("n", logging.INFO, "", 0, "hello", None, None)
+    assert handler.format(record) == "hello"

--- a/tests/unit/core/test_log.py
+++ b/tests/unit/core/test_log.py
@@ -27,16 +27,44 @@ def test_resolve_level(kwargs, env, expected, monkeypatch):
     assert log.resolve_level(**kwargs) == expected
 
 
-def test_configure_sets_message_only_stderr_handler():
-    """configure attaches one message-only handler and isolates the loggers."""
-    log.configure(logging.DEBUG)
+def test_configure_isolates_package_loggers():
+    """configure attaches one stderr handler and isolates the package loggers."""
+    log.configure(logging.INFO)
 
     pkg = logging.getLogger("easyspeak")
-    assert pkg.level == logging.DEBUG
+    assert pkg.level == logging.INFO
     assert pkg.propagate is False
     assert len(pkg.handlers) == 1
+    assert pkg.handlers[0].stream is sys.stderr
 
-    handler = pkg.handlers[0]
-    assert handler.stream is sys.stderr
+
+def _format_info_record():
+    handler = logging.getLogger("easyspeak").handlers[0]
     record = logging.LogRecord("n", logging.INFO, "", 0, "hello", None, None)
-    assert handler.format(record) == "hello"
+    return handler.format(record)
+
+
+def test_configure_message_only_above_debug():
+    """Above DEBUG, output is the bare message."""
+    log.configure(logging.INFO)
+    assert _format_info_record() == "hello"
+
+
+def test_configure_level_prefixed_at_debug():
+    """At DEBUG, output is prefixed with the level name."""
+    log.configure(logging.DEBUG)
+    assert _format_info_record() == "INFO hello"
+
+
+def test_configure_reports_config_at_debug(capsys):
+    """At DEBUG, configure echoes the resolved configuration on startup."""
+    log.configure(logging.DEBUG)
+
+    assert "logging configured: level=DEBUG" in capsys.readouterr().err
+
+
+def test_configure_quiet_about_config_above_debug(capsys):
+    """Below DEBUG, the configuration line is suppressed."""
+    log.configure(logging.INFO)
+
+    assert capsys.readouterr().err == ""

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -109,7 +109,7 @@ class TestEasySpeakPlugins:
 
     @patch("importlib.import_module")
     @patch("sys.path")
-    def test_load_plugins_no_directory(self, mock_syspath, mock_import, capsys):
+    def test_load_plugins_no_directory(self, mock_syspath, mock_import, readlog):
         """Test load_plugins when plugins directory doesn't exist."""
         easy = EasySpeak()
 
@@ -117,14 +117,14 @@ class TestEasySpeakPlugins:
         with patch.object(Path, "exists", return_value=False):
             easy.load_plugins()
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "No plugins directory found" in captured.out
         assert easy.plugins == []
 
     @patch("importlib.import_module")
     @patch("sys.path")
     def test_load_plugins_valid_plugin(
-        self, mock_syspath, mock_import, mock_plugin_with_setup, capsys
+        self, mock_syspath, mock_import, mock_plugin_with_setup, readlog
     ):
         """Test load_plugins with a valid plugin."""
         easy = EasySpeak()
@@ -147,13 +147,13 @@ class TestEasySpeakPlugins:
         assert easy.plugins[0] == mock_plugin_with_setup
         mock_plugin_with_setup.setup.assert_called_once_with(easy)
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "✓ Loaded: TestPlugin" in captured.out
 
     @patch("importlib.import_module")
     @patch("sys.path")
     def test_load_plugins_skip_underscore_files(
-        self, mock_syspath, mock_import, capsys
+        self, mock_syspath, mock_import, readlog
     ):
         """Test that files starting with underscore are skipped."""
         easy = EasySpeak()
@@ -175,7 +175,7 @@ class TestEasySpeakPlugins:
 
     @patch("importlib.import_module")
     @patch("sys.path")
-    def test_load_plugins_invalid_plugin(self, mock_syspath, mock_import, capsys):
+    def test_load_plugins_invalid_plugin(self, mock_syspath, mock_import, readlog):
         """Test load_plugins with an invalid plugin (missing NAME or handle)."""
         easy = EasySpeak()
 
@@ -197,12 +197,12 @@ class TestEasySpeakPlugins:
         # Check that plugin was not loaded
         assert easy.plugins == []
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "Invalid plugin: invalid_plugin.py" in captured.out
 
     @patch("importlib.import_module")
     @patch("sys.path")
-    def test_load_plugins_import_error(self, mock_syspath, mock_import, capsys):
+    def test_load_plugins_import_error(self, mock_syspath, mock_import, readlog):
         """Test load_plugins when import fails."""
         easy = EasySpeak()
 
@@ -223,7 +223,7 @@ class TestEasySpeakPlugins:
         # Check that plugin was not loaded
         assert easy.plugins == []
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "Failed to load broken_plugin.py" in captured.out
 
     def test_load_plugins_loads_all_shipped_plugins(self):
@@ -342,7 +342,7 @@ class TestEasySpeakRouteCommand:
 
     @patch.object(EasySpeak, "speak")
     def test_route_command_plugin_error(
-        self, mock_speak, mock_plugin_with_error, capsys
+        self, mock_speak, mock_plugin_with_error, readlog
     ):
         """Test route_command when plugin raises an exception."""
         easy = EasySpeak()
@@ -350,7 +350,7 @@ class TestEasySpeakRouteCommand:
 
         result = easy.route_command("test command")
 
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "Plugin error (TestPlugin)" in captured.out
         assert result is True
         mock_speak.assert_called_once()
@@ -744,7 +744,7 @@ class TestEasySpeakRun:
     @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     def test_run_no_plugins(
-        self, mock_load_plugins, mock_whisper_model, mock_wakeword_model, capsys
+        self, mock_load_plugins, mock_whisper_model, mock_wakeword_model, readlog
     ):
         """Test run method exits early when no plugins are loaded."""
         easy = EasySpeak()
@@ -761,7 +761,7 @@ class TestEasySpeakRun:
         mock_load_plugins.assert_called_once()
 
         # Check output
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "No plugins loaded. Exiting." in captured.out
 
     @patch("subprocess.run")
@@ -807,7 +807,7 @@ class TestEasySpeakRun:
         mock_subprocess_run,
         mock_plugin,
         _stub_speech_warmup,
-        capsys,
+        readlog,
     ):
         """When warmup fails (e.g. piper missing) then run still starts."""
         _stub_speech_warmup.side_effect = OSError()
@@ -822,7 +822,7 @@ class TestEasySpeakRun:
 
         easy.run()  # must not raise
 
-        assert "Speech unavailable" in capsys.readouterr().out
+        assert "Speech unavailable" in readlog().out
 
     @patch("subprocess.run")
     @patch("easyspeak.core.main.pyaudio")
@@ -837,7 +837,7 @@ class TestEasySpeakRun:
         mock_pyaudio,
         mock_subprocess_run,
         mock_plugin,
-        capsys,
+        readlog,
     ):
         """Test run method handles KeyboardInterrupt gracefully."""
         easy = EasySpeak()
@@ -858,7 +858,7 @@ class TestEasySpeakRun:
         mock_audio.terminate.assert_called_once()
 
         # Check output
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "Bye!" in captured.out
 
     @patch("subprocess.run")
@@ -886,7 +886,7 @@ class TestEasySpeakRun:
         mock_time,
         mock_subprocess_run,
         mock_plugin,
-        capsys,
+        readlog,
     ):
         """Test run method when wake word is detected and command is processed."""
         easy = EasySpeak()
@@ -922,7 +922,7 @@ class TestEasySpeakRun:
         easy.run()
 
         # Check that wake word was detected
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "Wake!" in captured.out
         assert "test command" in captured.out
 
@@ -1148,7 +1148,7 @@ class TestEasySpeakRun:
         mock_time,
         mock_subprocess_run,
         mock_plugin,
-        capsys,
+        readlog,
     ):
         """Test run method when wake word is detected but no speech follows."""
         easy = EasySpeak()
@@ -1216,7 +1216,6 @@ class TestEasySpeakRun:
         mock_time,
         mock_subprocess_run,
         mock_plugin,
-        capsys,
     ):
         """Test run method respects wake word cooldown period."""
         easy = EasySpeak()
@@ -1289,7 +1288,7 @@ class TestEasySpeakRun:
         mock_time,
         mock_subprocess_run,
         mock_plugin,
-        capsys,
+        readlog,
     ):
         """Test run method exits when route_command returns False."""
         easy = EasySpeak()
@@ -1344,7 +1343,7 @@ class TestEasySpeakRun:
         mock_time,
         mock_subprocess_run,
         mock_plugin,
-        capsys,
+        readlog,
     ):
         """Test run method manages audio buffer correctly when it exceeds 50 items."""
         easy = EasySpeak()

--- a/tests/unit/core/test_speech.py
+++ b/tests/unit/core/test_speech.py
@@ -27,7 +27,7 @@ class TestSpeechPipeline:
 
     @patch("shutil.which", return_value="/usr/bin/pw-play")
     @patch("subprocess.Popen")
-    def test_speak(self, mock_popen, mock_which, capsys):
+    def test_speak(self, mock_popen, mock_which, readlog):
         """When speak is called then it streams the phrase to a warm piper process."""
         pipe = SpeechPipeline()
 
@@ -41,7 +41,7 @@ class TestSpeechPipeline:
         pipe.speak("Hello world")
 
         # Check that text was printed
-        captured = capsys.readouterr()
+        captured = readlog()
         assert "💬 Hello world" in captured.out
 
         # Pipeline spawned: player + piper
@@ -55,7 +55,7 @@ class TestSpeechPipeline:
         assert mock_piper.stdin.flush.called
 
     @patch("subprocess.Popen")
-    def test_speak_reuses_warm_piper(self, mock_popen, capsys):
+    def test_speak_reuses_warm_piper(self, mock_popen, readlog):
         """When speak is called twice then the piper process is reused (model loaded once)."""
         pipe = SpeechPipeline()
         mock_player = Mock()

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -182,7 +182,7 @@ def test_parse_spoken_url_with_existing_protocol():
 
 
 @patch.object(browser, "core")
-def test_qb(mock_core, capsys):
+def test_qb(mock_core, readlog):
     """Test sending command to qutebrowser."""
     command = "reload"
 
@@ -190,7 +190,7 @@ def test_qb(mock_core, capsys):
 
     assert mock_core.host_run.call_count == 1
     assert mock_core.host_run.call_args.args[0] == ["qutebrowser", ":reload"]
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "🌐 qutebrowser :reload" in captured.out
 
 
@@ -537,14 +537,14 @@ def test_handle_browser_command_bookmark_save(mock_qb, mock_core):
     ],
 )
 @patch.object(browser, "qb")
-def test_handle_browser_command_direct_hint(mock_qb, command, hint, mock_core, capsys):
+def test_handle_browser_command_direct_hint(mock_qb, command, hint, mock_core, readlog):
     """Test handling direct hint number input."""
     result = browser.handle_browser_command(command, mock_core)
 
     assert result is True
     assert mock_qb.called
     assert mock_qb.call_args.args[0] == f"hint-follow {hint}"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Direct digits" in captured.out
 
 
@@ -645,7 +645,7 @@ def test_handle_unmatched_command(mock_handle_cmd, mock_core):
 @patch.object(browser, "handle_browser_command")
 @patch.object(browser, "browser_mode")
 def test_handle_browser_command_exception(
-    mock_browser_mode, mock_handle_cmd, mock_core, capsys
+    mock_browser_mode, mock_handle_cmd, mock_core, readlog
 ):
     """Test handle function handles exceptions gracefully."""
     mock_handle_cmd.side_effect = Exception("Test error")
@@ -653,8 +653,8 @@ def test_handle_browser_command_exception(
     result = browser.handle("back", mock_core)
 
     assert result is True
-    captured = capsys.readouterr()
-    assert "Browser error:" in captured.out
+    captured = readlog()
+    assert "Browser error" in captured.out
 
 
 # Tests for listen_for_hint function.
@@ -662,7 +662,7 @@ def test_handle_browser_command_exception(
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
-def test_listen_for_hint_timeout(mock_qb, mock_sleep, mock_core_factory, capsys):
+def test_listen_for_hint_timeout(mock_qb, mock_sleep, mock_core_factory, readlog):
     """When no speech is detected, hints are cancelled and mode-leave is called."""
     mock_core = mock_core_factory(wait_for_speech_values=[None])
 
@@ -670,14 +670,14 @@ def test_listen_for_hint_timeout(mock_qb, mock_sleep, mock_core_factory, capsys)
 
     assert mock_qb.called
     assert mock_qb.call_args.args[0] == "mode-leave"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Timeout - hints cancelled" in captured.out
 
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
 def test_listen_for_hint_no_transcription_timeout(
-    mock_qb, mock_sleep, mock_core_factory, capsys
+    mock_qb, mock_sleep, mock_core_factory, readlog
 ):
     """When transcription fails twice, hints are cancelled."""
     mock_core = mock_core_factory(
@@ -688,14 +688,14 @@ def test_listen_for_hint_no_transcription_timeout(
 
     assert mock_qb.called
     assert mock_qb.call_args.args[0] == "mode-leave"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "no transcription" in captured.out
 
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
 def test_listen_for_hint_no_transcription_retry_success(
-    mock_qb, mock_sleep, mock_core_factory, capsys
+    mock_qb, mock_sleep, mock_core_factory, readlog
 ):
     """When first transcription fails but second succeeds, hint is followed."""
     mock_core = mock_core_factory(
@@ -725,7 +725,7 @@ def test_listen_for_hint_no_transcription_retry_success(
 @patch("time.sleep")
 @patch.object(browser, "qb")
 def test_listen_for_hint_cancel(
-    mock_qb, mock_sleep, cancel_command, mock_core_factory, capsys
+    mock_qb, mock_sleep, cancel_command, mock_core_factory, readlog
 ):
     """When cancel command is spoken, hints are cancelled."""
     mock_core = mock_core_factory(
@@ -736,14 +736,14 @@ def test_listen_for_hint_cancel(
 
     assert mock_qb.called
     assert mock_qb.call_args.args[0] == "mode-leave"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Hints cancelled" in captured.out
 
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
 def test_listen_for_hint_successful_hint(
-    mock_qb, mock_sleep, mock_core_factory, capsys
+    mock_qb, mock_sleep, mock_core_factory, readlog
 ):
     """When a valid hint number is spoken, it is followed."""
     mock_core = mock_core_factory(
@@ -755,14 +755,14 @@ def test_listen_for_hint_successful_hint(
     assert mock_qb.call_count == 2
     assert mock_qb.call_args_list[0].args[0] == "hint-follow 02"
     assert mock_qb.call_args_list[1].args[0] == "fake-key <Escape>"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Hint:" in captured.out
 
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
 def test_listen_for_hint_phonetic_fallback(
-    mock_qb, mock_sleep, mock_core_factory, capsys
+    mock_qb, mock_sleep, mock_core_factory, readlog
 ):
     """When parse_hint_number returns empty but parse_hint_numbers succeeds (defensive coding)."""
     # Note: In practice, since NUM_WORDS is a superset of HINT_NUMBERS,
@@ -779,14 +779,14 @@ def test_listen_for_hint_phonetic_fallback(
     assert mock_qb.call_count == 2
     assert mock_qb.call_args_list[0].args[0] == "hint-follow 0"
     assert mock_qb.call_args_list[1].args[0] == "fake-key <Escape>"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Phonetic:" in captured.out
 
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
 def test_listen_for_hint_audio_buffer_exception(
-    mock_qb, mock_sleep, mock_core_factory, capsys
+    mock_qb, mock_sleep, mock_core_factory, readlog
 ):
     """When clearing audio buffer raises exception, it is caught and ignored."""
     mock_core = mock_core_factory(
@@ -800,7 +800,7 @@ def test_listen_for_hint_audio_buffer_exception(
     # Should still work despite the exception
     assert mock_qb.called
     assert mock_qb.call_args.args[0] == "mode-leave"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Timeout - hints cancelled" in captured.out
 
 
@@ -808,7 +808,7 @@ def test_listen_for_hint_audio_buffer_exception(
 @patch.object(browser, "handle_browser_command")
 @patch.object(browser, "qb")
 def test_listen_for_hint_not_a_hint_pass_through(
-    mock_qb, mock_handle_cmd, mock_sleep, mock_core_factory, capsys
+    mock_qb, mock_handle_cmd, mock_sleep, mock_core_factory, readlog
 ):
     """When command is not a hint, it is passed to handle_browser_command."""
     mock_core = mock_core_factory(
@@ -821,7 +821,7 @@ def test_listen_for_hint_not_a_hint_pass_through(
     assert mock_qb.call_args.args[0] == "mode-leave"
     assert mock_handle_cmd.called
     assert mock_handle_cmd.call_args.args == ("go back", mock_core)
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Not a hint, trying as command" in captured.out
 
 
@@ -829,7 +829,7 @@ def test_listen_for_hint_not_a_hint_pass_through(
 
 
 @patch.object(browser, "handle_browser_command")
-def test_browser_mode_timeout_continue(mock_handle_cmd, mock_core_factory, capsys):
+def test_browser_mode_timeout_continue(mock_handle_cmd, mock_core_factory, readlog):
     """When wait_for_speech times out, browser_mode continues listening."""
     mock_core = mock_core_factory(
         wait_for_speech_values=[None, b"audio"], transcribe_values=["exit browser"]
@@ -839,14 +839,14 @@ def test_browser_mode_timeout_continue(mock_handle_cmd, mock_core_factory, capsy
 
     assert mock_core.speak.call_count == 1
     assert mock_core.speak.call_args.args[0] == "Browser"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "BROWSER MODE ACTIVE" in captured.out
     assert "BROWSER MODE EXIT" in captured.out
 
 
 @patch.object(browser, "handle_browser_command")
 def test_browser_mode_no_transcription_continue(
-    mock_handle_cmd, mock_core_factory, capsys
+    mock_handle_cmd, mock_core_factory, readlog
 ):
     """When transcribe returns None, browser_mode continues listening."""
     mock_core = mock_core_factory(
@@ -856,7 +856,7 @@ def test_browser_mode_no_transcription_continue(
 
     browser.browser_mode(mock_core)
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "BROWSER MODE EXIT" in captured.out
 
 
@@ -871,7 +871,7 @@ def test_browser_mode_no_transcription_continue(
     ],
 )
 @patch.object(browser, "handle_browser_command")
-def test_browser_mode_exit(mock_handle_cmd, exit_command, mock_core_factory, capsys):
+def test_browser_mode_exit(mock_handle_cmd, exit_command, mock_core_factory, readlog):
     """When exit browser command is spoken, browser_mode exits."""
     mock_core = mock_core_factory(
         wait_for_speech_values=[b"audio"], transcribe_values=[exit_command]
@@ -879,7 +879,7 @@ def test_browser_mode_exit(mock_handle_cmd, exit_command, mock_core_factory, cap
 
     browser.browser_mode(mock_core)
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "BROWSER MODE EXIT" in captured.out
     assert exit_command in captured.out
 
@@ -897,7 +897,7 @@ def test_browser_mode_exit(mock_handle_cmd, exit_command, mock_core_factory, cap
 )
 @patch.object(browser, "handle_browser_command")
 def test_browser_mode_grid_trigger(
-    mock_handle_cmd, grid_trigger, mock_core_factory, capsys
+    mock_handle_cmd, grid_trigger, mock_core_factory, readlog
 ):
     """When grid trigger word is detected, browser_mode exits to grid mode."""
     mock_core = mock_core_factory(
@@ -908,12 +908,12 @@ def test_browser_mode_grid_trigger(
 
     assert mock_core.route_command.call_count == 1
     assert mock_core.route_command.call_args.args[0] == grid_trigger
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "BROWSER MODE EXIT → GRID" in captured.out
 
 
 @patch.object(browser, "handle_browser_command", return_value=False)
-def test_browser_mode_unknown_command(mock_handle_cmd, mock_core_factory, capsys):
+def test_browser_mode_unknown_command(mock_handle_cmd, mock_core_factory, readlog):
     """When an unknown command is spoken, browser_mode prints unknown message."""
     mock_core = mock_core_factory(
         wait_for_speech_values=[b"audio1", b"audio2"],
@@ -922,13 +922,13 @@ def test_browser_mode_unknown_command(mock_handle_cmd, mock_core_factory, capsys
 
     browser.browser_mode(mock_core)
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "? Unknown: unknown command" in captured.out
 
 
 @patch.object(browser, "handle_browser_command")
 def test_browser_mode_audio_buffer_exception(
-    mock_handle_cmd, mock_core_factory, capsys
+    mock_handle_cmd, mock_core_factory, readlog
 ):
     """When clearing audio buffer raises exception, it is caught and ignored."""
     mock_core = mock_core_factory(
@@ -940,7 +940,7 @@ def test_browser_mode_audio_buffer_exception(
     browser.browser_mode(mock_core)
 
     # Should still work despite the exception
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "BROWSER MODE EXIT" in captured.out
 
 
@@ -967,7 +967,7 @@ def test_handle_browser_command_open_returns_none(mock_qb_open, mock_core):
 
 
 @patch.object(browser, "qb")
-def test_handle_browser_command_phonetic_hint_not_digit(mock_qb, mock_core, capsys):
+def test_handle_browser_command_phonetic_hint_not_digit(mock_qb, mock_core, readlog):
     """When looks_like_hint but phonetic parsing fails, returns None."""
     result = browser.handle_browser_command("xy", mock_core)
 
@@ -976,7 +976,7 @@ def test_handle_browser_command_phonetic_hint_not_digit(mock_qb, mock_core, caps
 
 
 @patch.object(browser, "qb")
-def test_handle_browser_command_phonetic_hint_parsing(mock_qb, mock_core, capsys):
+def test_handle_browser_command_phonetic_hint_parsing(mock_qb, mock_core, readlog):
     """When looks_like_hint and phonetic parsing succeeds, hint is followed."""
     # Use a short command with number words that looks like a hint
     result = browser.handle_browser_command("one", mock_core)
@@ -984,7 +984,7 @@ def test_handle_browser_command_phonetic_hint_parsing(mock_qb, mock_core, capsys
     assert result is True
     assert mock_qb.called
     assert mock_qb.call_args.args[0] == "hint-follow 1"
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "Phonetic parsed:" in captured.out
 
 
@@ -1002,7 +1002,7 @@ def _read_cfg(home):
     return (home / ".config" / "qutebrowser" / "config.py").read_text()
 
 
-def test_ensure_qutebrowser_config_fresh(fake_home, capsys):
+def test_ensure_qutebrowser_config_fresh(fake_home, readlog):
     """When the file is missing, both required lines are written."""
     browser.ensure_qutebrowser_config()
 
@@ -1010,15 +1010,15 @@ def test_ensure_qutebrowser_config_fresh(fake_home, capsys):
     assert "config.load_autoconfig(False)" in content
     assert "c.hints.chars = '0123456789'" in content
 
-    captured = capsys.readouterr()
-    assert "browser: wrote" in captured.err
+    captured = readlog()
+    assert "wrote" in captured.err
     assert "config.load_autoconfig(False)" in captured.err
 
 
-def test_ensure_qutebrowser_config_idempotent(fake_home, capsys):
+def test_ensure_qutebrowser_config_idempotent(fake_home, readlog):
     """A second call on an already-correct file is silent and doesn't rewrite."""
     browser.ensure_qutebrowser_config()
-    capsys.readouterr()  # discard the "wrote" message from the first call
+    readlog()  # discard the "wrote" message from the first call
 
     cfg = fake_home / ".config" / "qutebrowser" / "config.py"
     mtime_before = cfg.stat().st_mtime
@@ -1026,11 +1026,11 @@ def test_ensure_qutebrowser_config_idempotent(fake_home, capsys):
     browser.ensure_qutebrowser_config()
 
     assert cfg.stat().st_mtime == mtime_before
-    captured = capsys.readouterr()
+    captured = readlog()
     assert captured.err == ""
 
 
-def test_ensure_qutebrowser_config_appends_missing(fake_home, capsys):
+def test_ensure_qutebrowser_config_appends_missing(fake_home, readlog):
     """User content + one of our lines: we append only what's missing."""
     cfg = fake_home / ".config" / "qutebrowser" / "config.py"
     cfg.parent.mkdir(parents=True)
@@ -1045,8 +1045,8 @@ def test_ensure_qutebrowser_config_appends_missing(fake_home, capsys):
     assert "c.tabs.background = True" in content
     assert "c.hints.chars = '0123456789'" in content
 
-    captured = capsys.readouterr()
-    assert "browser: updated" in captured.err
+    captured = readlog()
+    assert "updated" in captured.err
     assert "c.hints.chars = '0123456789'" in captured.err
     # The other required line was already present — shouldn't be listed as added.
     assert "added: config.load_autoconfig" not in captured.err
@@ -1066,20 +1066,20 @@ def test_ensure_qutebrowser_config_no_trailing_newline(fake_home):
     assert "c.hints.chars = '0123456789'" in content
 
 
-def test_ensure_qutebrowser_config_mkdir_fails(fake_home, capsys):
+def test_ensure_qutebrowser_config_mkdir_fails(fake_home, readlog):
     """mkdir OSError routes to the polite note with all required lines."""
     with patch.object(browser.Path, "mkdir", side_effect=PermissionError("denied")):
         browser.ensure_qutebrowser_config()
 
-    captured = capsys.readouterr()
-    assert "browser: note:" in captured.err
+    captured = readlog()
+    assert "Please make sure your qutebrowser config includes" in captured.err
     assert "could not create" in captured.err
     # Lists both required lines since we don't know what's there.
     assert "config.load_autoconfig(False)" in captured.err
     assert "c.hints.chars = '0123456789'" in captured.err
 
 
-def test_ensure_qutebrowser_config_read_fails(fake_home, capsys):
+def test_ensure_qutebrowser_config_read_fails(fake_home, readlog):
     """read_text OSError routes to the polite note with all required lines."""
     cfg = fake_home / ".config" / "qutebrowser" / "config.py"
     cfg.parent.mkdir(parents=True)
@@ -1088,13 +1088,13 @@ def test_ensure_qutebrowser_config_read_fails(fake_home, capsys):
     with patch.object(browser.Path, "read_text", side_effect=PermissionError("nope")):
         browser.ensure_qutebrowser_config()
 
-    captured = capsys.readouterr()
-    assert "browser: note:" in captured.err
+    captured = readlog()
+    assert "Please make sure your qutebrowser config includes" in captured.err
     assert "could not read" in captured.err
     assert "config.load_autoconfig(False)" in captured.err
 
 
-def test_ensure_qutebrowser_config_write_fails(fake_home, capsys):
+def test_ensure_qutebrowser_config_write_fails(fake_home, readlog):
     """Read-only file: warning lists only the lines that still need adding."""
     cfg = fake_home / ".config" / "qutebrowser" / "config.py"
     cfg.parent.mkdir(parents=True)
@@ -1103,8 +1103,8 @@ def test_ensure_qutebrowser_config_write_fails(fake_home, capsys):
     with patch.object(browser.Path, "write_text", side_effect=PermissionError("ro")):
         browser.ensure_qutebrowser_config()
 
-    captured = capsys.readouterr()
-    assert "browser: note:" in captured.err
+    captured = readlog()
+    assert "Please make sure your qutebrowser config includes" in captured.err
     assert "is read-only" in captured.err
     # Only the still-missing line should be listed.
     assert "c.hints.chars = '0123456789'" in captured.err

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -21,43 +21,43 @@ def test_setup(mock_ensure):
 
 
 @patch("easyspeak.plugins.dictation.shutil.which", return_value=None)
-def test_ensure_gnome_accessibility_no_gsettings(mock_which, capsys):
+def test_ensure_gnome_accessibility_no_gsettings(mock_which, readlog):
     """No gsettings on PATH (non-GNOME): silent no-op."""
     dictation.ensure_gnome_accessibility()
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert captured.err == ""
 
 
 @patch("easyspeak.plugins.dictation.subprocess.run")
 @patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
-def test_ensure_gnome_accessibility_schema_missing(mock_which, mock_run, capsys):
+def test_ensure_gnome_accessibility_schema_missing(mock_which, mock_run, readlog):
     """gsettings present but schema lookup fails: silent no-op."""
     mock_run.return_value = Mock(returncode=1, stdout="")
 
     dictation.ensure_gnome_accessibility()
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert captured.err == ""
     mock_run.assert_called_once()  # only 'get' is attempted, no 'set'
 
 
 @patch("easyspeak.plugins.dictation.subprocess.run")
 @patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
-def test_ensure_gnome_accessibility_already_on(mock_which, mock_run, capsys):
+def test_ensure_gnome_accessibility_already_on(mock_which, mock_run, readlog):
     """Setting is already true: silent no-op, no 'set' call."""
     mock_run.return_value = Mock(returncode=0, stdout="true\n")
 
     dictation.ensure_gnome_accessibility()
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert captured.err == ""
     mock_run.assert_called_once()
 
 
 @patch("easyspeak.plugins.dictation.subprocess.run")
 @patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
-def test_ensure_gnome_accessibility_enables(mock_which, mock_run, capsys):
+def test_ensure_gnome_accessibility_enables(mock_which, mock_run, readlog):
     """Setting is false and 'set' succeeds: prints enabled message + re-login hint."""
     mock_run.side_effect = [
         Mock(returncode=0, stdout="false\n"),  # get
@@ -66,7 +66,7 @@ def test_ensure_gnome_accessibility_enables(mock_which, mock_run, capsys):
 
     dictation.ensure_gnome_accessibility()
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "enabled GNOME toolkit-accessibility" in captured.err
     assert "log out" in captured.err
     assert mock_run.call_count == 2
@@ -74,7 +74,7 @@ def test_ensure_gnome_accessibility_enables(mock_which, mock_run, capsys):
 
 @patch("easyspeak.plugins.dictation.subprocess.run")
 @patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
-def test_ensure_gnome_accessibility_set_fails(mock_which, mock_run, capsys):
+def test_ensure_gnome_accessibility_set_fails(mock_which, mock_run, readlog):
     """Setting is false but 'set' fails: prints WARNING."""
     mock_run.side_effect = [
         Mock(returncode=0, stdout="false\n"),  # get
@@ -83,18 +83,18 @@ def test_ensure_gnome_accessibility_set_fails(mock_which, mock_run, capsys):
 
     dictation.ensure_gnome_accessibility()
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert "WARNING" in captured.err
     assert "could not enable" in captured.err
 
 
 @patch("easyspeak.plugins.dictation.subprocess.run", side_effect=OSError("nope"))
 @patch("easyspeak.plugins.dictation.shutil.which", return_value="/usr/bin/gsettings")
-def test_ensure_gnome_accessibility_oserror(mock_which, mock_run, capsys):
+def test_ensure_gnome_accessibility_oserror(mock_which, mock_run, readlog):
     """subprocess.run raising OSError is swallowed silently."""
     dictation.ensure_gnome_accessibility()
 
-    captured = capsys.readouterr()
+    captured = readlog()
     assert captured.err == ""
 
 


### PR DESCRIPTION
Closes #64.

Replaces the ~90 ad-hoc `print()` calls across `src/` with module-level loggers, and puts the logging setup and CLI parsing in two small dedicated modules.

## Structure

- **`core/log.py`** — `resolve_level(verbose, quiet)` (CLI flags → `EASYSPEAK_LOG_LEVEL` → INFO) and `configure(level)` (handler on just the `easyspeak`/`plugins` loggers). Stdlib-only, so it's import-light.
- **`core/cli.py`** — `parse_args()` and the `run()` entry point: parse args → `log.configure(...)` → start `EasySpeak`. The console script and `python -m easyspeak.core` resolve to `cli:run`.

## Behaviour / decisions

- **Format — clean by default, richer on debug:**
  - At INFO and above, output is **message-only** (no level/timestamp prefixes), so the terminal looks exactly as it did with `print()`.
  - At **DEBUG** (`-v` / `EASYSPEAK_LOG_LEVEL=DEBUG`) every line is prefixed with its level (`%(levelname)s %(message)s`), and `configure()` emits a one-line summary of the resolved configuration on startup. Example:
    ```
    DEBUG logging configured: level=DEBUG, stderr, format='%(levelname)s %(message)s', loggers=easyspeak, plugins
    INFO Listening for wake word...
    🎤 Wake! (confidence: 0.87)   # at INFO+ this line has no prefix
    ```
  - Output goes to **stderr**; the level only gates which lines appear.
- **Verbosity:** `-v/--verbose`, `-q/--quiet`, and `EASYSPEAK_LOG_LEVEL` (CLI wins). Default INFO.
- **Levels:**
  - **INFO** — status and results
  - **DEBUG** — chatty per-frame and trace lines
  - **WARNING / ERROR** — failures
  - **`logger.exception`** — caught exceptions (with traceback)
- Lazy `%`-args throughout (no f-strings, per `G004`).
- **Library-friendly:** only the package loggers are configured (not root), addressing #64's library point and the stream-separation point relevant to #9.
- **Kept as `print()`:** the `help` command listing — an explicit user request that must show regardless of verbosity (`# noqa: T201`).
- The blanket `T201` ignore is dropped from `pyproject.toml`, so new stray `print()` calls are flagged.

## Tests

Log assertions read captured output via a small `readlog()` conftest adapter over `caplog`; package loggers are snapshot/restored per test. 859 unit tests pass at **100% coverage**; lint + formatter clean.
