### PR TITLE
docs: hosted MkDocs + Material + mkdocstrings site on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Docs
+
+# Build the MkDocs site and publish versioned docs to GitHub Pages with mike.
+# mike commits the built site to the gh-pages branch; Pages serves from there.
+on:
+  push:
+    branches: [dev]
+    tags: ["*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write  # mike pushes the built site to the gh-pages branch
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # mike needs the full history of the gh-pages branch
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Configure git for mike
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Tags publish a named version and move the "latest" alias; pushes to the
+      # default branch publish the in-progress "dev" docs. Both deploy to the
+      # gh-pages branch via mike. --push lets GitHub Pages serve the result.
+      - name: Deploy release docs
+        if: startsWith(github.ref, 'refs/tags/')
+        run: uv run --extra docs mike deploy --push --update-aliases "${GITHUB_REF_NAME}" latest
+
+      - name: Set default version to latest
+        if: startsWith(github.ref, 'refs/tags/')
+        run: uv run --extra docs mike set-default --push latest
+
+      - name: Deploy development docs
+        if: github.ref == 'refs/heads/dev'
+        run: uv run --extra docs mike deploy --push dev

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [dev]
     tags: ["*"]
+  pull_request:  # build-only check; the deploy steps below are guarded by ref
   workflow_dispatch:
 
 permissions:
@@ -19,12 +20,26 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # mike needs the full history of the gh-pages branch
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+
+      - uses: taiki-e/install-action@just
+
+      # `uv run` installs the project, which depends on pyaudio; building that
+      # needs the PortAudio headers (mirrors the other workflows).
+      - run: |
+          sudo apt update
+          sudo apt install -y portaudio19-dev
+
+      # The same command developers run locally; a strict build fails on
+      # warnings, so this validates the docs on every push and pull request.
+      - name: Build docs
+        run: just docs
 
       - name: Configure git for mike
         run: |
@@ -34,6 +49,7 @@ jobs:
       # Tags publish a named version and move the "latest" alias; pushes to the
       # default branch publish the in-progress "dev" docs. Both deploy to the
       # gh-pages branch via mike. --push lets GitHub Pages serve the result.
+      # Pull requests run the build above only — neither condition matches.
       - name: Deploy release docs
         if: startsWith(github.ref, 'refs/tags/')
         run: uv run --extra docs mike deploy --push --update-aliases "${GITHUB_REF_NAME}" latest

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ requirements.txt
 Thumbs.db
 /result
 
+# Documentation site build (MkDocs)
+/site/
+
 # Project specific
 *.wav
 *.log

--- a/README.md
+++ b/README.md
@@ -14,488 +14,52 @@ Say "Hey Jarvis" and control your desktop with your voice.
 
 > ⚠️ **Early development.** This project works but is not polished. Expect bugs, incomplete docs, and changes without notice.
 
+📖 **Full documentation: <https://ctsdownloads.github.io/easyspeak/>**
+
 ## Why EasySpeak?
 
 Linux desktop voice control is a gap. Talon exists but has a steep learning curve and costs money for the full version. Most other tools are X11-only, abandoned, or cloud-dependent.
 
-EasySpeak is:
-- **Free and open source** - GPL-3.0 licensed, no paywalls
-- **Fully local** - No cloud, no accounts, no data leaving your machine
-- **Wayland-native** - Works on modern GNOME desktops where X11 tools fail
-- **Simple** - Say "Hey Jarvis, open downloads" and it works
-- **Extensible** - Drop a Python file in plugins/ to add commands
+EasySpeak is **free and open source** (GPL-3.0), **fully local** (no cloud, no accounts), **Wayland-native**, **simple** ("Hey Jarvis, open downloads"), and **extensible** (drop a Python file in `plugins/`). Built for people with RSI, accessibility needs, hands-busy workflows, or anyone who wants to talk to their computer.
 
-Built for people with RSI, accessibility needs, hands-busy workflows, or anyone who wants to talk to their computer.
-
-## Features
-
-Current and in active development:
-
-- **Wake word activation** - Hands-free with "Hey Jarvis"
-- **Mouse grid** - Navigate anywhere on screen with voice ("grid", "3 7 5", "click")
-- **Head tracking** - Control cursor with head movement (experimental)
-- **Browser control** - Qutebrowser integration with link hints, tabs, scrolling
-- **Dictation** - Voice-to-text in any text field with punctuation commands
-- **App launcher** - Open and close applications by name
-- **Media control** - Play, pause, skip via MPRIS
-- **System controls** - Volume, brightness, do not disturb
-- **Fully local** - OpenWakeWord + Whisper + Piper, no cloud services
-- **Wayland-native** - Works properly on modern Linux desktops
-- **Plugin architecture** - Easy to extend
+- Wake word activation ("Hey Jarvis")
+- Mouse grid and experimental head tracking
+- Browser control, dictation, app launcher, media and system controls
+- OpenWakeWord + Whisper + Piper, all on-device
 
 ## Demo
 
-Click the thumbnail to watch the demo video:
-
 [![Demo](https://img.youtube.com/vi/dl5m2Zo1oIE/maxresdefault.jpg)](https://www.youtube.com/watch?v=dl5m2Zo1oIE)
 
-**Terminal output:**
+## Quickstart
 
-![Terminal](images/1.png)
-
-**Mouse grid (Files):**
-
-![Grid Files](images/2.png)
-
-**Mouse grid (Browser):**
-
-![Grid zoomed](images/3.png)
-
-**Browser (Numbers click navigation):**
-
-![Browser](images/4.png)
-
-## Requirements
-
-- Linux with GNOME Shell 47+ on Wayland
-- Python 3.12 (not 3.13 and 3.14 - see installation notes)
-- Working microphone
-- ~2GB disk space for models
-
-Tested on Fedora 43.
-
-## Installation
-
-Fedora 43's default `python3` is 3.14. Unfortunately, we depend on a few Google packages that are not available for Python 3.13+ yet.
+Requirements: Linux with GNOME Shell 47+ on Wayland, Python 3.12, a microphone, and ~2 GB disk for models. Tested on Fedora 43.
 
 ```bash
-sudo dnf install python3.12
-python3.12 --version  # Verify it's installed
-```
+# 1. System packages (Fedora; see the docs for the full list)
+sudo dnf install python3.12 python3.12-devel gcc portaudio-devel \
+  pipewire-utils wireplumber at-spi2-core python3-gobject qutebrowser \
+  glib2 ffmpeg-free pulseaudio-utils sound-theme-freedesktop
 
-### 1. System Packages
-
-```bash
-sudo dnf install \
-  pipewire-utils \
-  wireplumber \
-  at-spi2-core \
-  python3-gobject \
-  qutebrowser \
-  glib2 \
-  ffmpeg-free \
-  pulseaudio-utils \
-  sound-theme-freedesktop \
-  portaudio-devel \
-  python3.12-devel \
-  gcc
-```
-
-### 2. Python Packages
-
-```bash
-python3.12 -m venv ~/easyspeak-venv
-source ~/easyspeak-venv/bin/activate
-pip install faster-whisper openwakeword numpy pyaudio
+# 2. Get EasySpeak and run it (uv manages the virtualenv for you)
+git clone https://github.com/ctsdownloads/easyspeak.git ~/easyspeak
 cd ~/easyspeak
-pip install -e .
-```
-
-If you use `uv` you can ignore the steps that create a virtual environment and simply run:
-
-```bash
 uv run easyspeak
 ```
 
-uv will transparently create and update a virtual environment, and run easyspeak from in there.
-
-### 3. Piper TTS
-
-```bash
-mkdir -p ~/.local/bin
-cd ~/.local/bin
-wget https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_x86_64.tar.gz
-tar xzf piper_linux_x86_64.tar.gz
-rm piper_linux_x86_64.tar.gz
-
-echo 'export PATH="$HOME/.local/bin/piper:$PATH"' >> ~/.bashrc
-source ~/.bashrc
-
-mkdir -p ~/.local/share/piper
-cd ~/.local/share/piper
-wget -O en_US-amy-medium.onnx \
-  "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx"
-wget -O en_US-amy-medium.onnx.json \
-  "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx.json"
-```
-
-### 4. Clone Repository
-
-```bash
-git clone https://github.com/ctsdownloads/easyspeak.git ~/easyspeak
-cd ~/easyspeak
-```
-
-## Usage
-
-```bash
-source ~/easyspeak-venv/bin/activate   # Now python = venv's python3.12
-easyspeak                              # the project execution script
-```
-
-Activate the venv each time you open a new terminal.
-
-Say "Hey Jarvis" followed by a command. After a command that gives no spoken
-reply (such as volume changes), EasySpeak keeps listening for a few seconds so
-you can chain commands — say "louder", "louder", "louder" without repeating the
-wake word each time.
-
-## Commands
-
-### Mouse Grid
-
-Screen splits into a 3x3 layout (like a phone keypad):
-
-```
-1 2 3
-4 5 6
-7 8 9
-```
-
-Say **"grid"** to show it. Say a number to zoom into that zone. Keep zooming until you're over your target, then **"click"**.
-
-Chain numbers to go faster: **"3 6 3"** zooms three times at once.
-
-**Drag and drop:**
-1. Navigate to the thing you want to drag
-2. Say **"mark"** - grabs it (mousedown)
-3. Grid resets to full screen
-4. Navigate to where you want to drop it
-5. Say **"drag"** - releases it (mouseup)
-
-| Command | Action |
-|---------|--------|
-| grid | Show grid |
-| 1-9 | Zoom to zone |
-| 3 7 5 | Chain zones |
-| click | Left click |
-| double click | Double click |
-| right click | Right click |
-| middle click | Middle click |
-| up/down/left/right | Nudge position |
-| left 5, down 3, etc. | Nudge with repeat |
-| scroll up/down/left/right | Scroll at cursor |
-| scroll down 3, etc. | Scroll with repeat |
-| mark | Grab (start drag) |
-| drag | Drop (end drag) |
-| again | Reopen at last spot |
-| close | Hide grid |
-
-### Head Tracking (Experimental)
-
-Requires webcam and additional dependencies (`pip install sixdrepnet opencv-python` or `pip install .[head-tracking]`, or run via `uv run --extra head-tracking easyspeak`).
-
-| Command | Action |
-|---------|--------|
-| start tracking | Begin head tracking |
-| stop tracking | End tracking |
-| freeze | Lock cursor position |
-| go | Resume tracking |
-| recalibrate | Reset center position |
-| nudge up/down/left/right | Fine tune when frozen |
-| click | Left click |
-| double click | Double click |
-| right click | Right click |
-
-### Browser (Qutebrowser)
-
-| Command | Action |
-|---------|--------|
-| browser | Enter browser mode |
-| numbers / hints | Show link hints |
-| zero two | Click hint 02 |
-| new tab | Open new tab |
-| close tab | Close current tab |
-| tab left/right | Switch tabs |
-| tab [number] | Jump to specific tab |
-| undo tab | Restore closed tab |
-| back / forward | Navigate history |
-| reload | Refresh page |
-| scroll up/down | Scroll page |
-| page up/down | Scroll by page |
-| top / bottom | Go to top/bottom |
-| find [text] | Search in page |
-| find next/previous | Navigate matches |
-| search [query] | Web search (DuckDuckGo) |
-| go to [url] | Navigate to URL |
-| open youtube | Open bookmark |
-| exit browser | Leave browser mode |
-
-Built-in bookmarks: youtube, google, gmail, github, reddit, twitter, facebook, amazon, netflix, duckduckgo
-
-### Dictation
-
-| Command | Action |
-|---------|--------|
-| notes | Start dictation mode |
-| stop notes | End dictation mode |
-| comma | Insert , |
-| period | Insert . |
-| question mark | Insert ? |
-| exclamation mark | Insert ! |
-| colon | Insert : |
-| semicolon | Insert ; |
-| apostrophe | Insert ' |
-| quote | Insert " |
-| dash | Insert - |
-| new line | Insert newline |
-| new paragraph | Insert double newline |
-| new sentence | Insert . and capitalize next |
-| backspace | Delete character |
-| space | Insert space |
-| tab | Insert tab |
-| at sign | Insert @ |
-| hashtag | Insert # |
-| percent | Insert % |
-| asterisk | Insert * |
-
-### Apps
-
-| Command | Action |
-|---------|--------|
-| open [app] | Launch application |
-| close [app] | Close application |
-
-Default apps in `plugins/apps.py` (edit to match your system):
-- firefox, steam, spotify, calculator, settings, files, terminal, browser, music player
-
-These are just examples. Edit `apps.py` to add your own apps. Some accept
-spoken aliases — e.g. "open music app" works the same as "open music player".
-
-### Files
-
-| Command | Action |
-|---------|--------|
-| open documents | Open Documents folder |
-| open downloads | Open Downloads folder |
-| open pictures | Open Pictures folder |
-| open music | Open Music folder |
-| open videos | Open Videos folder |
-| open projects | Open Projects folder |
-| open home | Open home folder |
-| open desktop | Open Desktop folder |
-
-### Media
-
-| Command | Action |
-|---------|--------|
-| play | Resume playback |
-| pause / stop the music | Pause playback |
-| next / skip | Next track |
-| previous / back | Previous track |
-
-### System
-
-| Command | Action |
-|---------|--------|
-| volume up/down (or louder / quieter) | Adjust volume one step (repeat to keep going) |
-| very loud / very silent | Jump straight to near-max (85%) / low (15%, not muted) |
-| mute | Toggle mute |
-| brightness up/down | Adjust brightness |
-| do not disturb on/off | Toggle notifications |
-
-Volume changes are silent — GNOME's own on-screen display and chime acknowledge them.
-
-### General
-
-| Command | Action |
-|---------|--------|
-| help | List all commands |
-| go to sleep / stop listening | Release the mic (reactivate from the tray icon) |
-| quit / exit / goodbye | Exit EasySpeak |
-
-## File Structure
-
-```
-easyspeak/
-├── pyproject.toml
-├── src
-│   ├── extension.js           # GNOME Shell extension (bundled as package data)
-│   ├── metadata.json          # Extension metadata
-│   ├── core
-│   │   ├── __init__.py
-│   │   ├── __main__.py
-│   │   ├── config.py          # Tuning constants + Whisper model factory
-│   │   ├── gnome_extension.py  # Installs/refreshes/enables the extension
-│   │   └── main.py            # EasySpeak class + main loop
-│   └── plugins
-│       ├── __init__.py
-│       ├── 00_eyetrack.py     # Head tracking (experimental)
-│       ├── 00_mousegrid.py    # Grid overlay mouse control
-│       ├── apps.py            # Application launcher
-│       ├── browser.py         # Qutebrowser control + auto-config
-│       ├── dictation.py       # Voice-to-text + AT-SPI enablement
-│       ├── files.py           # Folder navigation
-│       ├── media.py           # Playback controls
-│       ├── system.py          # Volume, brightness, DND
-│       └── zz_base.py         # Help and exit
-└── tests
-    ├── benchmarks             # pytest-benchmark suites for bencher.dev
-    ├── core                   # tests for src/core/
-    └── plugins                # tests for src/plugins/
-```
-
-On first start, core auto-installs the GNOME Shell extension to the
-user-local extensions directory (unless GNOME already sees it via a
-system-wide install). Files copied:
-
-```
-~/.local/share/gnome-shell/extensions/easyspeak-grid@local/
-├── extension.js
-└── metadata.json
-```
-
-## How It Works
-
-- **Wake word**: OpenWakeWord detects "Hey Jarvis" instantly
-- **Speech-to-text**: faster-whisper transcribes commands locally
-- **Text-to-speech**: Piper provides voice feedback
-- **Mouse control**: GNOME Shell extension with Clutter virtual input
-- **Browser scroll**: JavaScript injection via qutebrowser IPC
-- **Dictation**: AT-SPI accessibility framework
-
-All processing happens locally. No data leaves your machine.
-
-## Writing Plugins
-
-Drop a Python file in `plugins/` and it gets loaded automatically.
-
-```python
-NAME = "myplugin"
-DESCRIPTION = "What it does"
-
-COMMANDS = [
-    "say hello - speaks a greeting",
-]
-
-def setup(core):
-    """Called once at startup. Store core reference if needed."""
-    pass
-
-def handle(cmd, core):
-    """Called for every voice command. Return True if handled, None to pass to next plugin."""
-    if "say hello" in cmd:
-        core.speak("Hello there!")
-        return True
-    return None
-```
-
-**Core methods you can use:**
-- `core.speak("text")` - text-to-speech response
-- `core.host_run(["cmd", "arg"])` - run shell command
-- `core.transcribe(audio)` - transcribe audio to text
-- `core.wait_for_speech()` - wait for user to start speaking
-- `core.record_until_silence()` - record until user stops
-
-**Loading order:** Plugins load alphabetically. Use number prefixes to control order (`00_mousegrid.py` loads before `apps.py`).
-
-## Troubleshooting
-
-**Mouse grid: "Failed to show grid — is extension enabled?"**
-
-You don't install the extension yourself — EasySpeak does it automatically
-on startup, copying it to
-`~/.local/share/gnome-shell/extensions/easyspeak-grid@local/` and keeping it
-up to date (look for an `easyspeak: installed ...` or `easyspeak: updated ...`
-message). On Wayland, GNOME Shell only scans for new extensions at login, so
-you typically have to **log out and back in** before it becomes loadable.
-
-After re-login, enable it from the command line:
-
-```bash
-gnome-extensions enable easyspeak-grid@local
-```
-
-…or open the **Extensions** GNOME app and toggle *EasySpeak Grid* on.
-
-To remove it later:
-
-```bash
-gnome-extensions disable easyspeak-grid@local
-rm -rf ~/.local/share/gnome-shell/extensions/easyspeak-grid@local
-```
-
-…or click the trash icon next to *EasySpeak Grid* in the Extensions app.
-
-**Dictation not working**
-
-EasySpeak enables the GNOME accessibility bridge on first run; log out and
-back in after seeing the `dictation: enabled GNOME toolkit-accessibility`
-message. If the auto-config printed a `WARNING` instead (e.g. on a
-non-GNOME or locked-down desktop), run it manually:
-
-```bash
-gsettings set org.gnome.desktop.interface toolkit-accessibility true
-# Log out and back in
-```
-
-**Browser plugin: link numbers don't work**
-
-EasySpeak appends two required lines to `~/.config/qutebrowser/config.py`
-on first run (you'll see a `browser: wrote ...` or `browser: updated ...`
-message). If you see a `browser: note: ... is read-only` or a similar
-error instead, add these lines to the config module yourself:
-
-```python
-config.load_autoconfig(False)
-c.hints.chars = '0123456789'
-```
-
-**Wake word not detecting**
-- Check microphone: `arecord -d 3 test.wav && aplay test.wav`
-- Adjust `WAKE_THRESHOLD` in core.py (lower = more sensitive)
-
-**Wake word triggers multiple times**
-
-Mic gain too high. Lower capture level:
-```bash
-alsamixer
-# Press F6 to select your mic device
-# Press Tab to switch to Capture
-# Lower to ~70
-```
-
-**Commands misheard**
-- Adjust `SILENCE_THRESHOLD` in core.py
-- Speak clearly after the beep
-
-**Piper permission denied**
-```bash
-chmod +x ~/.local/bin/piper/piper
-chmod +x ~/.local/bin/piper/espeak-ng
-```
-
-**pip install fails with PyAV/Cython errors**
-
-You're on Python 3.14 or 3.13. Use `python3.12` with a venv instead:
-```bash
-sudo dnf install python3.12 python3.12-devel
-python3.12 -m venv ~/easyspeak-venv
-source ~/easyspeak-venv/bin/activate
-pip install faster-whisper openwakeword numpy pyaudio
-cd ~/easyspeak
-pip install -e .
-```
+You also need [Piper TTS](https://ctsdownloads.github.io/easyspeak/installation/#3-piper-tts) installed for voice feedback. See the **[Installation guide](https://ctsdownloads.github.io/easyspeak/installation/)** for the venv-based path, head tracking, and full details.
+
+Then say "Hey Jarvis" followed by a command. Say "help" to list all commands.
+
+## Documentation
+
+- **[Installation](https://ctsdownloads.github.io/easyspeak/installation/)** — system packages, Python, Piper TTS
+- **[Usage](https://ctsdownloads.github.io/easyspeak/usage/)** — running the daemon, CLI flags, configuration
+- **[Commands](https://ctsdownloads.github.io/easyspeak/commands/)** — the full command reference
+- **[Writing plugins](https://ctsdownloads.github.io/easyspeak/plugins/)** — extend EasySpeak with a Python file
+- **[Troubleshooting](https://ctsdownloads.github.io/easyspeak/troubleshooting/)** — common problems and fixes
+- **[How it works](https://ctsdownloads.github.io/easyspeak/how-it-works/)** — the architecture
+- **[API reference](https://ctsdownloads.github.io/easyspeak/reference/core/)** — generated from the source docstrings
 
 ## Contributing
 
@@ -507,7 +71,7 @@ GPL-3.0 License. See [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 
-- [OpenWakeWord](https://github.com/dscripka/openWakeWord) - Wake word detection
-- [faster-whisper](https://github.com/guillaumekln/faster-whisper) - Speech recognition
-- [Piper](https://github.com/OHF-Voice/piper1-gpl) - Text-to-speech (we use the last standalone binary from the original [rhasspy/piper](https://github.com/rhasspy/piper) repo)
-- [Talon](https://talonvoice.com/) - Inspiration for voice control concepts
+- [OpenWakeWord](https://github.com/dscripka/openWakeWord) — Wake word detection
+- [faster-whisper](https://github.com/guillaumekln/faster-whisper) — Speech recognition
+- [Piper](https://github.com/OHF-Voice/piper1-gpl) — Text-to-speech (we use the last standalone binary from the original [rhasspy/piper](https://github.com/rhasspy/piper) repo)
+- [Talon](https://talonvoice.com/) — Inspiration for voice control concepts

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+<!--
+This page includes the repository-root CHANGELOG.md verbatim via
+pymdownx.snippets, so the root file stays the single source of truth.
+-->
+--8<-- "CHANGELOG.md"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,169 @@
+# Commands
+
+Say "Hey Jarvis" followed by any of the commands below. Say **"help"** at any
+time to print the full list to the terminal.
+
+## Mouse grid
+
+Screen splits into a 3x3 layout (like a phone keypad):
+
+```
+1 2 3
+4 5 6
+7 8 9
+```
+
+Say **"grid"** to show it. Say a number to zoom into that zone. Keep zooming
+until you're over your target, then **"click"**.
+
+Chain numbers to go faster: **"3 6 3"** zooms three times at once.
+
+**Drag and drop:**
+
+1. Navigate to the thing you want to drag
+2. Say **"mark"** — grabs it (mousedown)
+3. Grid resets to full screen
+4. Navigate to where you want to drop it
+5. Say **"drag"** — releases it (mouseup)
+
+| Command | Action |
+|---------|--------|
+| grid | Show grid |
+| 1-9 | Zoom to zone |
+| 3 7 5 | Chain zones |
+| click | Left click |
+| double click | Double click |
+| right click | Right click |
+| middle click | Middle click |
+| up/down/left/right | Nudge position |
+| left 5, down 3, etc. | Nudge with repeat |
+| scroll up/down/left/right | Scroll at cursor |
+| scroll down 3, etc. | Scroll with repeat |
+| mark | Grab (start drag) |
+| drag | Drop (end drag) |
+| again | Reopen at last spot |
+| close | Hide grid |
+
+## Head tracking (experimental)
+
+Requires a webcam and additional dependencies — see [Installation](installation.md#head-tracking-optional).
+
+| Command | Action |
+|---------|--------|
+| start tracking | Begin head tracking |
+| stop tracking | End tracking |
+| freeze | Lock cursor position |
+| go | Resume tracking |
+| recalibrate | Reset center position |
+| nudge up/down/left/right | Fine tune when frozen |
+| click | Left click |
+| double click | Double click |
+| right click | Right click |
+
+## Browser (Qutebrowser)
+
+| Command | Action |
+|---------|--------|
+| browser | Enter browser mode |
+| numbers / hints | Show link hints |
+| zero two | Click hint 02 |
+| new tab | Open new tab |
+| close tab | Close current tab |
+| tab left/right | Switch tabs |
+| tab [number] | Jump to specific tab |
+| undo tab | Restore closed tab |
+| back / forward | Navigate history |
+| reload | Refresh page |
+| scroll up/down | Scroll page |
+| page up/down | Scroll by page |
+| top / bottom | Go to top/bottom |
+| find [text] | Search in page |
+| find next/previous | Navigate matches |
+| search [query] | Web search (DuckDuckGo) |
+| go to [url] | Navigate to URL |
+| open youtube | Open bookmark |
+| exit browser | Leave browser mode |
+
+Built-in bookmarks: youtube, google, gmail, github, reddit, twitter, facebook,
+amazon, netflix, duckduckgo
+
+## Dictation
+
+| Command | Action |
+|---------|--------|
+| notes | Start dictation mode |
+| stop notes | End dictation mode |
+| comma | Insert , |
+| period | Insert . |
+| question mark | Insert ? |
+| exclamation mark | Insert ! |
+| colon | Insert : |
+| semicolon | Insert ; |
+| apostrophe | Insert ' |
+| quote | Insert " |
+| dash | Insert - |
+| new line | Insert newline |
+| new paragraph | Insert double newline |
+| new sentence | Insert . and capitalize next |
+| backspace | Delete character |
+| space | Insert space |
+| tab | Insert tab |
+| at sign | Insert @ |
+| hashtag | Insert # |
+| percent | Insert % |
+| asterisk | Insert * |
+
+## Apps
+
+| Command | Action |
+|---------|--------|
+| open [app] | Launch application |
+| close [app] | Close application |
+
+Default apps live in `plugins/apps.py` (edit to match your system): firefox,
+steam, spotify, calculator, settings, files, terminal, browser, music player,
+and more. Some accept spoken aliases — e.g. "open music app" works the same as
+"open music player".
+
+## Files
+
+| Command | Action |
+|---------|--------|
+| open documents | Open Documents folder |
+| open downloads | Open Downloads folder |
+| open pictures | Open Pictures folder |
+| open music | Open Music folder |
+| open videos | Open Videos folder |
+| open projects | Open Projects folder |
+| open home | Open home folder |
+| open desktop | Open Desktop folder |
+
+## Media
+
+| Command | Action |
+|---------|--------|
+| play | Resume playback |
+| pause / stop the music | Pause playback |
+| next / skip | Next track |
+| previous / back | Previous track |
+
+## System
+
+| Command | Action |
+|---------|--------|
+| volume up/down (or louder / quieter) | Adjust volume one step (repeat to keep going) |
+| very loud / very silent | Jump straight to near-max (85%) / low (15%, not muted) |
+| mute | Toggle mute |
+| brightness up/down | Adjust brightness |
+| do not disturb on/off | Toggle notifications |
+
+Volume changes are silent — GNOME's own on-screen display and chime acknowledge
+them.
+
+## General
+
+| Command | Action |
+|---------|--------|
+| help | List all commands |
+| go to sleep / stop listening | Release the mic (reactivate from the tray icon) |
+| quit / exit / goodbye | Exit EasySpeak |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,5 @@
+<!--
+This page includes the repository-root CONTRIBUTING.md verbatim via
+pymdownx.snippets, so the root file stays the single source of truth.
+-->
+--8<-- "CONTRIBUTING.md"

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,67 @@
+# How it works
+
+- **Wake word** — OpenWakeWord detects "Hey Jarvis" instantly
+- **Speech-to-text** — faster-whisper transcribes commands locally
+- **Text-to-speech** — Piper provides voice feedback
+- **Mouse control** — GNOME Shell extension with Clutter virtual input
+- **Browser scroll** — JavaScript injection via qutebrowser IPC
+- **Dictation** — AT-SPI accessibility framework
+
+All processing happens locally. No data leaves your machine.
+
+## File structure
+
+```
+easyspeak/
+├── pyproject.toml
+├── src
+│   ├── extension.js           # GNOME Shell extension (bundled as package data)
+│   ├── metadata.json          # Extension metadata
+│   ├── core
+│   │   ├── __init__.py
+│   │   ├── __main__.py
+│   │   ├── cli.py             # CLI entry point: argument parsing + logging
+│   │   ├── config.py          # Tuning constants + Whisper model factory
+│   │   ├── gnome_extension.py # Installs/refreshes/enables the extension
+│   │   ├── log.py             # Logging setup
+│   │   ├── main.py            # EasySpeak class + main loop
+│   │   ├── mediakeys.py       # Replays multimedia keys via Mutter
+│   │   ├── speech.py          # Persistent piper -> player pipeline
+│   │   └── tray.py            # Panel indicator + asleep lifecycle
+│   └── plugins
+│       ├── __init__.py
+│       ├── 00_eyetrack.py     # Head tracking (experimental)
+│       ├── 00_mousegrid.py    # Grid overlay mouse control
+│       ├── apps.py            # Application launcher
+│       ├── browser.py         # Qutebrowser control + auto-config
+│       ├── dictation.py       # Voice-to-text + AT-SPI enablement
+│       ├── files.py           # Folder navigation
+│       ├── media.py           # Playback controls
+│       ├── sleep.py           # Voice deactivate
+│       ├── system.py          # Volume, brightness, DND
+│       └── zz_base.py         # Help and exit
+└── tests
+    ├── acceptance             # Gherkin scenarios (pytest-bdd)
+    ├── benchmarks             # pytest-benchmark suites for bencher.dev
+    ├── integration            # tests against real binaries
+    └── unit                   # tests for src/core/ and src/plugins/
+```
+
+## GNOME Shell extension
+
+On first start, core auto-installs the GNOME Shell extension to the user-local
+extensions directory (unless GNOME already sees it via a system-wide install).
+Files copied:
+
+```
+~/.local/share/gnome-shell/extensions/easyspeak-grid@local/
+├── extension.js
+├── extension-helpers.js
+└── metadata.json
+```
+
+The extension powers both the panel indicator and the mouse grid. On Wayland,
+GNOME Shell only scans for extensions at login, so a `oneshot` systemd *user*
+unit (installed by EasySpeak) re-copies the bundled files before the shell loads
+them at each login. See [`core.gnome_extension`][core.gnome_extension]
+for the full lifecycle.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,66 @@
+# EasySpeak
+
+Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
+
+Say "Hey Jarvis" and control your desktop with your voice.
+
+!!! warning "Early development"
+    This project works but is not polished. Expect bugs, incomplete docs, and
+    changes without notice.
+
+## Why EasySpeak?
+
+Linux desktop voice control is a gap. Talon exists but has a steep learning
+curve and costs money for the full version. Most other tools are X11-only,
+abandoned, or cloud-dependent.
+
+EasySpeak is:
+
+- **Free and open source** — GPL-3.0 licensed, no paywalls
+- **Fully local** — No cloud, no accounts, no data leaving your machine
+- **Wayland-native** — Works on modern GNOME desktops where X11 tools fail
+- **Simple** — Say "Hey Jarvis, open downloads" and it works
+- **Extensible** — Drop a Python file in `plugins/` to add commands
+
+Built for people with RSI, accessibility needs, hands-busy workflows, or anyone
+who wants to talk to their computer.
+
+## Features
+
+Current and in active development:
+
+- **Wake word activation** — Hands-free with "Hey Jarvis"
+- **Mouse grid** — Navigate anywhere on screen with voice ("grid", "3 7 5", "click")
+- **Head tracking** — Control cursor with head movement (experimental)
+- **Browser control** — Qutebrowser integration with link hints, tabs, scrolling
+- **Dictation** — Voice-to-text in any text field with punctuation commands
+- **App launcher** — Open and close applications by name
+- **Media control** — Play, pause, skip via MPRIS
+- **System controls** — Volume, brightness, do not disturb
+- **Fully local** — OpenWakeWord + Whisper + Piper, no cloud services
+- **Plugin architecture** — Easy to extend
+
+## Demo
+
+[![Demo](https://img.youtube.com/vi/dl5m2Zo1oIE/maxresdefault.jpg)](https://www.youtube.com/watch?v=dl5m2Zo1oIE)
+
+## Where to next?
+
+- [Installation](installation.md) — system packages, Python, Piper TTS
+- [Usage](usage.md) — running the daemon and the wake word
+- [Commands](commands.md) — the full command reference
+- [Writing Plugins](plugins.md) — extend EasySpeak with a Python file
+- [Troubleshooting](troubleshooting.md) — common problems and fixes
+- [How It Works](how-it-works.md) — the architecture
+- [API Reference](reference/core.md) — generated from the source docstrings
+
+## License
+
+GPL-3.0 License. See [LICENSE](https://github.com/ctsdownloads/easyspeak/blob/main/LICENSE) for details.
+
+## Acknowledgments
+
+- [OpenWakeWord](https://github.com/dscripka/openWakeWord) — Wake word detection
+- [faster-whisper](https://github.com/guillaumekln/faster-whisper) — Speech recognition
+- [Piper](https://github.com/OHF-Voice/piper1-gpl) — Text-to-speech (we use the last standalone binary from the original [rhasspy/piper](https://github.com/rhasspy/piper) repo)
+- [Talon](https://talonvoice.com/) — Inspiration for voice control concepts

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,95 @@
+# Installation
+
+## Requirements
+
+- Linux with GNOME Shell 47+ on Wayland
+- Python 3.12 (not 3.13 and 3.14 — see installation notes)
+- Working microphone
+- ~2 GB disk space for models
+
+Tested on Fedora 43.
+
+Fedora 43's default `python3` is 3.14. Unfortunately, we depend on a few Google
+packages that are not available for Python 3.13+ yet.
+
+```bash
+sudo dnf install python3.12
+python3.12 --version  # Verify it's installed
+```
+
+## 1. System packages
+
+```bash
+sudo dnf install \
+  pipewire-utils \
+  wireplumber \
+  at-spi2-core \
+  python3-gobject \
+  qutebrowser \
+  glib2 \
+  ffmpeg-free \
+  pulseaudio-utils \
+  sound-theme-freedesktop \
+  portaudio-devel \
+  python3.12-devel \
+  gcc
+```
+
+## 2. Python packages
+
+```bash
+python3.12 -m venv ~/easyspeak-venv
+source ~/easyspeak-venv/bin/activate
+pip install faster-whisper openwakeword numpy pyaudio
+cd ~/easyspeak
+pip install -e .
+```
+
+If you use `uv` you can ignore the steps that create a virtual environment and
+simply run:
+
+```bash
+uv run easyspeak
+```
+
+uv will transparently create and update a virtual environment, and run EasySpeak
+from in there.
+
+## 3. Piper TTS
+
+```bash
+mkdir -p ~/.local/bin
+cd ~/.local/bin
+wget https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_linux_x86_64.tar.gz
+tar xzf piper_linux_x86_64.tar.gz
+rm piper_linux_x86_64.tar.gz
+
+echo 'export PATH="$HOME/.local/bin/piper:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+mkdir -p ~/.local/share/piper
+cd ~/.local/share/piper
+wget -O en_US-amy-medium.onnx \
+  "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx"
+wget -O en_US-amy-medium.onnx.json \
+  "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx.json"
+```
+
+## 4. Clone the repository
+
+```bash
+git clone https://github.com/ctsdownloads/easyspeak.git ~/easyspeak
+cd ~/easyspeak
+```
+
+## Head tracking (optional)
+
+Head tracking requires a webcam and additional dependencies:
+
+```bash
+pip install sixdrepnet opencv-python
+# or
+pip install .[head-tracking]
+# or, with uv
+uv run --extra head-tracking easyspeak
+```

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,16 @@
+<!--
+This page includes the repository-root LICENSE verbatim via pymdownx.snippets,
+so the root file stays the single source of truth (GitHub's license detection
+and PyPI metadata both read it from there). It is wrapped in a code block to
+preserve the license text's original line breaks and indentation.
+-->
+# License
+
+EasySpeak is licensed under the **GNU General Public License v3.0**. The full
+text is reproduced below; the authoritative copy is the
+[`LICENSE`](https://github.com/ctsdownloads/easyspeak/blob/dev/LICENSE) file at
+the repository root.
+
+```text
+--8<-- "LICENSE"
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,81 @@
+# Writing plugins
+
+Drop a Python file in `plugins/` and it gets loaded automatically.
+
+```python
+NAME = "myplugin"
+DESCRIPTION = "What it does"
+
+COMMANDS = [
+    "say hello - speaks a greeting",
+]
+
+
+def setup(core):
+    """Called once at startup. Store the core reference if needed."""
+
+
+def handle(cmd, core):
+    """Called for every voice command.
+
+    Return True if handled, None to pass to the next plugin.
+    """
+    if "say hello" in cmd:
+        core.speak("Hello there!")
+        return True
+    return None
+```
+
+## The plugin contract
+
+A module is loaded as a plugin if it exposes a `NAME` and a `handle` function.
+There is no base class to subclass — plugins follow a duck-typed protocol:
+
+```mermaid
+classDiagram
+    class PluginContract {
+        <<protocol>>
+        +str NAME
+        +str DESCRIPTION
+        +list COMMANDS
+        +setup(core)
+        +handle(cmd, core)
+    }
+    PluginContract <|.. base
+    PluginContract <|.. apps
+    PluginContract <|.. browser
+    PluginContract <|.. dictation
+    PluginContract <|.. mousegrid
+```
+
+- `NAME` — short identifier shown in the help screen (required)
+- `DESCRIPTION` — one-line summary for the help screen
+- `COMMANDS` — list of `"phrase - description"` strings for the help screen
+- `setup(core)` — optional one-time hook; store the `core` reference and do any
+  host-environment setup here
+- `handle(cmd, core)` — required; returns `True` if it consumed the command,
+  `False` to make the daemon exit, or `None` to pass the command on
+
+## Core methods you can use
+
+| Method | Purpose |
+|--------|---------|
+| `core.speak("text")` | Text-to-speech response |
+| `core.host_run(["cmd", "arg"])` | Run a shell command |
+| `core.transcribe(audio)` | Transcribe audio to text |
+| `core.wait_for_speech()` | Wait for the user to start speaking |
+| `core.record_until_silence()` | Record until the user stops |
+| `core.deactivate()` | Put the assistant to sleep |
+
+The full surface is documented on the [`EasySpeak`][core.main.EasySpeak]
+class.
+
+## Loading order
+
+Plugins load alphabetically. Use number prefixes to control order
+(`00_mousegrid.py` loads before `apps.py`), and the `zz_` prefix loads the base
+plugin last so it acts as the catch-all for help and exit. Files whose names
+start with `_` are skipped.
+
+See the [Plugins API reference](reference/plugins.md) for the generated
+documentation of every bundled plugin.

--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -1,0 +1,39 @@
+# Core API
+
+The `core` package holds the voice-control engine: wake-word detection,
+transcription, command routing, speech output, the panel indicator, and the
+GNOME Shell extension lifecycle. Plugins receive an [`EasySpeak`][core.main.EasySpeak]
+instance and use its small public API (`speak`, `host_run`, `transcribe`,
+`wait_for_speech`, `record_until_silence`, `deactivate`, ...) to act on commands.
+
+## core.main
+
+::: core.main
+
+## core.cli
+
+::: core.cli
+
+## core.config
+
+::: core.config
+
+## core.log
+
+::: core.log
+
+## core.speech
+
+::: core.speech
+
+## core.tray
+
+::: core.tray
+
+## core.mediakeys
+
+::: core.mediakeys
+
+## core.gnome_extension
+
+::: core.gnome_extension

--- a/docs/reference/plugins.md
+++ b/docs/reference/plugins.md
@@ -1,0 +1,88 @@
+# Plugins API
+
+Every plugin is a plain Python module that follows a small contract rather than
+subclassing a base class. A module is loaded if it exposes a `NAME` string and a
+`handle(cmd, core)` function; the optional `setup(core)` hook runs once at
+startup, and `COMMANDS`/`DESCRIPTION` feed the help screen.
+
+```mermaid
+classDiagram
+    class PluginContract {
+        <<protocol>>
+        +str NAME
+        +str DESCRIPTION
+        +list COMMANDS
+        +setup(core)
+        +handle(cmd, core)
+    }
+    class base
+    class sleep
+    class system
+    class media
+    class files
+    class apps
+    class browser
+    class dictation
+    class mousegrid
+    class headtrack
+
+    PluginContract <|.. base
+    PluginContract <|.. sleep
+    PluginContract <|.. system
+    PluginContract <|.. media
+    PluginContract <|.. files
+    PluginContract <|.. apps
+    PluginContract <|.. browser
+    PluginContract <|.. dictation
+    PluginContract <|.. mousegrid
+    PluginContract <|.. headtrack
+
+    note for base "zz_base.py — loads last; help and exit fallback"
+    note for mousegrid "00_mousegrid.py — numeric prefix loads it early"
+    note for headtrack "00_eyetrack.py — numeric prefix loads it early"
+```
+
+`handle` returns `True` when it consumed the command, `False` to signal the
+daemon to exit, or `None` to pass the command to the next plugin. Load order is
+alphabetical, so numeric prefixes (`00_`) load a plugin early and the `zz_`
+prefix loads the base plugin last as the catch-all for help and exit.
+
+## base (zz_base)
+
+::: plugins.zz_base
+
+## sleep
+
+::: plugins.sleep
+
+## system
+
+::: plugins.system
+
+## media
+
+::: plugins.media
+
+## files
+
+::: plugins.files
+
+## apps
+
+::: plugins.apps
+
+## browser
+
+::: plugins.browser
+
+## dictation
+
+::: plugins.dictation
+
+## mousegrid (00_mousegrid)
+
+::: plugins.00_mousegrid
+
+## headtrack (00_eyetrack)
+
+::: plugins.00_eyetrack

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,92 @@
+# Troubleshooting
+
+## Mouse grid: "Failed to show grid — is extension enabled?"
+
+You don't install the extension yourself — EasySpeak does it automatically on
+startup, copying it to
+`~/.local/share/gnome-shell/extensions/easyspeak-grid@local/` and keeping it up
+to date (look for an `easyspeak: installed ...` or `easyspeak: updated ...`
+message). On Wayland, GNOME Shell only scans for new extensions at login, so you
+typically have to **log out and back in** before it becomes loadable.
+
+After re-login, enable it from the command line:
+
+```bash
+gnome-extensions enable easyspeak-grid@local
+```
+
+…or open the **Extensions** GNOME app and toggle *EasySpeak Grid* on.
+
+To remove it later:
+
+```bash
+gnome-extensions disable easyspeak-grid@local
+rm -rf ~/.local/share/gnome-shell/extensions/easyspeak-grid@local
+```
+
+…or click the trash icon next to *EasySpeak Grid* in the Extensions app.
+
+## Dictation not working
+
+EasySpeak enables the GNOME accessibility bridge on first run; log out and back
+in after seeing the `dictation: enabled GNOME toolkit-accessibility` message. If
+the auto-config printed a `WARNING` instead (e.g. on a non-GNOME or locked-down
+desktop), run it manually:
+
+```bash
+gsettings set org.gnome.desktop.interface toolkit-accessibility true
+# Log out and back in
+```
+
+## Browser plugin: link numbers don't work
+
+EasySpeak appends two required lines to `~/.config/qutebrowser/config.py` on
+first run (you'll see a `browser: wrote ...` or `browser: updated ...` message).
+If you see a `browser: note: ... is read-only` or a similar error instead, add
+these lines to the config module yourself:
+
+```python
+config.load_autoconfig(False)
+c.hints.chars = '0123456789'
+```
+
+## Wake word not detecting
+
+- Check the microphone: `arecord -d 3 test.wav && aplay test.wav`
+- Adjust `WAKE_THRESHOLD` (lower = more sensitive) — see [`core.config`][core.config]
+
+## Wake word triggers multiple times
+
+Mic gain too high. Lower the capture level:
+
+```bash
+alsamixer
+# Press F6 to select your mic device
+# Press Tab to switch to Capture
+# Lower to ~70
+```
+
+## Commands misheard
+
+- Adjust `SILENCE_THRESHOLD` — see [`core.config`][core.config]
+- Speak clearly after the beep
+
+## Piper permission denied
+
+```bash
+chmod +x ~/.local/bin/piper/piper
+chmod +x ~/.local/bin/piper/espeak-ng
+```
+
+## pip install fails with PyAV/Cython errors
+
+You're on Python 3.14 or 3.13. Use `python3.12` with a venv instead:
+
+```bash
+sudo dnf install python3.12 python3.12-devel
+python3.12 -m venv ~/easyspeak-venv
+source ~/easyspeak-venv/bin/activate
+pip install faster-whisper openwakeword numpy pyaudio
+cd ~/easyspeak
+pip install -e .
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,33 @@
+# Usage
+
+```bash
+source ~/easyspeak-venv/bin/activate   # Now python = venv's python3.12
+easyspeak                              # the project execution script
+```
+
+Activate the venv each time you open a new terminal. With `uv`, just run
+`uv run easyspeak` and it manages the environment for you.
+
+Say "Hey Jarvis" followed by a command. After a command that gives no spoken
+reply (such as volume changes), EasySpeak keeps listening for a few seconds so
+you can chain commands — say "louder", "louder", "louder" without repeating the
+wake word each time.
+
+## Command-line options
+
+| Flag | Effect |
+|------|--------|
+| `-v`, `--verbose` | Show debug output |
+| `-q`, `--quiet` | Show only warnings and errors |
+
+Verbosity can also be set with the `EASYSPEAK_LOG_LEVEL` environment variable
+(e.g. `DEBUG`, `INFO`, `WARNING`); the command-line flags take precedence.
+
+See [`core.cli`][core.cli] and [`core.log`][core.log] for
+the underlying argument parsing and logging setup.
+
+## Configuration
+
+Behaviour is tuned through `EASYSPEAK_*` environment variables (wake threshold,
+Whisper model, Piper model path, and more). The full list lives in
+[`core.config`][core.config].

--- a/justfile
+++ b/justfile
@@ -106,6 +106,11 @@ benchmark *args:
     uv run --extra=benchmark pytest tests/benchmarks/ \
         --benchmark-json=results.json {{ args }}
 
+# Build the docs (use `serve` to serve at http://127.0.0.1:8000 with live-reload)
+[group('release')]
+docs *args=('build --strict'):
+    uv run --extra=docs mkdocs {{ args }}
+
 # Build package and check metadata
 [group('release')]
 package *args:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Plugins: reference/plugins.md
   - Contributing: contributing.md
   - Changelog: changelog.md
+  - License: license.md
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,96 @@
+site_name: EasySpeak
+site_description: Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
+site_url: https://ctsdownloads.github.io/easyspeak/
+repo_url: https://github.com/ctsdownloads/easyspeak
+repo_name: ctsdownloads/easyspeak
+copyright: Copyright &copy; EasySpeak contributors — GPL-3.0
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - toc.follow
+    - search.suggest
+
+# CHANGELOG.md and CONTRIBUTING.md stay authoritative at the repo root; the docs
+# pages pull them in via pymdownx.snippets (the --8<-- directive), so they are
+# never duplicated. snippets' base_path lets those root files resolve.
+docs_dir: docs
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Usage: usage.md
+  - Commands: commands.md
+  - Writing Plugins: plugins.md
+  - Troubleshooting: troubleshooting.md
+  - How It Works: how-it-works.md
+  - API Reference:
+      - Core: reference/core.md
+      - Plugins: reference/plugins.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          # The package dir is `easyspeak = "src"` (see pyproject.toml), so the
+          # source lives under src/ and griffe analyses it statically from
+          # there: modules resolve as `core.*` / `plugins.*`.
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            merge_init_into_class: true
+            separate_signature: true
+            # Render Mermaid class/inheritance diagrams from the type hierarchy.
+            show_inheritance_diagram: true
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path: [.]
+      check_paths: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+extra:
+  version:
+    provider: mike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ benchmark = [
 ]
 docs = [
   "mike>=2.1",
+  # Cap MkDocs below 2.0: the 2.0 line may drop the plugin API that
+  # mkdocstrings/mike rely on, so stay on the plugin-supporting 1.x lineage.
+  "mkdocs<2",
   "mkdocs-material>=9.5",
   "mkdocstrings[python]>=0.27",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,9 +137,6 @@ ignore = [
   "TRY300",  # an explicit return inside try reads clearer than an else block here
   "TRY301",  # raising inside try to trigger local cleanup is intentional
   "FBT002",  # the host_run(background=...) plugin convenience flag stays positional
-
-  # --- TODO: remove as docstrings are written for src/ (see docs effort) ---
-  "D101", "D102", "D103", "D107", "D200", "D205", "D209", "D212", "D415",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ benchmark = [
   "pytest>=8",
   "pytest-benchmark>=5",
 ]
+docs = [
+  "mike>=2.1",
+  "mkdocs-material>=9.5",
+  "mkdocstrings[python]>=0.27",
+]
 head-tracking = [
   "opencv-python>=4.13.0.90",
   "sixdrepnet>=0.1.6",

--- a/src/core/__main__.py
+++ b/src/core/__main__.py
@@ -1,5 +1,4 @@
-"""
-Application entry point when executed as a module, e.g.
+"""Application entry point when executed as a module, e.g.
 
 .. code:: console
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -48,4 +48,5 @@ def load_whisper_model(
     compute_type: str = WHISPER_COMPUTE_TYPE,
     cpu_threads: int = WHISPER_CPU_THREADS,
 ) -> WhisperModel:
+    """Build a faster-whisper model from the configured (or given) settings."""
     return WhisperModel(model_name, compute_type=compute_type, cpu_threads=cpu_threads)

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -35,14 +35,19 @@ EXTENSION_ASSETS = ("extension.js", "extension-helpers.js", "metadata.json")
 
 
 class RefreshResult(enum.Enum):
+    """Outcome of a single :func:`refresh_extension_files` attempt."""
+
     REFRESHED = "refreshed"
     UNCHANGED = "unchanged"
     ERROR = "error"
 
 
 def extension_source_dir():
-    """Package dir holding the bundled assets (``src/``), resolved relative to
-    this module so it works in both editable and wheel installs."""
+    """Return the package dir holding the bundled assets.
+
+    Resolved relative to this module (``src/``) so it works in both editable
+    and wheel installs.
+    """
     return Path(__file__).resolve().parents[1]
 
 
@@ -70,12 +75,14 @@ def _discard_staged(dest_dir):
 
 
 def refresh_extension_files(src_dir, dest_dir):
-    """Copy the bundled assets into ``dest_dir`` when they differ from the
-    installed copy. Best-effort: returns ``REFRESHED`` if written, ``UNCHANGED``
-    if already current, or ``ERROR`` (noted on stderr) when a source is missing
-    or a copy fails. Assets are staged then moved into place (extension.js last),
-    so a failure leaves any working install untouched and never installs
-    extension.js without the helper it imports."""
+    """Copy the bundled assets into ``dest_dir`` when they differ from it.
+
+    Best-effort: returns ``REFRESHED`` if written, ``UNCHANGED`` if already
+    current, or ``ERROR`` (noted on stderr) when a source is missing or a copy
+    fails. Assets are staged then moved into place (extension.js last), so a
+    failure leaves any working install untouched and never installs extension.js
+    without the helper it imports.
+    """
     srcs = {name: src_dir / name for name in EXTENSION_ASSETS}
     if not all(s.is_file() for s in srcs.values()):
         logger.warning("bundled GNOME extension sources missing at %s", src_dir)
@@ -107,8 +114,10 @@ def refresh_extension_files(src_dir, dest_dir):
 
 
 def refresh_installed_extension():
-    """Refresh the installed extension from the bundled copy; run by the systemd
-    unit at each login."""
+    """Refresh the installed extension from the bundled copy.
+
+    Run by the systemd user unit at each login.
+    """
     return refresh_extension_files(extension_source_dir(), extension_dest_dir())
 
 
@@ -142,9 +151,11 @@ WantedBy={PRE_SHELL_TARGET}
 
 
 def _run_systemctl(*args):
-    """Run a ``systemctl --user`` command, or return None if it can't be exec'd —
-    an un-execable systemctl raises OSError despite ``check=False``, and the
-    refresh-unit install must stay non-fatal."""
+    """Run a ``systemctl --user`` command, or return None if it can't be run.
+
+    An un-execable systemctl raises OSError despite ``check=False``, and the
+    refresh-unit install must stay non-fatal.
+    """
     try:
         return subprocess.run(
             ["systemctl", "--user", *args],
@@ -167,9 +178,11 @@ def _is_enabled():
 
 
 def install_refresh_unit():
-    """Install and enable the pre-shell refresh unit, returning a short status
-    string or None when nothing changed or it isn't applicable (no systemd,
-    write/enable failure). Idempotent."""
+    """Install and enable the pre-shell refresh unit, idempotently.
+
+    Returns a short status string, or None when nothing changed or it isn't
+    applicable (no systemd, write/enable failure).
+    """
     if shutil.which("systemctl") is None:
         return None
 
@@ -200,9 +213,12 @@ def install_refresh_unit():
 
 
 def ensure_extension():
-    """Install the bundled extension if missing, keep the installed copy current,
-    and enable it, reporting what it did. Skipped on non-GNOME desktops; non-fatal
-    on missing sources or write failures."""
+    """Install, refresh, and enable the bundled extension, reporting what it did.
+
+    Installs it if missing, keeps the installed copy current, and enables it.
+    Skipped on non-GNOME desktops; non-fatal on missing sources or write
+    failures.
+    """
     if shutil.which("gnome-extensions") is None:
         return
 
@@ -321,6 +337,7 @@ def ensure_extension():
 
 
 def main():
+    """Refresh the installed extension; entry point for the systemd unit."""
     refresh_installed_extension()
     return 0
 

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -1,5 +1,4 @@
-"""
-EasySpeak Core - Voice Control for Linux
+"""EasySpeak Core - Voice Control for Linux.
 
 Loads plugins from plugins/ folder automatically.
 Uses OpenWakeWord for fast wake detection.
@@ -46,7 +45,16 @@ logger = logging.getLogger(__name__)
 
 
 class EasySpeak:
+    """The voice-control daemon: wake detection, transcription, and routing.
+
+    Owns the audio pipeline (wake word -> Whisper), the loaded plugins, the
+    text-to-speech pipeline, and the panel indicator, and exposes the small
+    plugin-facing API (:meth:`speak`, :meth:`host_run`, :meth:`transcribe`, ...)
+    that plugins use to act on commands.
+    """
+
     def __init__(self):
+        """Initialise daemon state; models and audio are loaded later in run()."""
         self.plugins = []
         self.whisper = None
         self.wakeword = None
@@ -96,15 +104,25 @@ class EasySpeak:
             return False
 
     def deactivate(self):
-        """Request the assistant go to sleep: release the mic and stop wake
-        detection until reactivated from the tray. Plugin-facing; the actual
-        release happens at the next main-loop iteration (handled by the tray
-        controller) so the triggering command can finish, and speak, first."""
+        """Request the assistant go to sleep (plugin-facing).
+
+        Releases the mic and stops wake detection until reactivated from the
+        tray. The actual release happens at the next main-loop iteration
+        (handled by the tray controller) so the triggering command can finish,
+        and speak, first.
+        """
         self.tray.request_sleep()
 
     # --- Plugin management ---
 
     def load_plugins(self):
+        """Discover and import every plugin module from the ``plugins/`` dir.
+
+        Files are loaded in sorted order (numeric prefixes set load order);
+        names starting with ``_`` are skipped. A module is registered only if it
+        exposes ``NAME`` and ``handle``; its optional ``setup`` hook runs once.
+        Import or setup failures are logged and skipped, never fatal.
+        """
         plugins_dir = Path(__file__).parent.parent / "plugins"
         if not plugins_dir.exists():
             logger.warning("No plugins directory found")
@@ -134,7 +152,7 @@ class EasySpeak:
                 logger.warning("  ✗ Failed to load %s: %s", file.name, e)
 
     def get_all_commands(self):
-        """Get all commands from all plugins for help text"""
+        """Get all commands from all plugins for help text."""
         commands = []
         for plugin in self.plugins:
             if hasattr(plugin, "COMMANDS"):
@@ -205,8 +223,11 @@ class EasySpeak:
         self.keep_listening = True
 
     def _show_help(self):
-        """Display the command list via the plugin that owns it (the base
-        plugin's ``show_help``), so the help text isn't duplicated here."""
+        """Display the command list via the plugin that owns it.
+
+        Delegates to the base plugin's ``show_help`` so the help text isn't
+        duplicated here.
+        """
         for plugin in self.plugins:
             if hasattr(plugin, "show_help"):
                 plugin.show_help(self)
@@ -231,8 +252,11 @@ class EasySpeak:
             )
 
     def _close_stream(self):
-        """Release the microphone so other apps — and GNOME's privacy mic
-        indicator — see it as free. The PyAudio instance is kept for reopening."""
+        """Release the microphone so other apps see it as free.
+
+        Also clears GNOME's privacy mic indicator. The PyAudio instance is kept
+        for reopening.
+        """
         if self.stream is None:
             return
         for release in (self.stream.stop_stream, self.stream.close):
@@ -250,9 +274,14 @@ class EasySpeak:
             )
 
     def is_silence(self, audio_chunk):
+        """Return True if the audio chunk's mean amplitude is below the threshold."""
         return np.abs(audio_chunk).mean() < SILENCE_THRESHOLD
 
     def record_until_silence(self):
+        """Record mic audio until a short silence, capped at five seconds.
+
+        Returns the captured PCM bytes. Plugin-facing.
+        """
         frames = []
         silent_chunks = 0
         chunks_needed = int(SILENCE_DURATION * 16000 / 1600)
@@ -272,6 +301,11 @@ class EasySpeak:
         return b"".join(frames)
 
     def wait_for_speech(self, timeout=5):
+        """Block until speech is heard, returning its first PCM chunk.
+
+        Returns None if nothing is heard within ``timeout`` seconds.
+        Plugin-facing.
+        """
         for _ in range(int(timeout * 16000 / 1600)):
             pcm = self.stream.read(1600, exception_on_overflow=False)
             if not self.is_silence(np.frombuffer(pcm, dtype=np.int16)):
@@ -279,6 +313,11 @@ class EasySpeak:
         return None
 
     def transcribe(self, audio_data, prompt=None):
+        """Transcribe raw PCM audio to text with Whisper.
+
+        ``prompt`` biases recognition (defaults to the command vocabulary).
+        Plugin-facing.
+        """
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
             with wave.open(f.name, "wb") as wf:
                 wf.setnchannels(1)
@@ -297,14 +336,19 @@ class EasySpeak:
     # --- Main loop ---
 
     def _reset_detector(self):
-        """Clear the wake detector's feature buffer and drop buffered mic audio,
-        so stale or half-primed state can't fire a spurious wake."""
+        """Reset the wake detector and drop buffered mic audio.
+
+        Stale or half-primed state can't then fire a spurious wake.
+        """
         self.wakeword.reset()
         self.flush_stream()
 
     def _play_wake_chime(self):
-        """Play the wake acknowledgement sound, then flush the audio it bled
-        into the mic so it isn't mistaken for the user speaking."""
+        """Play the wake acknowledgement sound, then flush the mic.
+
+        Flushing drops the chime audio that bled into the mic so it isn't
+        mistaken for the user speaking.
+        """
         subprocess.run(
             ["paplay", "/usr/share/sounds/freedesktop/stereo/message.oga"],
             capture_output=True,
@@ -312,10 +356,12 @@ class EasySpeak:
         self.flush_stream()
 
     def _drain_feedback(self):
-        """Wait for the spoken "didn't understand" feedback to finish playing,
-        then flush the mic. speak() is non-blocking, so flushing alone leaves the
-        still-playing tail for the open mic to transcribe into the next
-        escalation (e.g. opening help) with no one having spoken."""
+        """Wait for the "didn't understand" feedback to finish, then flush the mic.
+
+        speak() is non-blocking, so flushing alone leaves the still-playing tail
+        for the open mic to transcribe into the next escalation (e.g. opening
+        help) with no one having spoken.
+        """
         self.speech.drain()
         self.flush_stream()
 
@@ -363,6 +409,11 @@ class EasySpeak:
         return False
 
     def run(self):
+        """Load models and plugins, then run the wake-word listen loop forever.
+
+        Blocks until the user quits (voice command, tray, or Ctrl-C), always
+        releasing the microphone and draining speech on the way out.
+        """
         logger.info("Loading OpenWakeWord...")
         self.wakeword = WakeWordModel()
 

--- a/src/core/mediakeys.py
+++ b/src/core/mediakeys.py
@@ -1,7 +1,7 @@
-"""Replay multimedia keys through GNOME (Mutter) so the desktop renders its own
-native feedback — the volume OSD and the chime — rather than imitating them.
+"""Replay multimedia keys through GNOME (Mutter) for native desktop feedback.
 
-Pressing a volume key does not run any command: gnome-settings-daemon grabs the
+This lets the desktop render its own volume OSD and chime rather than imitating
+them. Pressing a volume key does not run any command: gnome-settings-daemon grabs the
 raw evdev key and handles the volume change, OSD and chime itself. The only way
 to reproduce that exactly is to replay the key. We inject it through Mutter's
 RemoteDesktop interface, which needs no special privileges. A RemoteDesktop

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -79,6 +79,7 @@ class SpeechPipeline:
     """
 
     def __init__(self):
+        """Create an idle pipeline; the subprocesses are spawned on first use."""
         self._piper = None
         self._player = None
 
@@ -231,9 +232,11 @@ class SpeechPipeline:
             SpeechPipeline._reap(proc)
 
     def drain(self):
-        """Flush pending speech and wait for playback to finish, then stop the
-        pipeline. Used on shutdown so a final phrase (e.g. "Goodbye.") is heard
-        in full before the process exits."""
+        """Flush pending speech, wait for playback, then stop the pipeline.
+
+        Used on shutdown so a final phrase (e.g. "Goodbye.") is heard in full
+        before the process exits.
+        """
         piper, player = self._piper, self._player
         self._piper = self._player = None
         if piper is not None:

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -72,6 +72,10 @@ class Tray:
     """
 
     def __init__(self, control_file=CONTROL_FILE, speak=None):
+        """Set up the controller, optionally with a spoken-feedback callback.
+
+        ``speak`` defaults to a no-op so the tray works headless and in tests.
+        """
         self._control_file = Path(control_file)
         self._sleep_requested = False
         # Spoken feedback callback (core.speak). The plugin only announces the
@@ -91,9 +95,11 @@ class Tray:
         self.set_state(STATE_LISTENING)
 
     def request_sleep(self):
-        """Queue a deactivate (e.g. the "go to sleep" voice command); the mic is
-        released at the audio loop's next :meth:`poll`, after the current command
-        finishes."""
+        """Queue a deactivate (e.g. the "go to sleep" voice command).
+
+        The mic is released at the audio loop's next :meth:`poll`, after the
+        current command finishes.
+        """
         self._sleep_requested = True
 
     def poll(self, release_mic, acquire_mic):

--- a/src/plugins/00_eyetrack.py
+++ b/src/plugins/00_eyetrack.py
@@ -1,6 +1,6 @@
-"""
-Head Tracking Plugin - Cursor control via SixDRepNet
-Uses 6D rotation representation for smooth head pose estimation
+"""Head Tracking Plugin - Cursor control via SixDRepNet.
+
+Uses a 6D rotation representation for smooth head pose estimation.
 """
 
 import contextlib
@@ -39,12 +39,13 @@ NUDGE_AMOUNT = 15
 
 
 class OneEuroFilter:
-    """
-    One-Euro Filter for smoothing noisy signals.
-    Adapts: smooth when still, responsive when moving.
+    """One-Euro filter for smoothing noisy signals.
+
+    Adaptive: smooth when the signal is still, responsive when it moves.
     """
 
     def __init__(self, freq=30.0, min_cutoff=1.0, beta=0.007, d_cutoff=1.0):
+        """Initialise the filter's cutoff/responsiveness parameters."""
         self.freq = freq
         self.min_cutoff = min_cutoff
         self.beta = beta
@@ -58,6 +59,7 @@ class OneEuroFilter:
         return 1.0 / (1.0 + tau / te)
 
     def __call__(self, x):
+        """Filter the next sample ``x`` and return the smoothed value."""
         if self.x_prev is None:
             self.x_prev = x
             return x
@@ -82,16 +84,18 @@ class OneEuroFilter:
 
 
 def setup(c):
+    """Store the core reference for use by the plugin's handlers."""
     global core
     core = c
 
 
 def host_run(cmd):
+    """Run a command and capture its output (the plugin's own subprocess seam)."""
     return subprocess.run(cmd, capture_output=True, text=True)
 
 
 def dbus_call(method, *args):
-    """Call GNOME Shell extension for cursor movement"""
+    """Call GNOME Shell extension for cursor movement."""
     cmd = [
         "gdbus",
         "call",
@@ -109,7 +113,7 @@ def dbus_call(method, *args):
 
 
 def get_screen_size():
-    """Get screen size from GNOME Shell extension"""
+    """Get screen size from GNOME Shell extension."""
     result = host_run(
         [
             "gdbus",
@@ -134,7 +138,7 @@ def get_screen_size():
 
 
 def run_tracking():
-    """Main tracking loop"""
+    """Main tracking loop."""
     global tracking_active, stop_event, cursor_x, cursor_y, frozen
 
     import cv2
@@ -342,6 +346,7 @@ def run_tracking():
 
 
 def start_tracking():
+    """Start the head-tracking thread; returns (started, message)."""
     global tracking_active, tracking_thread, stop_event, frozen
 
     if tracking_active:
@@ -356,6 +361,7 @@ def start_tracking():
 
 
 def stop_tracking():
+    """Signal the tracking thread to stop; returns (stopped, message)."""
     global tracking_active, stop_event
     stop_event.set()
     tracking_active = False
@@ -364,7 +370,7 @@ def stop_tracking():
 
 
 def recalibrate():
-    """Reset calibration - will auto-calibrate on next frames"""
+    """Reset calibration - will auto-calibrate on next frames."""
     # center_yaw/pitch are in the tracking thread scope, so restart tracking
     if tracking_active:
         stop_tracking()
@@ -375,6 +381,7 @@ def recalibrate():
 
 
 def handle(cmd, core):
+    """Start/stop tracking or run a tracking command; None if not head-tracking."""
     global cursor_x, cursor_y
     cmd_lower = cmd.lower()
 
@@ -415,7 +422,7 @@ def handle(cmd, core):
 
 
 def listen_for_tracking_commands(core):
-    """Continuous listening while tracking active"""
+    """Continuous listening while tracking active."""
     global tracking_active, cursor_x, cursor_y, frozen
 
     SCREEN_W, SCREEN_H = get_screen_size()

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -1,5 +1,4 @@
-"""
-Mouse Grid Plugin - Voice-controlled mouse via GNOME Shell D-Bus extension
+"""Mouse Grid Plugin - Voice-controlled mouse via GNOME Shell D-Bus extension.
 
 Features:
 - Chained numbers: "3 7 5" zooms three times in one utterance
@@ -104,15 +103,18 @@ DIRECTIONS = {
 
 
 def setup(c):
+    """Store the core reference for use by the plugin's handlers."""
     global core
     core = c
 
 
 def host_run(cmd):
+    """Run a command and capture its output (the plugin's own subprocess seam)."""
     return subprocess.run(cmd, capture_output=True, text=True)
 
 
 def dbus_call(method, *args):
+    """Call a method on the grid extension over D-Bus; True on success."""
     cmd = [
         "gdbus",
         "call",
@@ -130,7 +132,7 @@ def dbus_call(method, *args):
 
 
 def get_screen_size():
-    """Get screen size from GNOME Shell extension (accurate for Wayland)"""
+    """Get screen size from GNOME Shell extension (accurate for Wayland)."""
     result = host_run(
         [
             "gdbus",
@@ -170,6 +172,7 @@ def get_screen_size():
 
 
 def cleanup():
+    """Hide the grid on interpreter exit so no overlay is left on screen."""
     dbus_call("Hide")
 
 
@@ -177,7 +180,7 @@ atexit.register(cleanup)
 
 
 def parse_number_sequence(text):
-    """Extract ALL numbers from text as a sequence. '3 7 5' -> [3, 7, 5]"""
+    """Extract ALL numbers from text as a sequence. '3 7 5' -> [3, 7, 5]."""
     # Replace word numbers with digits
     text_lower = text.lower()
     for word, num in WORD_TO_NUM.items():
@@ -200,6 +203,7 @@ def parse_count(text):
 
 
 def parse_direction(text):
+    """Return the direction (up/down/left/right) named in text, or None."""
     for direction, words in DIRECTIONS.items():
         for word in words:
             if word in text:
@@ -208,6 +212,7 @@ def parse_direction(text):
 
 
 def get_center():
+    """Return the (x, y) center of the current grid cell, or None if no grid."""
     if not grid_bounds:
         return None
     x, y, w, h = grid_bounds
@@ -218,6 +223,7 @@ def get_center():
 
 
 def show_grid():
+    """Show the full-screen grid overlay (no-op if it is already active)."""
     global grid_active, grid_bounds, screen_size
 
     if grid_active:
@@ -235,6 +241,7 @@ def show_grid():
 
 
 def close_grid():
+    """Hide the grid overlay and clear its bounds."""
     global grid_active, grid_bounds
     dbus_call("Hide")
     grid_active = False
@@ -295,6 +302,7 @@ def process_zones(zones):
 
 
 def do_click(click_type="click"):
+    """Click at the current cell center and close the grid; False if no grid."""
     global grid_bounds, grid_active, last_bounds
 
     center = get_center()
@@ -317,6 +325,7 @@ def do_click(click_type="click"):
 
 
 def do_scroll(direction, count=1):
+    """Scroll ``count`` steps at the current cell center; False if no grid."""
     global grid_bounds, grid_active, last_bounds
 
     center = get_center()
@@ -333,6 +342,7 @@ def do_scroll(direction, count=1):
 
 
 def nudge_grid(direction, count=1):
+    """Shift the current cell ``count`` steps in a direction; False if no grid."""
     global grid_bounds
 
     if not grid_bounds:
@@ -357,6 +367,11 @@ def nudge_grid(direction, count=1):
 
 
 def start_drag():
+    """Press at the current cell center and reset the grid to full screen.
+
+    Leaves a drag in progress so a later :func:`end_drag` releases at the new
+    target. False if no grid is active.
+    """
     global drag_start, grid_bounds
     center = get_center()
     if not center:
@@ -373,6 +388,10 @@ def start_drag():
 
 
 def end_drag():
+    """Release a drag started by :func:`start_drag` and close the grid.
+
+    False if no drag is in progress or no grid is active.
+    """
     global drag_start, grid_bounds, grid_active, last_bounds
     if not drag_start:
         logger.debug("  → No drag in progress")
@@ -393,6 +412,10 @@ def end_drag():
 
 
 def handle(cmd, core):
+    """Show or reopen the grid on a trigger word, then enter grid mode.
+
+    Returns None for commands that don't open the grid.
+    """
     global grid_active, grid_bounds, last_bounds, screen_size
 
     cmd_lower = cmd.lower().strip()
@@ -423,7 +446,7 @@ def handle(cmd, core):
 
 
 def listen_for_grid_commands(core):
-    """Continuous listening while grid active"""
+    """Continuous listening while grid active."""
     global grid_active, drag_start
 
     logger.info("Grid mode: say numbers (e.g. '3 7 5'), nudge, scroll, click, close")

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -1,6 +1,4 @@
-"""
-Apps Plugin - Launch and close applications
-"""
+"""Apps Plugin - Launch and close applications."""
 
 import os
 
@@ -75,6 +73,7 @@ core = None
 
 
 def setup(c):
+    """Store the core reference and resolve the user's default terminal."""
     global core
     core = c
     _register_terminal(c)
@@ -146,7 +145,7 @@ def _register_from_argv(argv, core):
 
 
 def find_app(name, core):
-    """Find app - returns (type, id)"""
+    """Find app - returns (type, id)."""
     if name in FLATPAK_APPS:
         result = core.host_run(["flatpak", "info", FLATPAK_APPS[name]])
         if result.returncode == 0:
@@ -163,6 +162,7 @@ def find_app(name, core):
 
 
 def launch_app(name, core):
+    """Launch the named app (flatpak or local binary); False if not found."""
     app_type, app_id = find_app(name, core)
     if app_type == "flatpak":
         core.host_run(["flatpak", "run", app_id], background=True)
@@ -174,6 +174,7 @@ def launch_app(name, core):
 
 
 def close_app(name, core):
+    """Close the named app (flatpak kill or pkill); False if not found."""
     app_type, app_id = find_app(name, core)
     if app_type == "flatpak":
         core.host_run(["flatpak", "kill", app_id])
@@ -185,6 +186,7 @@ def close_app(name, core):
 
 
 def handle(cmd, core):
+    """Open or close an app named in the command; return None if none matched."""
     all_apps = list(FLATPAK_APPS.keys()) + list(LOCAL_APPS.keys())
 
     for app in all_apps:

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -1,6 +1,4 @@
-"""
-Browser Plugin - Qutebrowser voice control via IPC
-"""
+"""Browser Plugin - Qutebrowser voice control via IPC."""
 
 import contextlib
 import logging
@@ -217,24 +215,25 @@ def _note_missing_qb_lines(cfg, lines, reason):
 
 
 def setup(c):
+    """Store the core reference and write the required qutebrowser config."""
     global core
     core = c
     ensure_qutebrowser_config()
 
 
 def qb(command):
-    """Send command to qutebrowser via IPC"""
+    """Send command to qutebrowser via IPC."""
     logger.debug("  🌐 qutebrowser :%s", command)
     core.host_run(["qutebrowser", f":{command}"])
 
 
 def qb_open(url):
-    """Open URL in qutebrowser"""
+    """Open URL in qutebrowser."""
     core.host_run(["qutebrowser", url])
 
 
 def parse_hint_numbers(cmd):
-    """Extract hint numbers from spoken words"""
+    """Extract hint numbers from spoken words."""
     clean = re.sub(r"[.,!?\-]", " ", cmd.lower())
     words = clean.split()
     digits = [HINT_NUMBERS[word] for word in words if word in HINT_NUMBERS]
@@ -242,7 +241,7 @@ def parse_hint_numbers(cmd):
 
 
 def looks_like_hint(cmd):
-    """Check if command looks like a hint number (short, mostly digits/number words)"""
+    """Check if command looks like a hint number (short, mostly digits/number words)."""
     clean = re.sub(r"[.,!?\-\s]", "", cmd.lower())
     # Must be short
     if len(clean) > 6:
@@ -319,7 +318,7 @@ def parse_hint_number(cmd):
 
 
 def parse_spoken_url(spoken):
-    """Convert spoken URL to actual URL. 'claude dot ai' -> 'https://claude.ai'"""
+    """Convert spoken URL to actual URL. 'claude dot ai' -> 'https://claude.ai'."""
     url = spoken.lower().strip()
 
     # Replace spoken elements
@@ -341,7 +340,7 @@ def parse_spoken_url(spoken):
 
 
 def listen_for_hint(core):
-    """Listen for hint number after showing hints"""
+    """Listen for hint number after showing hints."""
     logger.info("  🔢 Say hint number (e.g. 'zero two'), 'exit links' to cancel")
 
     # Small delay to let hints render
@@ -441,6 +440,11 @@ def _is_reserved_global(cmd_lower):
 
 
 def handle(cmd, core):
+    """Enter browser mode on a browser command; return None otherwise.
+
+    A matching command launches qutebrowser (if needed) and runs the continuous
+    browser-mode loop; reserved global commands (sleep/quit) are passed through.
+    """
     cmd_lower = cmd.lower().strip(".,!? ")
 
     # Global sleep/quit commands belong to other plugins; if we matched them as
@@ -469,7 +473,7 @@ def handle(cmd, core):
 
 
 def browser_mode(core):
-    """Continuous listening for browser commands"""
+    """Continuous listening for browser commands."""
     core.speak("Browser")
     logger.info("=== BROWSER MODE ACTIVE ===")
     logger.info("Say commands directly. 'exit browser' to leave.")
@@ -517,6 +521,7 @@ def browser_mode(core):
 
 
 def handle_browser_command(cmd_lower, core):
+    """Execute a single in-browser command; False if it isn't recognised."""
     # --- Hints ---
     if cmd_lower in [
         "numbers",

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -1,6 +1,4 @@
-"""
-Dictation Plugin - Voice to text via AT-SPI
-"""
+"""Dictation Plugin - Voice to text via AT-SPI."""
 
 import logging
 import os
@@ -73,6 +71,7 @@ def ensure_gnome_accessibility():
 
 
 def setup(c):
+    """Store the core reference and enable the GNOME accessibility bridge."""
     global core
     core = c
     ensure_gnome_accessibility()
@@ -128,7 +127,7 @@ def insert_text(text):
 
 
 def format_text(text):
-    """Convert spoken punctuation to actual punctuation"""
+    """Convert spoken punctuation to actual punctuation."""
     text = text.strip()
 
     # Strip ALL punctuation Whisper auto-adds; only explicit commands add it back
@@ -222,6 +221,11 @@ def format_text(text):
 
 
 def handle(cmd, core):
+    """Enter dictation mode on "notes"; return None for other commands.
+
+    While in dictation mode it loops, transcribing speech and inserting it into
+    the focused field until "stop notes" is heard.
+    """
     if ("notes" in cmd or "note" in cmd) and "stop" not in cmd:
         core.speak("Dictation")
 

--- a/src/plugins/files.py
+++ b/src/plugins/files.py
@@ -1,6 +1,4 @@
-"""
-Files Plugin - Open folders in file manager
-"""
+"""Files Plugin - Open folders in file manager."""
 
 import os
 
@@ -27,12 +25,13 @@ core = None
 
 
 def setup(c):
+    """Store the core reference for use by the plugin's handlers."""
     global core
     core = c
 
 
 def open_folder(path, core):
-    """Open folder in file manager"""
+    """Open a folder in the first available file manager; False if none found."""
     expanded = os.path.expanduser(path)
 
     file_managers = [
@@ -52,6 +51,7 @@ def open_folder(path, core):
 
 
 def handle(cmd, core):
+    """Open a known folder when the command names one; return None otherwise."""
     for folder, path in FOLDERS.items():
         if folder in cmd and (
             "open" in cmd or "go to" in cmd or "show" in cmd or "browse" in cmd

--- a/src/plugins/media.py
+++ b/src/plugins/media.py
@@ -1,6 +1,4 @@
-"""
-Media Plugin - Playback controls via MPRIS
-"""
+"""Media Plugin - Playback controls via MPRIS."""
 
 NAME = "media"
 DESCRIPTION = "Media playback controls"
@@ -16,11 +14,13 @@ core = None
 
 
 def setup(c):
+    """Store the core reference for use by the plugin's handlers."""
     global core
     core = c
 
 
 def get_media_players(core):
+    """Return the bus names of all running MPRIS media players."""
     result = core.host_run(
         [
             "dbus-send",
@@ -40,6 +40,10 @@ def get_media_players(core):
 
 
 def media_control(action, core):
+    """Send an MPRIS action (play/pause/next/previous) to every running player.
+
+    Returns False if no player is running or the action is unknown.
+    """
     players = get_media_players(core)
     if not players:
         return False
@@ -69,6 +73,7 @@ def media_control(action, core):
 
 
 def handle(cmd, core):
+    """Map a playback command to an MPRIS action; return None if not media."""
     # "stop the music"/"stop playing" mean pause; bare "stop" isn't a media command.
     # Whole-word match so "stop tracking" (eye tracking) isn't caught by "track".
     words = cmd.split()

--- a/src/plugins/sleep.py
+++ b/src/plugins/sleep.py
@@ -1,5 +1,4 @@
-"""
-Sleep Plugin - Deactivate the assistant by voice.
+"""Sleep Plugin - Deactivate the assistant by voice.
 
 "Go to sleep" (or "stop listening") releases the microphone and stops wake-word
 detection until the user reactivates EasySpeak from the GNOME tray indicator. It
@@ -22,6 +21,7 @@ SLEEP_PHRASES = ("go to sleep", "goto sleep", "stop listening")
 
 
 def handle(cmd, core):
+    """Deactivate the assistant on a sleep phrase; return None otherwise."""
     cmd_lower = cmd.lower().strip()
     if any(phrase in cmd_lower for phrase in SLEEP_PHRASES):
         # Announce only the attempt. The tray controller confirms once sleep

--- a/src/plugins/system.py
+++ b/src/plugins/system.py
@@ -1,6 +1,4 @@
-"""
-System Plugin - Volume, brightness, do not disturb
-"""
+"""System Plugin - Volume, brightness, do not disturb."""
 
 NAME = "system"
 DESCRIPTION = "System controls"
@@ -38,6 +36,7 @@ _POWER_SCREEN = [
 
 
 def setup(c):
+    """Store the core reference for use by the plugin's handlers."""
     global core
     core = c
 
@@ -53,18 +52,21 @@ def _media_key(core, keycode, fallback):
 
 
 def volume_up(core):
+    """Raise the volume one step."""
     _media_key(
         core, KEY_VOLUME_UP, ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%+"]
     )
 
 
 def volume_down(core):
+    """Lower the volume one step."""
     _media_key(
         core, KEY_VOLUME_DOWN, ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "10%-"]
     )
 
 
 def volume_mute(core):
+    """Toggle mute on the default audio sink."""
     _media_key(core, KEY_MUTE, ["wpctl", "set-mute", "@DEFAULT_AUDIO_SINK@", "toggle"])
 
 
@@ -79,6 +81,7 @@ def volume_min(core):
 
 
 def brightness_up(core):
+    """Raise screen brightness one step."""
     _media_key(
         core,
         KEY_BRIGHTNESS_UP,
@@ -87,6 +90,7 @@ def brightness_up(core):
 
 
 def brightness_down(core):
+    """Lower screen brightness one step."""
     _media_key(
         core,
         KEY_BRIGHTNESS_DOWN,
@@ -95,18 +99,21 @@ def brightness_down(core):
 
 
 def dnd_on(core):
+    """Enable do-not-disturb by hiding notification banners."""
     core.host_run(
         ["gsettings", "set", "org.gnome.desktop.notifications", "show-banners", "false"]
     )
 
 
 def dnd_off(core):
+    """Disable do-not-disturb by showing notification banners again."""
     core.host_run(
         ["gsettings", "set", "org.gnome.desktop.notifications", "show-banners", "true"]
     )
 
 
 def handle(cmd, core):
+    """Route a volume/brightness/DND command; return None if none matched."""
     # Volume -- "louder"/"quieter" etc. work on their own, without "volume"/"sound".
     # Match whole words so "silent" doesn't fire on "silently", "softer" on "softest"...
     words = cmd.split()

--- a/src/plugins/zz_base.py
+++ b/src/plugins/zz_base.py
@@ -1,6 +1,4 @@
-"""
-Base Plugin - Help and Exit
-"""
+"""Base Plugin - Help and Exit."""
 
 NAME = "base"
 DESCRIPTION = "Help and exit commands"
@@ -14,11 +12,17 @@ core = None
 
 
 def setup(c):
+    """Store the core reference for use by the plugin's handlers."""
     global core
     core = c
 
 
 def handle(cmd, core):
+    """Handle the help and exit commands; return None to pass others through.
+
+    Returns False to signal the daemon to exit, True if help was shown, or None
+    when the command is for another plugin.
+    """
     cmd_lower = cmd.lower().strip()
 
     # Exit - but NOT if it's "quit tracking" etc

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,7 @@ benchmark = [
 ]
 docs = [
     { name = "mike" },
+    { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
@@ -598,6 +599,7 @@ requires-dist = [
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "jeepney", specifier = ">=0.9" },
     { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1" },
+    { name = "mkdocs", marker = "extra == 'docs'", specifier = "<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'mypy'", specifier = ">=1.19.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -83,12 +83,106 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -477,6 +571,11 @@ benchmark = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
 ]
+docs = [
+    { name = "mike" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
 head-tracking = [
     { name = "opencv-python" },
     { name = "sixdrepnet" },
@@ -498,6 +597,9 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'unittest'", specifier = ">=7.14" },
     { name = "faster-whisper", specifier = ">=1.2.1" },
     { name = "jeepney", specifier = ">=0.9" },
+    { name = "mike", marker = "extra == 'docs'", specifier = ">=2.1" },
+    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.27" },
     { name = "mypy", marker = "extra == 'mypy'", specifier = ">=1.19.1" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "onnxruntime", specifier = ">=1.23.2" },
@@ -513,7 +615,7 @@ requires-dist = [
     { name = "sixdrepnet", marker = "extra == 'head-tracking'", specifier = ">=0.1.6" },
     { name = "types-pyaudio", marker = "extra == 'mypy'", specifier = ">=0.2.16.20250801" },
 ]
-provides-extras = ["acceptance", "benchmark", "head-tracking", "integration", "mypy", "unittest"]
+provides-extras = ["acceptance", "benchmark", "docs", "head-tracking", "integration", "mypy", "unittest"]
 
 [[package]]
 name = "exceptiongroup"
@@ -618,6 +720,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/d8/7a28537efd7638448f7512a0cce011d4e3bf1c7f4794ad4e9c87b3f1e98e/gherkin_official-29.0.0.tar.gz", hash = "sha256:dbea32561158f02280d7579d179b019160d072ce083197625e2f80a6776bb9eb", size = 32303, upload-time = "2024-08-12T09:41:09.595Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/fc/b86c22ad3b18d8324a9d6fe5a3b55403291d2bf7572ba6a16efa5aa88059/gherkin_official-29.0.0-py3-none-any.whl", hash = "sha256:26967b0d537a302119066742669e0e8b663e632769330be675457ae993e1d1bc", size = 37085, upload-time = "2024-08-12T09:41:07.954Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -919,6 +1042,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1117,6 +1249,152 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
 ]
 
 [[package]]
@@ -1592,6 +1870,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1796,6 +2083,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1851,6 +2147,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymdown-extensions"
+version = "10.21.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
 ]
 
 [[package]]
@@ -1985,6 +2294,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
     { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
     { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -2387,4 +2723,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]


### PR DESCRIPTION
Closes #66.

Migrates documentation out of the README into a hosted MkDocs site, per the decision recorded in #66 (Material theme + mkdocstrings + `mike` versioning + GitHub Pages via Actions).

## What's included

- **`mkdocs.yml` + `docs/`** — Material theme, mkdocstrings Python handler (configured with `paths: [src]`), search; narrative pages (install, usage, commands, plugins, troubleshooting, how-it-works) plus generated API reference for `core` / `plugins`.
- **Docstrings across `src/`** (Google convention) and removal of the temporary docstring entries from the Ruff TODO ignore block — Ruff's full rule set now applies to `src/`.
- **`.github/workflows/docs.yml`** — builds and deploys via `mike` to GitHub Pages (authored only; not run here).
- **CHANGELOG/CONTRIBUTING included via `pymdownx.snippets`** — root files stay authoritative, no duplication.
- **README trimmed** to a concise landing page linking into the docs.
- `docs` optional-dependencies group + `uv.lock` updated.

## Verification

`uv run --extra docs mkdocs build --strict` exits 0 (no warnings); `ruff check src/` passes with the docstring ignores removed; `pytest -q` green.

## Decisions worth a look

- **The plugins are not a class hierarchy.** They're duck-typed modules (`NAME`/`DESCRIPTION`/`COMMANDS`/`setup`/`handle`); `zz_base.py` is the help/exit *fallback module*, not a base class. The issue's "`zz_base` → concrete plugins inheritance diagram" doesn't exist as described, so the reference renders the actual protocol instead (hand-authored Mermaid `classDiagram`).
- **Recommend pinning `mkdocs<2`.** Given the MkDocs 2.0 / ProperDocs split (2.0 may drop plugin support), an unpinned `mkdocs` could pull a plugin-dropping release and break `mkdocstrings`/`mike`. Not yet pinned — easy to add here.
- `site_url`/`repo_url` are set to `ctsdownloads/easyspeak`; update if Pages is enabled elsewhere.