### PR TITLE
feat(core): silent (keyboard) hold-to-dictate activation

### DIFF
--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -30,6 +30,10 @@ instance and use its small public API (`speak`, `host_run`, `transcribe`,
 
 ::: core.tray
 
+## core.hotkey
+
+::: core.hotkey
+
 ## core.mediakeys
 
 ::: core.mediakeys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ keywords = [
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
 dependencies = [
+  # Prebuilt wheel (provides `import evdev`) for raw /dev/input hold-to-dictate;
+  # avoids the source build's kernel-header requirement. Linux-only by nature.
+  "evdev-binary>=1.7 ; sys_platform == 'linux'",
   "faster-whisper>=1.2.1",
   "jeepney>=0.9",
   "numpy>=2.2.6",

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -21,6 +21,19 @@ SILENCE_DURATION = 0.3
 MISUNDERSTAND_GRACE = 4.0  # Seconds to ignore repeat misses after feedback
 FOLLOWUP_IDLE_ROUNDS = 2  # Quiet listens tolerated before a command session ends
 
+# --- Keyboard (silent) activation ---
+# Hold this combo to dictate without the wake word; release to stop. Accepts the
+# aliases ctrl/shift/alt/super or raw evdev key names, joined with '+'. Needs
+# read access to /dev/input (be in the 'input' group). Set EASYSPEAK_HOTKEY=0
+# to turn the feature off.
+HOTKEY_COMBO = os.environ.get("EASYSPEAK_HOTKEY_COMBO", "ctrl+shift")
+HOTKEY_ENABLED = os.environ.get("EASYSPEAK_HOTKEY", "1").lower() not in (
+    "0",
+    "false",
+    "no",
+    "off",
+)
+
 # --- Models ---
 PIPER_MODEL = os.environ.get(
     "EASYSPEAK_PIPER_MODEL",

--- a/src/core/hotkey.py
+++ b/src/core/hotkey.py
@@ -1,0 +1,231 @@
+"""Hold-to-dictate keyboard activation via evdev (the silent-activation path).
+
+On Wayland an ordinary process can't grab global keys, and only raw evdev
+events from ``/dev/input`` expose key *release* — which "hold the keys to
+dictate, release to stop" needs. This listener reads every keyboard device in a
+background thread and tracks whether a configured modifier combo (default
+Ctrl+Shift) is fully held, so the audio loop can start dictation on press and
+end it the moment the keys come up.
+
+It is best-effort: if python-evdev isn't installed or ``/dev/input`` isn't
+readable (the user isn't in the ``input`` group), the listener logs how to
+enable it and stays inert, so the daemon runs normally without the hotkey.
+"""
+
+import contextlib
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# How long select() blocks per cycle, so stop() is honoured promptly.
+POLL_TIMEOUT = 0.5
+
+# Friendly modifier name -> the evdev key names that satisfy it (left OR right),
+# so "ctrl+shift" matches whichever Ctrl and Shift the user happens to hold.
+_MODIFIER_ALIASES = {
+    "ctrl": ("KEY_LEFTCTRL", "KEY_RIGHTCTRL"),
+    "control": ("KEY_LEFTCTRL", "KEY_RIGHTCTRL"),
+    "shift": ("KEY_LEFTSHIFT", "KEY_RIGHTSHIFT"),
+    "alt": ("KEY_LEFTALT", "KEY_RIGHTALT"),
+    "super": ("KEY_LEFTMETA", "KEY_RIGHTMETA"),
+    "meta": ("KEY_LEFTMETA", "KEY_RIGHTMETA"),
+    "win": ("KEY_LEFTMETA", "KEY_RIGHTMETA"),
+}
+
+
+def parse_combo(spec: str) -> tuple[frozenset[str], ...]:
+    """Parse a ``'+'``-separated combo string into groups of accepted key names.
+
+    Each element becomes a group of evdev key names of which any one satisfies
+    that part of the combo, so ``"ctrl+shift"`` matches either Ctrl together
+    with either Shift. Names that aren't known aliases fall through as a single
+    literal evdev key name (``"rightctrl"`` -> ``"KEY_RIGHTCTRL"``) so less
+    common combos still work.
+
+    Args:
+        spec: A combo such as ``"ctrl+shift"`` or ``"super+space"``.
+
+    Returns:
+        A tuple of frozensets, one per combo element; the combo is held when
+        every group has at least one of its keys down.
+    """
+    groups = []
+    for part in spec.split("+"):
+        name = part.strip().lower()
+        if not name:
+            continue
+        if name in _MODIFIER_ALIASES:
+            groups.append(frozenset(_MODIFIER_ALIASES[name]))
+        else:
+            key = name.upper()
+            if not key.startswith("KEY_"):
+                key = "KEY_" + key
+            groups.append(frozenset((key,)))
+    return tuple(groups)
+
+
+class HotkeyListener:
+    """Track whether a key combo is held, off a background evdev reader.
+
+    The audio loop calls :meth:`take_activation` once per iteration to learn
+    when the combo was just pressed, then drives a dictation session gated on
+    :meth:`is_held` so releasing the keys ends it. All evdev/threading state is
+    kept behind a lock; the event-processing logic in :meth:`_process` is pure
+    and the I/O lives in :meth:`_grab_devices`/:meth:`_drain`, so the behaviour
+    is unit-testable without a real keyboard.
+    """
+
+    def __init__(self, combo="ctrl+shift", enabled=True):
+        """Set up the listener for ``combo`` (e.g. ``"ctrl+shift"``).
+
+        An unparseable or empty combo, or ``enabled=False``, leaves the
+        listener disabled so :meth:`start` is a no-op.
+        """
+        self._spec = combo
+        self._groups = parse_combo(combo)
+        self._enabled = enabled and bool(self._groups)
+        self._pressed = set()  # combo keys currently held
+        self._held = False  # whole combo satisfied
+        self._activation = False  # rising edge, consumed by take_activation()
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = None
+        self._devices = []
+
+    # --- audio-loop facing API ---
+
+    def is_held(self):
+        """Return whether the full combo is currently held."""
+        with self._lock:
+            return self._held
+
+    def take_activation(self):
+        """Return True once per press of the combo, clearing the edge.
+
+        The audio loop polls this each iteration; a True means "the user just
+        pressed the combo — start dictation now".
+        """
+        with self._lock:
+            fired = self._activation
+            self._activation = False
+            return fired
+
+    # --- lifecycle ---
+
+    def start(self):
+        """Begin watching the keyboard, unless disabled or no device is readable.
+
+        Logs and stays inert (no thread) when the feature is turned off, evdev
+        is missing, or ``/dev/input`` can't be read, so the daemon runs normally
+        either way.
+        """
+        if not self._enabled:
+            logger.debug("Keyboard activation disabled.")
+            return
+        self._devices = self._grab_devices()
+        if not self._devices:
+            return
+        logger.info("Hold %s to dictate (silent activation).", self._spec)
+        self._thread = threading.Thread(
+            target=self._run, name="easyspeak-hotkey", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self):
+        """Stop the reader thread and release the keyboard devices."""
+        self._stop.set()
+        for device in self._devices:
+            with contextlib.suppress(Exception):
+                device.close()
+        self._devices = []
+
+    # --- evdev I/O (kept thin so the logic above stays testable) ---
+
+    def _grab_devices(self):
+        """Open every readable keyboard device, or return [] if unavailable.
+
+        Missing python-evdev or an unreadable ``/dev/input`` (no ``input`` group
+        membership) is reported with how to fix it, then treated as "no hotkey".
+        """
+        try:
+            import evdev
+        except ImportError:
+            logger.info(
+                "python-evdev not installed; keyboard activation disabled. "
+                "Install the 'evdev' package to enable hold-to-dictate."
+            )
+            return []
+
+        devices = []
+        for path in evdev.list_devices():
+            try:
+                device = evdev.InputDevice(path)
+            except OSError:
+                continue
+            if evdev.ecodes.EV_KEY in device.capabilities():
+                devices.append(device)
+
+        if not devices:
+            logger.warning(
+                "No readable keyboard for hotkey activation. Add yourself to the "
+                "'input' group (sudo usermod -aG input $USER) and re-login to "
+                "enable hold-to-dictate."
+            )
+        return devices
+
+    def _run(self):
+        """Select across the keyboard devices and feed key events to _process."""
+        import select
+
+        fd_map = {device.fd: device for device in self._devices}
+        while not self._stop.is_set():
+            readable, _, _ = select.select(list(fd_map), [], [], POLL_TIMEOUT)
+            for fd in readable:
+                self._drain(fd_map[fd])
+
+    def _drain(self, device):
+        """Process all currently-available key events from one device."""
+        try:
+            events = list(device.read())
+        except OSError:
+            return  # device unplugged mid-read; the others keep working
+        for event in events:
+            name = self._event_keyname(event)
+            if name is not None:
+                self._process(name, event.value)
+
+    def _event_keyname(self, event):
+        """Return the evdev key name for a key event, or None if not a key.
+
+        ``ecodes.KEY[code]`` is a list when a code has aliases; the first name
+        is the canonical one and the only form our combos use.
+        """
+        import evdev
+
+        if event.type != evdev.ecodes.EV_KEY:
+            return None
+        name = evdev.ecodes.KEY.get(event.code)
+        if isinstance(name, (list, tuple)):
+            name = name[0]
+        return name
+
+    def _process(self, keyname, value):
+        """Update held state from one key event (value: 0=up, 1=down, 2=repeat).
+
+        Only keys that belong to the combo move the state. The rising edge to
+        "fully held" arms :meth:`take_activation`; releasing any key clears the
+        held state so the dictation session ends.
+        """
+        if not any(keyname in group for group in self._groups):
+            return
+        pressed = value != 0
+        with self._lock:
+            if pressed:
+                self._pressed.add(keyname)
+            else:
+                self._pressed.discard(keyname)
+            held = all(self._pressed & group for group in self._groups)
+            if held and not self._held:
+                self._activation = True
+            self._held = held

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -22,6 +22,8 @@ from openwakeword.model import Model as WakeWordModel
 from .config import (
     COMMAND_PROMPT,
     FOLLOWUP_IDLE_ROUNDS,
+    HOTKEY_COMBO,
+    HOTKEY_ENABLED,
     MISUNDERSTAND_GRACE,
     SILENCE_DURATION,
     SILENCE_THRESHOLD,
@@ -34,6 +36,7 @@ from .config import (
     load_whisper_model,
 )
 from .gnome_extension import ensure_extension
+from .hotkey import HotkeyListener
 from .speech import SpeechPipeline, suppressed_c_stderr
 from .tray import Tray, TrayAction
 
@@ -72,6 +75,10 @@ class EasySpeak:
         self.speech = SpeechPipeline()
         # GNOME panel indicator: owns the icon and the asleep lifecycle.
         self.tray = Tray(speak=self.speak)
+        # Hold-to-dictate keyboard activation; the dictation plugin registers
+        # the session to run while the combo is held (see register_push_to_talk).
+        self.hotkey = HotkeyListener(HOTKEY_COMBO, HOTKEY_ENABLED)
+        self._push_to_talk = None
 
     # --- Utilities for plugins ---
 
@@ -112,6 +119,16 @@ class EasySpeak:
         and speak, first.
         """
         self.tray.request_sleep()
+
+    def register_push_to_talk(self, handler):
+        """Register the dictation session the hotkey runs while its combo is held.
+
+        Plugin-facing: the dictation plugin registers here in its setup() so core
+        can drive keyboard (silent) activation without importing a plugin
+        directly. ``handler`` takes one ``should_continue`` predicate and runs
+        until it returns False (the keys are released).
+        """
+        self._push_to_talk = handler
 
     # --- Plugin management ---
 
@@ -277,16 +294,20 @@ class EasySpeak:
         """Return True if the audio chunk's mean amplitude is below the threshold."""
         return np.abs(audio_chunk).mean() < SILENCE_THRESHOLD
 
-    def record_until_silence(self):
+    def record_until_silence(self, should_continue=None):
         """Record mic audio until a short silence, capped at five seconds.
 
-        Returns the captured PCM bytes. Plugin-facing.
+        Returns the captured PCM bytes. Plugin-facing. ``should_continue``
+        (used by push-to-talk) lets a key release cut the recording short
+        instead of waiting out the silence window.
         """
         frames = []
         silent_chunks = 0
         chunks_needed = int(SILENCE_DURATION * 16000 / 1600)
 
         for i in range(int(5 * 16000 / 1600)):
+            if should_continue is not None and not should_continue():
+                break
             pcm = self.stream.read(1600, exception_on_overflow=False)
             frames.append(pcm)
 
@@ -300,13 +321,16 @@ class EasySpeak:
 
         return b"".join(frames)
 
-    def wait_for_speech(self, timeout=5):
+    def wait_for_speech(self, timeout=5, should_continue=None):
         """Block until speech is heard, returning its first PCM chunk.
 
         Returns None if nothing is heard within ``timeout`` seconds.
-        Plugin-facing.
+        Plugin-facing. ``should_continue`` (used by push-to-talk) returns None
+        early once it goes False, so a key release ends the wait.
         """
         for _ in range(int(timeout * 16000 / 1600)):
+            if should_continue is not None and not should_continue():
+                return None
             pcm = self.stream.read(1600, exception_on_overflow=False)
             if not self.is_silence(np.frombuffer(pcm, dtype=np.int16)):
                 return pcm
@@ -364,6 +388,24 @@ class EasySpeak:
         """
         self.speech.drain()
         self.flush_stream()
+
+    def _run_push_to_talk(self):
+        """Run a hotkey-triggered dictation session for as long as the keys are held.
+
+        Triggered from the main loop when the silent-activation combo fires.
+        Acknowledges with the wake chime — but speaks no prompt, this being the
+        *silent* path — then hands off to the registered dictation handler,
+        gating it on the still-held key state so releasing the keys ends it.
+        Warns and does nothing if no handler is registered (e.g. the dictation
+        plugin didn't load).
+        """
+        if self._push_to_talk is None:
+            logger.warning("Hotkey pressed but no dictation handler is registered.")
+            return
+        logger.info("⌨️  Hotkey dictation")
+        self._reset_detector()
+        self._play_wake_chime()
+        self._push_to_talk(self.hotkey.is_held)
 
     def _capture_command_session(self):
         """Capture and route commands after a wake, staying open for follow-ups.
@@ -464,6 +506,9 @@ class EasySpeak:
             self._open_stream()
 
             self.tray.started()
+            # Start keyboard (silent) activation; no-op if disabled or no
+            # /dev/input access. Plugins have registered their handlers by now.
+            self.hotkey.start()
             logger.info("Listening for wake word...")
             audio_buffer = []
 
@@ -474,6 +519,14 @@ class EasySpeak:
                 if action is TrayAction.QUIT:
                     break
                 if action is TrayAction.RESUME:
+                    self._reset_detector()
+                    audio_buffer = []
+                    logger.info("Listening for wake word...")
+                    continue
+
+                # Keyboard activation bypasses the wake word: dictate while held.
+                if self.hotkey.take_activation():
+                    self._run_push_to_talk()
                     self._reset_detector()
                     audio_buffer = []
                     logger.info("Listening for wake word...")
@@ -512,6 +565,7 @@ class EasySpeak:
         finally:
             # Hide the indicator so the daemon's exit doesn't leave a stale icon.
             self.tray.stopped()
+            self.hotkey.stop()
             self.speech.drain()
             if self.stream is not None:
                 self.stream.stop_stream()

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -75,6 +75,12 @@ def setup(c):
     global core
     core = c
     ensure_gnome_accessibility()
+    # Offer dictation to the keyboard (silent) activation path too: core runs
+    # this while the hotkey combo is held, with no wake word spoken.
+    if hasattr(c, "register_push_to_talk"):
+        c.register_push_to_talk(
+            lambda should_continue: run_push_to_talk(c, should_continue)
+        )
 
 
 # insert_text() outcomes — kept distinct so the spoken feedback is accurate:
@@ -220,6 +226,61 @@ def format_text(text):
     return text.strip()
 
 
+def _dictate_utterance(core, text):
+    """Format one transcribed utterance, insert it, and give error feedback.
+
+    Shared by the voice ``notes`` flow and the push-to-talk hotkey. Returns True
+    when dictation should stop because insertion failed and the user was told
+    why (no focused field, or the backend isn't set up); False to keep going.
+    Text that formats to nothing is a silent no-op.
+    """
+    formatted = format_text(text)
+    if not formatted:
+        return False
+    logger.info("📝 %s", formatted)
+    # Add a leading space before words, but not before punctuation.
+    if formatted[0].isalpha():
+        formatted = " " + formatted
+    status = insert_text(formatted)
+    if status == NO_FOCUS:
+        core.speak("No text field focused.")
+        return True
+    if status == BACKEND_ERROR:
+        core.speak("Dictation isn't set up on this system.")
+        return True
+    return False
+
+
+# How long each push-to-talk listen waits before looping; kept short so a key
+# release ends dictation promptly (the wait also re-checks the held state).
+PTT_LISTEN_TIMEOUT = 2
+
+
+def run_push_to_talk(core, should_continue):
+    """Dictate while the activation keys are held (the silent-activation path).
+
+    Mirrors the voice ``notes`` loop but is gated on ``should_continue`` — a
+    predicate that is True while the keys remain held — instead of a spoken
+    "stop notes": each utterance captured from ``core`` is formatted and
+    inserted until the keys are released. The capture waits re-check
+    ``should_continue`` so releasing stops dictation promptly.
+    """
+    logger.info("🎙️ Push-to-talk dictation — release to end")
+    while should_continue():
+        core.flush_stream()
+        first = core.wait_for_speech(
+            timeout=PTT_LISTEN_TIMEOUT, should_continue=should_continue
+        )
+        if not first:
+            continue
+        audio = first + core.record_until_silence(should_continue=should_continue)
+        text = core.transcribe(audio, prompt=DICTATION_PROMPT)
+        if not text:
+            continue
+        if _dictate_utterance(core, text.strip().lower()):
+            return
+
+
 def handle(cmd, core):
     """Enter dictation mode on "notes"; return None for other commands.
 
@@ -273,21 +334,8 @@ def handle(cmd, core):
                 return True
 
             # Format and insert
-            formatted = format_text(text)
-            logger.info("📝 %s", formatted)
-
-            if formatted:
-                # Add space before words, not before punctuation
-                if formatted[0].isalpha():
-                    formatted = " " + formatted
-
-                status = insert_text(formatted)
-                if status == NO_FOCUS:
-                    core.speak("No text field focused.")
-                    return True
-                if status == BACKEND_ERROR:
-                    core.speak("Dictation isn't set up on this system.")
-                    return True
+            if _dictate_utterance(core, text):
+                return True
 
         return True
 

--- a/tests/unit/core/test_hotkey.py
+++ b/tests/unit/core/test_hotkey.py
@@ -1,0 +1,310 @@
+"""Tests for the hold-to-dictate keyboard listener (core.hotkey)."""
+
+import logging
+import sys
+import types
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+# Mirror the other core tests: stub heavy deps so importing the package stays
+# light. core.hotkey itself imports evdev only lazily, so it needs no stub.
+sys.modules["pyaudio"] = MagicMock()
+sys.modules["openwakeword"] = MagicMock()
+sys.modules["openwakeword.model"] = MagicMock()
+sys.modules["faster_whisper"] = MagicMock()
+
+from easyspeak.core.hotkey import HotkeyListener, parse_combo  # noqa: E402
+
+# evdev key codes used by the fakes below (the real values).
+LEFTCTRL, RIGHTCTRL = 29, 97
+LEFTSHIFT, RIGHTSHIFT = 42, 54
+KEY_A = 30
+ALIASED = 100  # a code whose name is a list, to exercise the alias branch
+
+
+def _event(type_, code, value):
+    return types.SimpleNamespace(type=type_, code=code, value=value)
+
+
+class _FakeDevice:
+    """Stand-in for an evdev InputDevice."""
+
+    def __init__(self, fd=1, caps=(1,), events=(), read_error=False):
+        self.fd = fd
+        self._caps = caps
+        self._events = list(events)
+        self._read_error = read_error
+        self.closed = False
+
+    def capabilities(self):
+        return {code: [] for code in self._caps}
+
+    def read(self):
+        if self._read_error:
+            raise OSError("device gone")
+        return list(self._events)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_evdev(monkeypatch):
+    """Inject a minimal fake ``evdev`` module for the I/O-touching code paths."""
+    module = types.ModuleType("evdev")
+    module.ecodes = types.SimpleNamespace(
+        EV_KEY=1,
+        KEY={
+            LEFTCTRL: "KEY_LEFTCTRL",
+            RIGHTCTRL: "KEY_RIGHTCTRL",
+            LEFTSHIFT: "KEY_LEFTSHIFT",
+            RIGHTSHIFT: "KEY_RIGHTSHIFT",
+            KEY_A: "KEY_A",
+            ALIASED: ["KEY_ALIASED", "KEY_OTHER"],
+        },
+    )
+    module.list_devices = list
+    module.InputDevice = lambda path: _FakeDevice()
+    monkeypatch.setitem(sys.modules, "evdev", module)
+    return module
+
+
+class TestParseCombo:
+    """Tests for translating a combo string into groups of accepted keys."""
+
+    def test_ctrl_shift_accepts_left_or_right(self):
+        groups = parse_combo("ctrl+shift")
+
+        assert groups == (
+            frozenset({"KEY_LEFTCTRL", "KEY_RIGHTCTRL"}),
+            frozenset({"KEY_LEFTSHIFT", "KEY_RIGHTSHIFT"}),
+        )
+
+    def test_unknown_name_becomes_literal_evdev_key(self):
+        """A name that isn't an alias falls through as a single KEY_ literal."""
+        assert parse_combo("rightctrl") == (frozenset({"KEY_RIGHTCTRL"}),)
+
+    def test_already_prefixed_name_is_kept(self):
+        assert parse_combo("KEY_F13") == (frozenset({"KEY_F13"}),)
+
+    def test_blank_parts_are_ignored(self):
+        assert parse_combo("ctrl++") == (frozenset({"KEY_LEFTCTRL", "KEY_RIGHTCTRL"}),)
+
+    def test_empty_spec_is_empty(self):
+        assert parse_combo("") == ()
+
+
+class TestState:
+    """Tests for the held/activation state machine (no evdev needed)."""
+
+    def test_full_combo_arms_activation_once(self):
+        h = HotkeyListener("ctrl+shift")
+
+        h._process("KEY_LEFTCTRL", 1)
+        assert h.is_held() is False
+        assert h.take_activation() is False
+
+        h._process("KEY_LEFTSHIFT", 1)
+        assert h.is_held() is True
+        assert h.take_activation() is True
+        # The edge is consumed; a second poll without a new press is False.
+        assert h.take_activation() is False
+
+    def test_release_ends_held(self):
+        h = HotkeyListener("ctrl+shift")
+        h._process("KEY_LEFTCTRL", 1)
+        h._process("KEY_LEFTSHIFT", 1)
+
+        h._process("KEY_LEFTCTRL", 0)
+
+        assert h.is_held() is False
+
+    def test_right_hand_variants_satisfy_the_combo(self):
+        h = HotkeyListener("ctrl+shift")
+
+        h._process("KEY_RIGHTCTRL", 1)
+        h._process("KEY_RIGHTSHIFT", 1)
+
+        assert h.is_held() is True
+
+    def test_autorepeat_counts_as_pressed(self):
+        h = HotkeyListener("ctrl+shift")
+
+        h._process("KEY_LEFTCTRL", 1)
+        h._process("KEY_LEFTSHIFT", 2)  # value 2 == key repeat
+
+        assert h.is_held() is True
+
+    def test_keys_outside_the_combo_are_ignored(self):
+        h = HotkeyListener("ctrl+shift")
+
+        h._process("KEY_A", 1)
+
+        assert h.is_held() is False
+        assert h.take_activation() is False
+
+    def test_releasing_already_up_key_is_a_noop(self):
+        h = HotkeyListener("ctrl+shift")
+
+        h._process("KEY_LEFTCTRL", 0)  # never pressed
+
+        assert h.is_held() is False
+
+
+class TestStart:
+    """Tests for start()'s gating and thread spawn."""
+
+    def test_disabled_listener_does_nothing(self, caplog):
+        h = HotkeyListener("ctrl+shift", enabled=False)
+
+        with patch.object(h, "_grab_devices") as grab:
+            h.start()
+
+        grab.assert_not_called()
+        assert h._thread is None
+
+    def test_empty_combo_disables_the_feature(self):
+        h = HotkeyListener("", enabled=True)
+
+        with patch.object(h, "_grab_devices") as grab:
+            h.start()
+
+        grab.assert_not_called()
+
+    def test_no_devices_starts_no_thread(self):
+        h = HotkeyListener("ctrl+shift")
+
+        with patch.object(h, "_grab_devices", return_value=[]):
+            h.start()
+
+        assert h._thread is None
+
+    def test_with_devices_spawns_a_daemon_thread(self):
+        h = HotkeyListener("ctrl+shift")
+        device = _FakeDevice()
+
+        with (
+            patch.object(h, "_grab_devices", return_value=[device]),
+            patch("easyspeak.core.hotkey.threading.Thread") as thread_cls,
+        ):
+            h.start()
+
+        thread_cls.assert_called_once()
+        assert thread_cls.call_args.kwargs["target"] == h._run
+        assert thread_cls.call_args.kwargs["daemon"] is True
+        thread_cls.return_value.start.assert_called_once()
+
+
+class TestStop:
+    """Tests for releasing devices on shutdown."""
+
+    def test_stop_closes_devices_and_sets_event(self):
+        h = HotkeyListener("ctrl+shift")
+        device = _FakeDevice()
+        h._devices = [device]
+
+        h.stop()
+
+        assert h._stop.is_set()
+        assert device.closed is True
+        assert h._devices == []
+
+    def test_stop_swallows_close_errors(self):
+        h = HotkeyListener("ctrl+shift")
+        device = Mock()
+        device.close.side_effect = OSError("already gone")
+        h._devices = [device]
+
+        h.stop()  # must not raise
+
+        assert h._devices == []
+
+
+class TestGrabDevices:
+    """Tests for opening keyboard devices (with a faked evdev)."""
+
+    def test_missing_evdev_is_reported_and_inert(self, monkeypatch, caplog):
+        # A None entry in sys.modules makes `import evdev` raise ImportError.
+        monkeypatch.setitem(sys.modules, "evdev", None)
+
+        h = HotkeyListener("ctrl+shift")
+        with caplog.at_level(logging.INFO):
+            assert h._grab_devices() == []
+        assert "python-evdev not installed" in caplog.text
+
+    def test_keeps_only_readable_keyboards(self, fake_evdev):
+        keyboard = _FakeDevice(fd=3, caps=(fake_evdev.ecodes.EV_KEY,))
+        mouse = _FakeDevice(fd=4, caps=(2,))  # no EV_KEY -> filtered out
+
+        def open_device(path):
+            if path == "/dev/input/event2":
+                raise OSError("permission denied")  # skipped
+            return {"/dev/input/event0": keyboard, "/dev/input/event1": mouse}[path]
+
+        fake_evdev.list_devices = lambda: [
+            "/dev/input/event0",
+            "/dev/input/event1",
+            "/dev/input/event2",
+        ]
+        fake_evdev.InputDevice = open_device
+
+        h = HotkeyListener("ctrl+shift")
+        assert h._grab_devices() == [keyboard]
+
+    def test_no_keyboard_warns_with_input_group_hint(self, fake_evdev, caplog):
+        fake_evdev.list_devices = list
+
+        h = HotkeyListener("ctrl+shift")
+        assert h._grab_devices() == []
+        assert "input" in caplog.text
+
+
+class TestRun:
+    """Tests for the select/read loop feeding events into the state machine."""
+
+    def test_processes_events_then_honours_stop(self, fake_evdev, monkeypatch):
+        h = HotkeyListener("ctrl+shift")
+        device = _FakeDevice(
+            fd=7,
+            events=[
+                _event(fake_evdev.ecodes.EV_KEY, LEFTCTRL, 1),
+                _event(fake_evdev.ecodes.EV_KEY, LEFTSHIFT, 1),
+            ],
+        )
+        h._devices = [device]
+
+        calls = {"n": 0}
+
+        def fake_select(rlist, _w, _x, _timeout):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return ([device.fd], [], [])
+            h._stop.set()
+            return ([], [], [])
+
+        monkeypatch.setattr("select.select", fake_select)
+
+        h._run()
+
+        assert h.is_held() is True
+
+    def test_drain_ignores_read_errors(self, fake_evdev):
+        h = HotkeyListener("ctrl+shift")
+        device = _FakeDevice(fd=7, read_error=True)
+
+        h._drain(device)  # must not raise
+
+        assert h.is_held() is False
+
+    def test_event_keyname_skips_non_key_events(self, fake_evdev):
+        h = HotkeyListener("ctrl+shift")
+
+        assert h._event_keyname(_event(99, LEFTCTRL, 1)) is None
+
+    def test_event_keyname_resolves_aliased_codes(self, fake_evdev):
+        h = HotkeyListener("ctrl+shift")
+
+        name = h._event_keyname(_event(fake_evdev.ecodes.EV_KEY, ALIASED, 1))
+
+        assert name == "KEY_ALIASED"

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -722,6 +722,57 @@ class TestEasySpeakRun:
         with patch("easyspeak.core.main.ensure_extension") as mock_ensure_ext:
             yield mock_ensure_ext
 
+    @pytest.fixture(autouse=True)
+    def _stub_hotkey(self):
+        """Keep run() from reading real /dev/input; hotkey has its own tests.
+
+        take_activation() defaults to False so the loop never enters the
+        push-to-talk branch unless a test opts in.
+        """
+        with patch("easyspeak.core.main.HotkeyListener") as mock_cls:
+            listener = mock_cls.return_value
+            listener.take_activation.return_value = False
+            yield listener
+
+    @patch("subprocess.run")
+    @patch("easyspeak.core.main.pyaudio")
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
+    @patch.object(EasySpeak, "load_plugins")
+    @patch.object(EasySpeak, "_reset_detector")
+    @patch.object(EasySpeak, "_run_push_to_talk")
+    def test_run_hotkey_activation_runs_push_to_talk(
+        self,
+        mock_ptt,
+        mock_reset,
+        mock_load_plugins,
+        mock_whisper_model,
+        mock_wakeword_model,
+        mock_pyaudio,
+        mock_subprocess_run,
+        mock_plugin,
+        _stub_hotkey,
+    ):
+        """A hotkey press runs push-to-talk and skips wake-word detection."""
+        easy = EasySpeak()
+        easy.plugins = [mock_plugin]
+
+        # Fire the hotkey on the first iteration, then fall through to a read
+        # that ends the loop on the next iteration.
+        _stub_hotkey.take_activation.side_effect = [True, False]
+
+        mock_stream = Mock()
+        mock_stream.read.side_effect = KeyboardInterrupt()
+        mock_audio = Mock()
+        mock_audio.open.return_value = mock_stream
+        mock_pyaudio.PyAudio.return_value = mock_audio
+
+        easy.run()
+
+        mock_ptt.assert_called_once_with()
+        _stub_hotkey.start.assert_called_once_with()
+        _stub_hotkey.stop.assert_called_once_with()
+
     @patch("easyspeak.core.main.WakeWordModel")
     @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
@@ -1478,3 +1529,94 @@ class TestEasySpeakRun:
         easy.run()
 
         easy.tray.poll.assert_called_with(easy._close_stream, easy._open_stream)
+
+
+class TestEasySpeakShouldContinue:
+    """Tests for the push-to-talk-aware capture guards."""
+
+    def test_wait_for_speech_stops_when_should_continue_false(self):
+        """A False predicate ends the wait immediately, reading nothing."""
+        easy = EasySpeak()
+        easy.stream = Mock()
+
+        result = easy.wait_for_speech(timeout=5, should_continue=lambda: False)
+
+        assert result is None
+        easy.stream.read.assert_not_called()
+
+    def test_wait_for_speech_runs_while_should_continue_true(self):
+        """A True predicate lets the wait proceed and return detected speech."""
+        easy = EasySpeak()
+        easy.stream = Mock()
+        loud = np.array([1000] * 1600, dtype=np.int16).tobytes()
+        easy.stream.read = Mock(return_value=loud)
+
+        result = easy.wait_for_speech(timeout=5, should_continue=lambda: True)
+
+        assert result == loud
+
+    def test_record_until_silence_stops_when_should_continue_false(self):
+        """A False predicate cuts the recording short before reading."""
+        easy = EasySpeak()
+        easy.stream = Mock()
+
+        result = easy.record_until_silence(should_continue=lambda: False)
+
+        assert result == b""
+        easy.stream.read.assert_not_called()
+
+    def test_record_until_silence_runs_while_should_continue_true(self):
+        """A True predicate records normally until the silence window."""
+        easy = EasySpeak()
+        easy.stream = Mock()
+        loud = np.array([1000] * 1600, dtype=np.int16).tobytes()
+        silent = np.array([10] * 1600, dtype=np.int16).tobytes()
+        easy.stream.read = Mock(side_effect=[loud] * 6 + [silent] * 10)
+
+        result = easy.record_until_silence(should_continue=lambda: True)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+
+class TestEasySpeakPushToTalk:
+    """Tests for hotkey-driven dictation hand-off."""
+
+    def test_register_push_to_talk_stores_handler(self):
+        """The dictation plugin's registration is kept for the hotkey to run."""
+        easy = EasySpeak()
+        handler = Mock()
+
+        easy.register_push_to_talk(handler)
+
+        assert easy._push_to_talk is handler
+
+    def test_run_push_to_talk_without_handler_warns(self, readlog):
+        """With no dictation plugin registered the press warns and no-ops."""
+        easy = EasySpeak()
+        easy._push_to_talk = None
+
+        with patch.object(easy, "_play_wake_chime") as chime:
+            easy._run_push_to_talk()
+
+        assert "no dictation handler" in readlog().err.lower()
+        chime.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_run_push_to_talk_acks_then_runs_handler(self, mock_run):
+        """A press chimes (no spoken prompt) and runs the handler gated on hold."""
+        easy = EasySpeak()
+        easy.speak = Mock()  # the silent path must speak no prompt
+        handler = Mock()
+        easy.register_push_to_talk(handler)
+
+        with (
+            patch.object(easy, "_reset_detector") as reset,
+            patch.object(easy, "_play_wake_chime") as chime,
+        ):
+            easy._run_push_to_talk()
+
+        reset.assert_called_once_with()
+        chime.assert_called_once_with()
+        handler.assert_called_once_with(easy.hotkey.is_held)
+        easy.speak.assert_not_called()

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -466,3 +466,117 @@ def test_handle_dictation_mode_with_prompt(mock_format, mock_insert, mock_core_f
     assert mock_core.transcribe.call_count == 2
     first_call = mock_core.transcribe.call_args_list[0]
     assert first_call.kwargs["prompt"] == dictation.DICTATION_PROMPT
+
+
+# Tests for the push-to-talk (silent activation) path.
+
+
+def _holds(times):
+    """Return a should_continue predicate True for ``times`` polls then False."""
+    state = {"n": 0}
+
+    def should_continue():
+        state["n"] += 1
+        return state["n"] <= times
+
+    return should_continue
+
+
+@patch.object(dictation, "ensure_gnome_accessibility")
+def test_setup_registers_push_to_talk(mock_ensure):
+    """setup() registers the push-to-talk session with a core that supports it."""
+    mock_core = Mock()
+
+    dictation.setup(mock_core)
+
+    mock_core.register_push_to_talk.assert_called_once()
+    assert callable(mock_core.register_push_to_talk.call_args.args[0])
+
+
+@patch.object(dictation, "ensure_gnome_accessibility")
+def test_setup_skips_registration_without_support(mock_ensure):
+    """A core lacking register_push_to_talk (older/mocked) is tolerated."""
+    core = Mock(spec=["speak"])  # no register_push_to_talk attribute
+
+    dictation.setup(core)  # must not raise
+
+
+@patch("easyspeak.plugins.dictation.insert_text", return_value=dictation.INSERTED)
+@patch("easyspeak.plugins.dictation.format_text", return_value="Hello")
+def test_run_push_to_talk_inserts_until_released(mock_format, mock_insert):
+    """While held, each utterance is formatted and inserted via AT-SPI."""
+    core = Mock()
+    core.wait_for_speech = Mock(return_value=b"audio1")
+    core.record_until_silence = Mock(return_value=b"audio2")
+    core.transcribe = Mock(return_value="hello")
+
+    dictation.run_push_to_talk(core, _holds(1))
+
+    assert mock_insert.call_count == 1
+    assert mock_insert.call_args.args == (" Hello",)
+    # The capture is gated on the held state so a release can cut it short.
+    assert core.wait_for_speech.call_args.kwargs["should_continue"] is not None
+    assert core.record_until_silence.call_args.kwargs["should_continue"] is not None
+
+
+@patch("easyspeak.plugins.dictation.insert_text")
+def test_run_push_to_talk_skips_silence(mock_insert):
+    """A listen that returns no speech loops without inserting."""
+    core = Mock()
+    core.wait_for_speech = Mock(return_value=None)
+
+    dictation.run_push_to_talk(core, _holds(1))
+
+    mock_insert.assert_not_called()
+    core.transcribe.assert_not_called()
+
+
+@patch("easyspeak.plugins.dictation.insert_text")
+def test_run_push_to_talk_skips_empty_transcription(mock_insert):
+    """An empty transcription is skipped."""
+    core = Mock()
+    core.wait_for_speech = Mock(return_value=b"audio1")
+    core.record_until_silence = Mock(return_value=b"audio2")
+    core.transcribe = Mock(return_value="")
+
+    dictation.run_push_to_talk(core, _holds(1))
+
+    mock_insert.assert_not_called()
+
+
+@patch("easyspeak.plugins.dictation.insert_text", return_value=dictation.NO_FOCUS)
+@patch("easyspeak.plugins.dictation.format_text", return_value="Hello")
+def test_run_push_to_talk_no_focus_stops(mock_format, mock_insert):
+    """No focused field is spoken once and ends the session."""
+    core = Mock()
+    core.wait_for_speech = Mock(return_value=b"audio1")
+    core.record_until_silence = Mock(return_value=b"audio2")
+    core.transcribe = Mock(return_value="hello")
+
+    dictation.run_push_to_talk(core, _holds(5))
+
+    core.speak.assert_called_once_with("No text field focused.")
+
+
+@patch("easyspeak.plugins.dictation.insert_text", return_value=dictation.BACKEND_ERROR)
+@patch("easyspeak.plugins.dictation.format_text", return_value="Hello")
+def test_run_push_to_talk_backend_error_stops(mock_format, mock_insert):
+    """A backend error gives the setup hint once and ends the session."""
+    core = Mock()
+    core.wait_for_speech = Mock(return_value=b"audio1")
+    core.record_until_silence = Mock(return_value=b"audio2")
+    core.transcribe = Mock(return_value="hello")
+
+    dictation.run_push_to_talk(core, _holds(5))
+
+    core.speak.assert_called_once_with("Dictation isn't set up on this system.")
+
+
+@patch("easyspeak.plugins.dictation.insert_text")
+@patch("easyspeak.plugins.dictation.format_text", return_value="")
+def test_dictate_utterance_noop_on_empty_format(mock_format, mock_insert):
+    """Text that formats to nothing inserts nothing and keeps dictating."""
+    core = Mock()
+
+    assert dictation._dictate_utterance(core, "   ") is False
+    mock_insert.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -553,6 +553,7 @@ wheels = [
 name = "easyspeak-linux"
 source = { editable = "." }
 dependencies = [
+    { name = "evdev-binary", marker = "sys_platform == 'linux'" },
     { name = "faster-whisper" },
     { name = "jeepney" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -596,6 +597,7 @@ unittest = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'unittest'", specifier = ">=7.14" },
+    { name = "evdev-binary", marker = "sys_platform == 'linux'", specifier = ">=1.7" },
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "jeepney", specifier = ">=0.9" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1" },
@@ -618,6 +620,21 @@ requires-dist = [
     { name = "types-pyaudio", marker = "extra == 'mypy'", specifier = ">=0.2.16.20250801" },
 ]
 provides-extras = ["acceptance", "benchmark", "docs", "head-tracking", "integration", "mypy", "unittest"]
+
+[[package]]
+name = "evdev-binary"
+version = "1.9.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/ee/7ba59ead34defda81e04fec90a376f03a2e35ec144d5610a6d6519476c1d/evdev_binary-1.9.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f0ed8723b5382e37c7d6b32ed4e4963205fa4f7a8d6c8d53c70b43e1174b13e7", size = 109989, upload-time = "2026-02-05T21:59:18.763Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/18/11911004b181403ba6c8f719a56bfea2dbcc5f629696706caaf8021a3584/evdev_binary-1.9.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:91507a6dd721bb8037f67f0a9bbbc32b7b4e5536324f71818a0e58290197f649", size = 111359, upload-time = "2026-02-05T21:59:20.719Z" },
+    { url = "https://files.pythonhosted.org/packages/72/88/65adf424f8f99401677a94ec07903f4880e03d0ac63cd63153780c8e6415/evdev_binary-1.9.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d90c4126398fa6a5f760fec7cee8a42f87fd266e4a37aa9c36b7958c4a1ae7b", size = 110997, upload-time = "2026-02-05T21:59:22.38Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/3e/1e7fa235b4766dd1198c4d832c1560d8abcea14d32759914e6e74bf20006/evdev_binary-1.9.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ed6419bca316890c80deb6bd31b1d04e441b013e826aa3122ffe4528a094c7e3", size = 112295, upload-time = "2026-02-05T21:59:23.636Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/30/645606224343ecc02599b731a9090180519b84276c7331bb7805aeb907a5/evdev_binary-1.9.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:53bda21275627cc28008bd94dc1ba324c3c24debd0a4b779a64242f19697d681", size = 111362, upload-time = "2026-02-05T21:59:25.167Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/63/b9bb5d2fdf836581821f2ebce82b8b35ec8718482e8f78ec1733ed97fd9b/evdev_binary-1.9.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4404fc4222c9c6670b91ab07784b9d0ed06b6138079f91216d0e9238fcd89df3", size = 112497, upload-time = "2026-02-05T21:59:26.424Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/36/c109d26825e66847721e004708ee4c4b46b2b2c4a22a5b84e40fed051336/evdev_binary-1.9.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ef92f0259d3bd1d9b449a4ea1ff7b747064a98c4c55844e3f1cbe880c2efe25c", size = 111512, upload-time = "2026-02-05T21:59:27.538Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/3c4a5e2ca1a07c15db1afa48acf090ec906464bb428fb6b930a4028ca7bf/evdev_binary-1.9.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1eb0166c89d96dfe56187b18155323f655bdfdf2695777df29b33c44e48ffc74", size = 112661, upload-time = "2026-02-05T21:59:28.727Z" },
+]
 
 [[package]]
 name = "exceptiongroup"


### PR DESCRIPTION
Closes #67 (the silent-activation part).

## What

Start dictation by **holding a key combo (default Ctrl+Shift)** instead of saying the wake word; release the keys to stop. A chime acknowledges activation — no spoken prompt, since this is the *silent* path.

## How

- **`core/hotkey.py` (new)** — `HotkeyListener` reads keyboards from `/dev/input` via evdev in a daemon thread and tracks whether the combo is held (left/right variants both count). Pure state logic is separated from evdev I/O.
- **`core/main.py`** — constructs the listener, starts/stops it in `run()`, and polls `take_activation()` in the audio loop to launch a push-to-talk session that bypasses the wake word. `wait_for_speech`/`record_until_silence` gained an optional `should_continue` so a key release cuts capture short.
- **`plugins/dictation.py`** — registers the session via a new `register_push_to_talk` hook and reuses existing punctuation/formatting/AT-SPI insertion (extracted into `_dictate_utterance`).
- **`core/config.py`** — `HOTKEY_COMBO` (default `ctrl+shift`) and `HOTKEY_ENABLED`, overridable via `EASYSPEAK_HOTKEY_COMBO` / `EASYSPEAK_HOTKEY=0`.
- **`pyproject.toml`** — adds `evdev-binary` (prebuilt wheel; the source `evdev` needs kernel headers, which would break installs).

## Why evdev / why a permission is needed

On Wayland an ordinary process can't grab global keys, and only raw evdev events expose key *release* — which "hold to dictate, release to stop" requires. The listener is **best-effort**: if evdev is missing or `/dev/input` isn't readable (user not in the `input` group), it logs how to enable it and stays inert, so the daemon runs normally without the hotkey.

## Tests

929 unit tests pass; **100% coverage** on `hotkey.py`, `main.py`, `config.py`, `dictation.py`; ruff lint + format clean; mypy clean. The evdev I/O is exercised with a fake device feeding real key codes through the held-state machine.