### PR TITLE
Make dictation work: provide the AT-SPI backend and report failures honestly

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,21 @@
         # so the project is currently pinned to 3.12.
         python = pkgs.python312;
 
+        # The dictation plugin shells out to an AT-SPI helper that needs
+        # PyGObject + the AT-SPI typelib — which uv can't put in the app's
+        # venv (PyGObject isn't a wheel). So ship a dedicated interpreter that
+        # has it and point EASYSPEAK_ATSPI_PYTHON at it.
+        atspiPython = python.withPackages (ps: [ ps.pygobject3 ]);
+
+        # Typelibs the helper's `gi` imports resolve at runtime: GLib/GObject/
+        # Gio from glib, GIRepository from gobject-introspection, Atspi from
+        # at-spi2-core.
+        giTypelibPath = pkgs.lib.makeSearchPath "lib/girepository-1.0" [
+          pkgs.glib
+          pkgs.gobject-introspection
+          pkgs.at-spi2-core
+        ];
+
         # .git is stripped from the flake source, so setuptools_scm can't
         # infer a version. Derive a PEP 440 "local version" from whatever
         # the flake knows (clean rev > dirty rev > nothing).
@@ -45,6 +60,7 @@
           glib # libglib-2.0.so.0 + libgthread-2.0.so.0
           libGL # libGL.so.1
           libxcb # libxcb.so.1
+          at-spi2-core # libatspi.so.0 for the dictation helper's gi import
         ];
 
         # Tools the app shells out to (paplay, ffplay, piper, etc).
@@ -132,6 +148,10 @@
             export C_INCLUDE_PATH="${pkgs.portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
             export LIBRARY_PATH="${pkgs.portaudio}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
             export LD_LIBRARY_PATH='${pkgs.lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
+            # Dictation's AT-SPI helper runs in this PyGObject-equipped
+            # interpreter, with the typelibs it imports on GI_TYPELIB_PATH.
+            export EASYSPEAK_ATSPI_PYTHON='${atspiPython}/bin/python3'
+            export GI_TYPELIB_PATH='${giTypelibPath}'":''${GI_TYPELIB_PATH:-}"
 
             cd "$src_dir"
             # --with openwakeword: pyproject.toml leaves it commented out
@@ -173,6 +193,8 @@
             unset PYTHONPATH PYTHONHOME
 
             export LD_LIBRARY_PATH='${pkgs.lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
+            export EASYSPEAK_ATSPI_PYTHON='${atspiPython}/bin/python3'
+            export GI_TYPELIB_PATH='${giTypelibPath}'":''${GI_TYPELIB_PATH:-}"
             export CPPFLAGS="-I${pkgs.portaudio}/include ''${CPPFLAGS:-}"
             export LDFLAGS="-L${pkgs.portaudio}/lib -Wl,-rpath,${pkgs.portaudio}/lib ''${LDFLAGS:-}"
             export C_INCLUDE_PATH="${pkgs.portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"

--- a/src/plugins/_atspi_insert.py
+++ b/src/plugins/_atspi_insert.py
@@ -1,0 +1,101 @@
+"""Standalone AT-SPI caret-insertion helper.
+
+The dictation plugin runs this as a script (see ``dictation.atspi_python``) in
+an interpreter that has PyGObject and the AT-SPI typelib — which the app's own
+venv usually lacks. It is a real module rather than an embedded ``python3 -c``
+string so Ruff lints it and the unit tests can import and exercise it; an
+unlinted string is exactly how the earlier ``contextlib`` NameError slipped in.
+
+It communicates with the parent purely through stdout tokens:
+``OK`` (text inserted), ``NO_FOCUS`` (no editable field), ``NO_BACKEND``
+(PyGObject/AT-SPI not importable). Kept out of plugin discovery by the leading
+underscore in the filename.
+"""
+
+import contextlib
+import sys
+
+OK = "OK"
+NO_FOCUS = "NO_FOCUS"
+NO_BACKEND = "NO_BACKEND"
+
+MAX_DEPTH = 25
+BACKSPACE = chr(8)
+
+
+def load_atspi():
+    """Return PyGObject's ``Atspi`` namespace, or ``None`` if unavailable.
+
+    The detail of why it failed is written to stderr so the parent can log it.
+    """
+    try:
+        import gi
+
+        gi.require_version("Atspi", "2.0")
+        from gi.repository import Atspi
+    except (ImportError, ValueError) as exc:
+        sys.stderr.write(str(exc))
+        return None
+    return Atspi
+
+
+def find_focused_editable(atspi, obj, depth=0):
+    """Depth-first search for the focused, editable accessible under ``obj``."""
+    if depth > MAX_DEPTH:
+        return None
+    # AT-SPI nodes can raise while being queried (apps closing, slow a11y
+    # responses); skip a node that misbehaves rather than aborting the walk.
+    with contextlib.suppress(Exception):
+        state = obj.get_state_set()
+        if state.contains(atspi.StateType.FOCUSED) and state.contains(
+            atspi.StateType.EDITABLE
+        ):
+            return obj
+        for i in range(obj.get_child_count()):
+            found = find_focused_editable(atspi, obj.get_child_at_index(i), depth + 1)
+            if found:
+                return found
+    return None
+
+
+def insert_into(target, text):
+    """Type ``text`` into ``target`` at the caret, honouring backspaces."""
+    try:
+        pos = target.get_caret_offset()
+    except Exception:
+        pos = -1
+
+    for char in text:
+        if char == BACKSPACE:
+            if pos > 0:
+                target.delete_text(pos - 1, pos)
+                pos -= 1
+        else:
+            target.insert_text(pos, char, len(char.encode("utf-8")))
+            pos += 1
+
+
+def run(atspi, text):
+    """Insert ``text`` into the focused editable; return an OK/NO_FOCUS token."""
+    desktop = atspi.get_desktop(0)
+    for i in range(desktop.get_child_count()):
+        target = find_focused_editable(atspi, desktop.get_child_at_index(i))
+        if target:
+            insert_into(target, text)
+            return OK
+    return NO_FOCUS
+
+
+def main(argv):
+    """Entry point: load AT-SPI, insert argv[1], print a status token."""
+    atspi = load_atspi()
+    if atspi is None:
+        sys.stdout.write(NO_BACKEND + "\n")
+        return 0
+    text = argv[1] if len(argv) > 1 else ""
+    sys.stdout.write(run(atspi, text) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -3,9 +3,11 @@ Dictation Plugin - Voice to text via AT-SPI
 """
 
 import logging
+import os
 import re
 import shutil
 import subprocess
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -76,61 +78,53 @@ def setup(c):
     ensure_gnome_accessibility()
 
 
-ATSPI_INSERT_SCRIPT = """
-import gi
-gi.require_version('Atspi', '2.0')
-from gi.repository import Atspi
-import sys
+# insert_text() outcomes — kept distinct so the spoken feedback is accurate:
+# the text went in, no editable field was focused, or the AT-SPI backend
+# couldn't even start (no PyGObject/typelib, no accessibility bus).
+INSERTED = "inserted"
+NO_FOCUS = "no_focus"
+BACKEND_ERROR = "backend_error"
 
-text = sys.argv[1] if len(sys.argv) > 1 else ""
+# The AT-SPI logic lives in a sibling module run as a script in an interpreter
+# that has PyGObject (see atspi_python). It's a real file, not an embedded
+# string, so it gets linted and unit-tested.
+ATSPI_HELPER = str(Path(__file__).with_name("_atspi_insert.py"))
 
-def find_focused_editable(obj, depth=0):
-    if depth > 25:
-        return None
-    with contextlib.suppress(Exception):
-        state = obj.get_state_set()
-        if state.contains(Atspi.StateType.FOCUSED) and state.contains(
-            Atspi.StateType.EDITABLE
-        ):
-            return obj
-        for i in range(obj.get_child_count()):
-            result = find_focused_editable(obj.get_child_at_index(i), depth + 1)
-            if result:
-                return result
-    return None
 
-desktop = Atspi.get_desktop(0)
-for i in range(desktop.get_child_count()):
-    app = desktop.get_child_at_index(i)
-    result = find_focused_editable(app)
-    if result:
-        try:
-            pos = result.get_caret_offset()
-        except Exception:
-            pos = -1
+def atspi_python():
+    """Path to the interpreter that runs the AT-SPI helper.
 
-        # Handle special characters
-        for char in text:
-            if char == chr(8):  # backspace
-                if pos > 0:
-                    result.delete_text(pos - 1, pos)
-                    pos -= 1
-            else:
-                result.insert_text(pos, char, len(char.encode('utf-8')))
-                pos += 1
-
-        print("OK")
-        sys.exit(0)
-
-print("NO_FOCUS")
-"""
+    The helper needs PyGObject and the AT-SPI typelib, which the app's own
+    venv usually lacks. ``EASYSPEAK_ATSPI_PYTHON`` lets the packaging point at
+    an interpreter that has them (the Nix flake sets it); otherwise we fall
+    back to the system ``python3``, where distro packages like ``python3-gi``
+    typically live.
+    """
+    return os.environ.get("EASYSPEAK_ATSPI_PYTHON") or "python3"
 
 
 def insert_text(text):
-    """Insert text via AT-SPI"""
-    cmd = ["python3", "-c", ATSPI_INSERT_SCRIPT, text]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    return "OK" in result.stdout
+    """Insert text via AT-SPI.
+
+    Returns one of INSERTED, NO_FOCUS or BACKEND_ERROR so the caller can give
+    feedback that matches the real cause instead of always blaming focus.
+    """
+    cmd = [atspi_python(), ATSPI_HELPER, text]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        logger.warning("dictation backend could not start: %s", exc)
+        return BACKEND_ERROR
+
+    if "OK" in result.stdout:
+        return INSERTED
+    if "NO_BACKEND" in result.stdout or result.returncode != 0:
+        logger.warning(
+            "dictation backend unavailable (PyGObject/AT-SPI missing): %s",
+            result.stderr.strip() or "no detail",
+        )
+        return BACKEND_ERROR
+    return NO_FOCUS
 
 
 def format_text(text):
@@ -283,8 +277,12 @@ def handle(cmd, core):
                 if formatted[0].isalpha():
                     formatted = " " + formatted
 
-                if not insert_text(formatted):
+                status = insert_text(formatted)
+                if status == NO_FOCUS:
                     core.speak("No text field focused.")
+                    return True
+                if status == BACKEND_ERROR:
+                    core.speak("Dictation isn't set up on this system.")
                     return True
 
         return True

--- a/tests/unit/plugins/test_atspi_insert.py
+++ b/tests/unit/plugins/test_atspi_insert.py
@@ -1,0 +1,229 @@
+"""Tests for the standalone AT-SPI caret-insertion helper."""
+
+import sys
+import types
+
+from easyspeak.plugins import _atspi_insert as helper
+
+
+class FakeState:
+    """A minimal AT-SPI state set."""
+
+    def __init__(self, states):
+        self._states = set(states)
+
+    def contains(self, state):
+        return state in self._states
+
+
+class FakeAccessible:
+    """A minimal AT-SPI accessible node for tree-walk tests."""
+
+    def __init__(self, states=(), children=(), caret=0, *, raises=False):
+        self._state = FakeState(states)
+        self._children = list(children)
+        self.caret = caret
+        self.raises = raises
+        self.inserted = []
+        self.deleted = []
+
+    def get_state_set(self):
+        if self.raises:
+            raise RuntimeError("boom")
+        return self._state
+
+    def get_child_count(self):
+        return len(self._children)
+
+    def get_child_at_index(self, i):
+        return self._children[i]
+
+    def get_caret_offset(self):
+        if self.caret is None:
+            raise RuntimeError("no caret")
+        return self.caret
+
+    def insert_text(self, pos, char, length):
+        self.inserted.append((pos, char, length))
+
+    def delete_text(self, start, end):
+        self.deleted.append((start, end))
+
+
+class FakeAtspi:
+    """Stand-in for the gi ``Atspi`` namespace."""
+
+    class StateType:
+        FOCUSED = "FOCUSED"
+        EDITABLE = "EDITABLE"
+
+    def __init__(self, desktop):
+        self._desktop = desktop
+
+    def get_desktop(self, _index):
+        return self._desktop
+
+
+# --- load_atspi ---
+
+
+def test_load_atspi_missing(monkeypatch, capsys):
+    """Without PyGObject importable, load_atspi returns None and explains why.
+
+    ``gi`` is forced absent so the test is hermetic — it must not depend on
+    whether PyGObject happens to be installed in the test interpreter.
+    """
+    monkeypatch.setitem(sys.modules, "gi", None)
+
+    result = helper.load_atspi()
+
+    assert result is None
+    assert capsys.readouterr().err != ""
+
+
+def test_load_atspi_success(monkeypatch):
+    """With gi importable, load_atspi returns the Atspi namespace."""
+    sentinel = object()
+    fake_gi = types.ModuleType("gi")
+    fake_gi.require_version = lambda *args: None
+    fake_repo = types.ModuleType("gi.repository")
+    fake_repo.Atspi = sentinel
+    monkeypatch.setitem(sys.modules, "gi", fake_gi)
+    monkeypatch.setitem(sys.modules, "gi.repository", fake_repo)
+
+    assert helper.load_atspi() is sentinel
+
+
+# --- find_focused_editable ---
+
+
+def test_find_focused_editable_direct():
+    """A node that is itself focused and editable is returned."""
+    node = FakeAccessible(states=["FOCUSED", "EDITABLE"])
+
+    assert helper.find_focused_editable(FakeAtspi, node) is node
+
+
+def test_find_focused_editable_nested():
+    """The search recurses into children."""
+    target = FakeAccessible(states=["FOCUSED", "EDITABLE"])
+    root = FakeAccessible(children=[FakeAccessible(), target])
+
+    assert helper.find_focused_editable(FakeAtspi, root) is target
+
+
+def test_find_focused_editable_none():
+    """No focused-editable anywhere yields None."""
+    root = FakeAccessible(children=[FakeAccessible(states=["FOCUSED"])])
+
+    assert helper.find_focused_editable(FakeAtspi, root) is None
+
+
+def test_find_focused_editable_depth_limit():
+    """Recursion stops past MAX_DEPTH."""
+    node = FakeAccessible(states=["FOCUSED", "EDITABLE"])
+
+    assert (
+        helper.find_focused_editable(FakeAtspi, node, depth=helper.MAX_DEPTH + 1)
+        is None
+    )
+
+
+def test_find_focused_editable_swallows_errors():
+    """An accessible that raises is treated as not-a-match, not a crash."""
+    node = FakeAccessible(raises=True)
+
+    assert helper.find_focused_editable(FakeAtspi, node) is None
+
+
+# --- insert_into ---
+
+
+def test_insert_into_types_characters():
+    """Plain characters are inserted at the advancing caret."""
+    node = FakeAccessible(caret=0)
+
+    helper.insert_into(node, "hi")
+
+    assert node.inserted == [(0, "h", 1), (1, "i", 1)]
+
+
+def test_insert_into_backspace_deletes():
+    """A backspace deletes the character before the caret."""
+    node = FakeAccessible(caret=2)
+
+    helper.insert_into(node, helper.BACKSPACE)
+
+    assert node.deleted == [(1, 2)]
+
+
+def test_insert_into_backspace_at_start_is_noop():
+    """A backspace with the caret at position 0 deletes nothing."""
+    node = FakeAccessible(caret=0)
+
+    helper.insert_into(node, helper.BACKSPACE)
+
+    assert node.deleted == []
+
+
+def test_insert_into_unknown_caret_starts_at_minus_one():
+    """When the caret offset can't be read, insertion still proceeds."""
+    node = FakeAccessible(caret=None)
+
+    helper.insert_into(node, "x")
+
+    assert node.inserted == [(-1, "x", 1)]
+
+
+# --- run / main ---
+
+
+def test_run_inserts_into_focused_field():
+    """run finds the focused editable across apps and reports OK."""
+    target = FakeAccessible(states=["FOCUSED", "EDITABLE"], caret=0)
+    desktop = FakeAccessible(children=[FakeAccessible(), target])
+
+    assert helper.run(FakeAtspi(desktop), "hi") == helper.OK
+    assert target.inserted == [(0, "h", 1), (1, "i", 1)]
+
+
+def test_run_no_focus():
+    """run reports NO_FOCUS when nothing editable is focused."""
+    desktop = FakeAccessible(children=[FakeAccessible()])
+
+    assert helper.run(FakeAtspi(desktop), "hi") == helper.NO_FOCUS
+
+
+def test_main_no_backend(monkeypatch, capsys):
+    """main prints NO_BACKEND when AT-SPI can't be loaded."""
+    monkeypatch.setitem(sys.modules, "gi", None)
+
+    rc = helper.main(["_atspi_insert.py", "hi"])
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == helper.NO_BACKEND
+
+
+def test_main_inserts(monkeypatch, capsys):
+    """main loads AT-SPI and prints the run() status token."""
+    target = FakeAccessible(states=["FOCUSED", "EDITABLE"], caret=0)
+    desktop = FakeAccessible(children=[target])
+    monkeypatch.setattr(helper, "load_atspi", lambda: FakeAtspi(desktop))
+
+    rc = helper.main(["_atspi_insert.py", "hi"])
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == helper.OK
+
+
+def test_main_defaults_to_empty_text(monkeypatch, capsys):
+    """With no text argument main inserts an empty string and reports OK."""
+    target = FakeAccessible(states=["FOCUSED", "EDITABLE"], caret=0)
+    desktop = FakeAccessible(children=[target])
+    monkeypatch.setattr(helper, "load_atspi", lambda: FakeAtspi(desktop))
+
+    rc = helper.main(["_atspi_insert.py"])
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == helper.OK
+    assert target.inserted == []

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -209,37 +209,88 @@ def test_format_text_edge_cases(input_text, expected_output):
     assert result == expected_output
 
 
-@patch("subprocess.run", return_value=Mock(stdout="OK\n", stderr=""))
-def test_insert_text_success(mock_run):
-    """When text insertion succeeds the result should be True."""
+@patch("subprocess.run", return_value=Mock(returncode=0, stdout="OK\n", stderr=""))
+def test_insert_text_success(mock_run, monkeypatch):
+    """When text insertion succeeds the result should be INSERTED.
+
+    EASYSPEAK_ATSPI_PYTHON is cleared so the default-interpreter fallback is
+    what's asserted, regardless of the environment the tests run in (the Nix
+    dev shell exports it).
+    """
+    monkeypatch.delenv("EASYSPEAK_ATSPI_PYTHON", raising=False)
+
     result = dictation.insert_text("Hello world")
 
-    assert result is True
+    assert result == dictation.INSERTED
     assert mock_run.call_count == 1
     call_args = mock_run.call_args.args[0]
     assert call_args[0] == "python3"
-    assert call_args[1] == "-c"
-    assert call_args[2] == dictation.ATSPI_INSERT_SCRIPT
-    assert call_args[3] == "Hello world"
+    assert call_args[1] == dictation.ATSPI_HELPER
+    assert call_args[1].endswith("_atspi_insert.py")
+    assert call_args[2] == "Hello world"
 
 
-@patch("subprocess.run", return_value=Mock(stdout="NO_FOCUS\n", stderr=""))
+@patch(
+    "subprocess.run", return_value=Mock(returncode=0, stdout="NO_FOCUS\n", stderr="")
+)
 def test_insert_text_no_focus(mock_run):
-    """When no text field is focused the result should be False."""
+    """When no text field is focused the result should be NO_FOCUS."""
     result = dictation.insert_text("Hello world")
 
-    assert result is False
+    assert result == dictation.NO_FOCUS
 
 
-@patch("subprocess.run", return_value=Mock(stdout="OK\n", stderr=""))
+@patch(
+    "subprocess.run",
+    return_value=Mock(returncode=0, stdout="NO_BACKEND\n", stderr="No module named gi"),
+)
+def test_insert_text_backend_missing(mock_run, readlog):
+    """When the helper reports a missing backend the result is BACKEND_ERROR."""
+    result = dictation.insert_text("Hello world")
+
+    assert result == dictation.BACKEND_ERROR
+    assert "backend unavailable" in readlog().err
+
+
+@patch(
+    "subprocess.run",
+    return_value=Mock(returncode=1, stdout="", stderr="boom"),
+)
+def test_insert_text_helper_crash(mock_run, readlog):
+    """A non-zero exit from the helper is treated as a backend error."""
+    result = dictation.insert_text("Hello world")
+
+    assert result == dictation.BACKEND_ERROR
+    assert "boom" in readlog().err
+
+
+@patch("subprocess.run", side_effect=OSError("no python3"))
+def test_insert_text_interpreter_missing(mock_run, readlog):
+    """When the interpreter can't even launch the result is BACKEND_ERROR."""
+    result = dictation.insert_text("Hello world")
+
+    assert result == dictation.BACKEND_ERROR
+    assert "could not start" in readlog().err
+
+
+@patch.dict("os.environ", {"EASYSPEAK_ATSPI_PYTHON": "/opt/atspi/bin/python3"})
+@patch("subprocess.run", return_value=Mock(returncode=0, stdout="OK\n", stderr=""))
+def test_insert_text_uses_configured_interpreter(mock_run):
+    """EASYSPEAK_ATSPI_PYTHON overrides the interpreter the helper runs in."""
+    dictation.insert_text("Hello world")
+
+    assert mock_run.call_args.args[0][0] == "/opt/atspi/bin/python3"
+
+
+@patch("subprocess.run", return_value=Mock(returncode=0, stdout="OK\n", stderr=""))
 def test_insert_text_empty_string(mock_run):
-    """When inserting an empty string the result should be True."""
+    """When inserting an empty string the result should be INSERTED."""
     result = dictation.insert_text("")
 
-    assert result is True
+    assert result == dictation.INSERTED
     assert mock_run.call_count == 1
     call_args = mock_run.call_args.args[0]
-    assert call_args[3] == ""
+    assert call_args[2] == ""
 
 
 @patch("easyspeak.plugins.dictation.insert_text")
@@ -304,7 +355,7 @@ def test_handle_dictation_mode_no_space_before_punctuation(
     assert mock_insert.call_args.args == (".",)
 
 
-@patch("easyspeak.plugins.dictation.insert_text", return_value=False)
+@patch("easyspeak.plugins.dictation.insert_text", return_value=dictation.NO_FOCUS)
 @patch("easyspeak.plugins.dictation.format_text", return_value="Hello")
 def test_handle_dictation_mode_no_focus(mock_format, mock_insert, mock_core_with_audio):
     """When no text field is focused a warning should be spoken."""
@@ -314,6 +365,22 @@ def test_handle_dictation_mode_no_focus(mock_format, mock_insert, mock_core_with
 
     assert result is True
     assert ("No text field focused.",) in [
+        call.args for call in mock_core_with_audio.speak.call_args_list
+    ]
+
+
+@patch("easyspeak.plugins.dictation.insert_text", return_value=dictation.BACKEND_ERROR)
+@patch("easyspeak.plugins.dictation.format_text", return_value="Hello")
+def test_handle_dictation_mode_backend_error(
+    mock_format, mock_insert, mock_core_with_audio
+):
+    """When the AT-SPI backend is unavailable a setup hint should be spoken."""
+    mock_core_with_audio.transcribe = Mock(return_value="some text")
+
+    result = dictation.handle("notes", mock_core_with_audio)
+
+    assert result is True
+    assert ("Dictation isn't set up on this system.",) in [
         call.args for call in mock_core_with_audio.speak.call_args_list
     ]
 


### PR DESCRIPTION
Refs #67 — fixes the dictation bug only; **keyboard activation stays open** on #67 (or a follow-up). Supersedes the original #69 scope (the `contextlib` NameError), which is folded into this change.

## The bug

The "notes" feature almost always answered *"No text field focused."* — but that was usually misreporting the cause. The AT-SPI helper that inserts text runs in a **fresh interpreter** via `python3`, which on Nix (and many setups) has no PyGObject. So the embedded script crashed on `import gi`, `insert_text()` saw no `OK`, and reported it as a focus problem. There was no way to tell a real no-focus from a missing backend.

## Changes

- **Packaging (`flake.nix`)** — ship a PyGObject-equipped interpreter (`atspiPython`) and point `EASYSPEAK_ATSPI_PYTHON` at it, with the AT-SPI/GLib typelibs on `GI_TYPELIB_PATH` and `libatspi` on `LD_LIBRARY_PATH`, in both the app runner and the dev shell. Verified: `import Atspi` now succeeds through the configured interpreter.
- **Honest feedback** — `insert_text()` distinguishes `INSERTED` / `NO_FOCUS` / `BACKEND_ERROR`. A genuine no-focus still says *"No text field focused."*; a missing/broken backend says *"Dictation isn't set up on this system."* and logs the underlying detail.
- **Configurable interpreter** — `EASYSPEAK_ATSPI_PYTHON` overrides the helper interpreter; otherwise it falls back to the system `python3` (where distro `python3-gi` lives). This keeps the door open to running the whole app under a system Python later — then the helper is just that same interpreter.
- **No more unlinted code-in-a-string** — the embedded `python3 -c` script is extracted into a real, Ruff-linted and unit-tested module (`_atspi_insert.py`). The unlinted string is exactly how the earlier `contextlib` NameError got in — that fix is folded in here too.

## Tests

- New `tests/unit/plugins/test_atspi_insert.py` exercises the helper with a fake AT-SPI tree (focus search, caret insertion, backspace, backend-missing).
- `dictation` tests updated for the status-based API + backend-error branch.
- 100% coverage on both `dictation.py` and `_atspi_insert.py`; full unit suite green; Ruff clean.