### PR TITLE
fix: address post-0.3.0 review findings (browser-launch trap, AT-SPI caret, hotkey shutdown)

### DIFF
--- a/src/core/hotkey.py
+++ b/src/core/hotkey.py
@@ -133,8 +133,16 @@ class HotkeyListener:
         self._thread.start()
 
     def stop(self):
-        """Stop the reader thread and release the keyboard devices."""
+        """Stop the reader thread, then release the keyboard devices.
+
+        Joins the thread first so it leaves its ``select()`` loop before the fds
+        close under it — closing a fd mid-select can raise in the thread. The
+        loop wakes within one POLL_TIMEOUT, so the join returns promptly.
+        """
         self._stop.set()
+        thread, self._thread = self._thread, None
+        if thread is not None:
+            thread.join(timeout=POLL_TIMEOUT + 1.0)
         for device in self._devices:
             with contextlib.suppress(Exception):
                 device.close()

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -191,6 +191,7 @@ class SpeechPipeline:
                 return
             except (BrokenPipeError, OSError, ValueError):
                 self._kill_speech()  # tear down the broken pipeline, then retry
+        logger.debug("speech pipeline unavailable; dropped phrase: %s", text)
 
     @staticmethod
     def _reap(proc):

--- a/src/plugins/_atspi_insert.py
+++ b/src/plugins/_atspi_insert.py
@@ -58,12 +58,32 @@ def find_focused_editable(atspi, obj, depth=0):
     return None
 
 
-def insert_into(target, text):
-    """Type ``text`` into ``target`` at the caret, honouring backspaces."""
-    try:
+def _insertion_point(target):
+    """Where to start inserting: the caret, else end-of-text, else None.
+
+    Falling back to the end keeps multi-character insertion in order; the old
+    code advanced from a bogus ``-1``, scattering later characters to the start.
+    None means neither the caret nor the character count was readable.
+    """
+    with contextlib.suppress(Exception):
         pos = target.get_caret_offset()
-    except Exception:
-        pos = -1
+        if pos >= 0:
+            return pos
+    with contextlib.suppress(Exception):
+        return target.get_character_count()
+    return None
+
+
+def insert_into(target, text):
+    """Type ``text`` into ``target`` at the caret, honouring backspaces.
+
+    Returns True once the text is inserted, or False if no usable insertion
+    point could be found — so the caller reports "no focus" rather than
+    scattering characters across the field.
+    """
+    pos = _insertion_point(target)
+    if pos is None:
+        return False
 
     for char in text:
         if char == BACKSPACE:
@@ -73,6 +93,7 @@ def insert_into(target, text):
         else:
             target.insert_text(pos, char, len(char.encode("utf-8")))
             pos += 1
+    return True
 
 
 def run(atspi, text):
@@ -81,8 +102,7 @@ def run(atspi, text):
     for i in range(desktop.get_child_count()):
         target = find_focused_editable(atspi, desktop.get_child_at_index(i))
         if target:
-            insert_into(target, text)
-            return OK
+            return OK if insert_into(target, text) else NO_FOCUS
     return NO_FOCUS
 
 

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -439,11 +439,25 @@ def _is_reserved_global(cmd_lower):
     )
 
 
+def _qutebrowser_running(core):
+    """Whether a qutebrowser instance is already running.
+
+    Used by :func:`handle` to gate ambiguous navigation commands: we only act
+    on them when there is actually a browser to receive them. ``pgrep -f``
+    (rather than ``-x``) matches however the binary is wrapped — e.g. a Nix
+    ``.qutebrowser-wrapped`` launcher — so an open browser isn't missed.
+    """
+    result = core.host_run(["pgrep", "-f", "qutebrowser"])
+    return getattr(result, "returncode", 1) == 0
+
+
 def handle(cmd, core):
     """Enter browser mode on a browser command; return None otherwise.
 
     A matching command launches qutebrowser (if needed) and runs the continuous
     browser-mode loop; reserved global commands (sleep/quit) are passed through.
+    Outside the explicit "open browser", navigation commands are only acted on
+    when a browser is already running, so ambiguous words can't open one.
     """
     cmd_lower = cmd.lower().strip(".,!? ")
 
@@ -457,6 +471,9 @@ def handle(cmd, core):
         core.host_run(["qutebrowser"], background=True)
         browser_mode(core)
         return True
+
+    if not _qutebrowser_running(core):
+        return None
 
     # --- Single browser commands → enters browser mode ---
     try:
@@ -521,7 +538,7 @@ def browser_mode(core):
 
 
 def handle_browser_command(cmd_lower, core):
-    """Execute a single in-browser command; False if it isn't recognised."""
+    """Execute a single in-browser command; None if it isn't recognised."""
     # --- Hints ---
     if cmd_lower in [
         "numbers",

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -282,12 +282,14 @@ def run_push_to_talk(core, should_continue):
 
 
 def handle(cmd, core):
-    """Enter dictation mode on "notes"; return None for other commands.
+    """Enter dictation mode on a whole-word "note"/"notes"; return None otherwise.
 
-    While in dictation mode it loops, transcribing speech and inserting it into
-    the focused field until "stop notes" is heard.
+    Matching whole words (not substrings) keeps unrelated words like "notebook"
+    or "noted" from triggering it. While in dictation mode it loops, transcribing
+    speech and inserting it into the focused field until "stop notes" is heard.
     """
-    if ("notes" in cmd or "note" in cmd) and "stop" not in cmd:
+    words = cmd.split()
+    if ("notes" in words or "note" in words) and "stop" not in words:
         core.speak("Dictation")
 
         logger.info("🎙️ Dictation mode - say 'stop notes' to end")
@@ -336,7 +338,5 @@ def handle(cmd, core):
             # Format and insert
             if _dictate_utterance(core, text):
                 return True
-
-        return True
 
     return None

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -1,8 +1,15 @@
 """Pytest fixtures for core module tests."""
 
-from unittest.mock import Mock
+import sys
+from unittest.mock import MagicMock, Mock
 
 import pytest
+
+# Stub the heavy native/model deps once for the whole core suite. conftest is
+# imported before any test module, so importing easyspeak.core.* below needs no
+# model or GPU. Assign directly (not setdefault) to override a real install too.
+for _name in ("pyaudio", "openwakeword", "openwakeword.model", "faster_whisper"):
+    sys.modules[_name] = MagicMock()
 
 
 def create_mock_plugin(name="TestPlugin", **kwargs) -> Mock:

--- a/tests/unit/core/test_cli.py
+++ b/tests/unit/core/test_cli.py
@@ -2,19 +2,11 @@
 
 import logging
 import shutil
-import sys
 from importlib import import_module
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
 import pytest
-
-# Mock external deps before importing the module
-sys.modules["pyaudio"] = MagicMock()
-sys.modules["openwakeword"] = MagicMock()
-sys.modules["openwakeword.model"] = MagicMock()
-sys.modules["faster_whisper"] = MagicMock()
-
-from easyspeak.core import cli  # noqa: E402
+from easyspeak.core import cli
 
 
 def test_dunder_main_module():

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,15 +1,10 @@
 """Tests for the core config module."""
 
 import importlib
-import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
-# Mock the heavy external dep before importing
-sys.modules["faster_whisper"] = MagicMock()
-
-from easyspeak.core import config  # noqa: E402
+from easyspeak.core import config
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/core/test_hotkey.py
+++ b/tests/unit/core/test_hotkey.py
@@ -3,18 +3,10 @@
 import logging
 import sys
 import types
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
-
-# Mirror the other core tests: stub heavy deps so importing the package stays
-# light. core.hotkey itself imports evdev only lazily, so it needs no stub.
-sys.modules["pyaudio"] = MagicMock()
-sys.modules["openwakeword"] = MagicMock()
-sys.modules["openwakeword.model"] = MagicMock()
-sys.modules["faster_whisper"] = MagicMock()
-
-from easyspeak.core.hotkey import HotkeyListener, parse_combo  # noqa: E402
+from easyspeak.core.hotkey import HotkeyListener, parse_combo
 
 # evdev key codes used by the fakes below (the real values).
 LEFTCTRL, RIGHTCTRL = 29, 97
@@ -218,6 +210,29 @@ class TestStop:
 
         h.stop()  # must not raise
 
+        assert h._devices == []
+
+    def test_stop_joins_reader_thread_before_closing_devices(self):
+        """The reader thread must leave select() before its fds are closed.
+
+        Closing a device out from under a blocked select() can raise in the
+        thread, so stop() joins it first. We assert the ordering directly.
+        """
+        h = HotkeyListener("ctrl+shift")
+        events = []
+        thread = Mock()
+        thread.join.side_effect = lambda **_kw: events.append("join")
+        device = Mock()
+        device.close.side_effect = lambda: events.append("close")
+        h._thread = thread
+        h._devices = [device]
+
+        h.stop()
+
+        assert h._stop.is_set()
+        thread.join.assert_called_once()
+        assert events == ["join", "close"]
+        assert h._thread is None
         assert h._devices == []
 
 

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -1,21 +1,13 @@
 """Tests for the core main module."""
 
 import subprocess
-import sys
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
-
-# Mock all external dependencies before importing the module
-sys.modules["pyaudio"] = MagicMock()
-sys.modules["openwakeword"] = MagicMock()
-sys.modules["openwakeword.model"] = MagicMock()
-sys.modules["faster_whisper"] = MagicMock()
-
-from easyspeak.core.main import EasySpeak  # noqa: E402
-from easyspeak.core.tray import TrayAction  # noqa: E402
+from easyspeak.core.main import EasySpeak
+from easyspeak.core.tray import TrayAction
 
 
 class TestEasySpeakInit:

--- a/tests/unit/core/test_speech.py
+++ b/tests/unit/core/test_speech.py
@@ -1,19 +1,10 @@
 """Tests for the core speech module (persistent piper -> player pipeline)."""
 
 import subprocess
-import sys
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
-
-# easyspeak.core.config imports faster_whisper at module load; stub the heavy
-# deps so importing the speech module doesn't require a model or GPU.
-sys.modules["pyaudio"] = MagicMock()
-sys.modules["openwakeword"] = MagicMock()
-sys.modules["openwakeword.model"] = MagicMock()
-sys.modules["faster_whisper"] = MagicMock()
-
-from easyspeak.core.speech import SpeechPipeline  # noqa: E402
+from easyspeak.core.speech import SpeechPipeline
 
 
 class TestSpeechPipeline:

--- a/tests/unit/core/test_tray.py
+++ b/tests/unit/core/test_tray.py
@@ -2,18 +2,9 @@
 
 import itertools
 import subprocess
-import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
-# Mirror the other core tests: stub heavy deps so importing the package stays
-# light (no model/GPU needed just to reach core.tray). Assign directly rather
-# than setdefault so a real install in the environment is overridden too.
-sys.modules["pyaudio"] = MagicMock()
-sys.modules["openwakeword"] = MagicMock()
-sys.modules["openwakeword.model"] = MagicMock()
-sys.modules["faster_whisper"] = MagicMock()
-
-from easyspeak.core.tray import (  # noqa: E402
+from easyspeak.core.tray import (
     COMMAND_QUIT,
     STATE_LISTENING,
     STATE_MUTED,

--- a/tests/unit/plugins/test_atspi_insert.py
+++ b/tests/unit/plugins/test_atspi_insert.py
@@ -19,10 +19,11 @@ class FakeState:
 class FakeAccessible:
     """A minimal AT-SPI accessible node for tree-walk tests."""
 
-    def __init__(self, states=(), children=(), caret=0, *, raises=False):
+    def __init__(self, states=(), children=(), caret=0, char_count=0, *, raises=False):
         self._state = FakeState(states)
         self._children = list(children)
         self.caret = caret
+        self.char_count = char_count
         self.raises = raises
         self.inserted = []
         self.deleted = []
@@ -42,6 +43,11 @@ class FakeAccessible:
         if self.caret is None:
             raise RuntimeError("no caret")
         return self.caret
+
+    def get_character_count(self):
+        if self.char_count is None:
+            raise RuntimeError("no count")
+        return self.char_count
 
     def insert_text(self, pos, char, length):
         self.inserted.append((pos, char, length))
@@ -143,8 +149,7 @@ def test_insert_into_types_characters():
     """Plain characters are inserted at the advancing caret."""
     node = FakeAccessible(caret=0)
 
-    helper.insert_into(node, "hi")
-
+    assert helper.insert_into(node, "hi") is True
     assert node.inserted == [(0, "h", 1), (1, "i", 1)]
 
 
@@ -166,13 +171,33 @@ def test_insert_into_backspace_at_start_is_noop():
     assert node.deleted == []
 
 
-def test_insert_into_unknown_caret_starts_at_minus_one():
-    """When the caret offset can't be read, insertion still proceeds."""
-    node = FakeAccessible(caret=None)
+def test_insert_into_unreadable_caret_appends_in_order():
+    """When the caret can't be read, text appends at the end — in order.
 
-    helper.insert_into(node, "x")
+    Regression: the old code started at ``-1`` and advanced, which placed the
+    first character at the end and the rest at the start, scrambling the text.
+    """
+    node = FakeAccessible(caret=None, char_count=5)
 
-    assert node.inserted == [(-1, "x", 1)]
+    assert helper.insert_into(node, "hi") is True
+    assert node.inserted == [(5, "h", 1), (6, "i", 1)]
+
+
+def test_insert_into_no_insertion_point_reports_failure():
+    """With neither caret nor character count, nothing is inserted."""
+    node = FakeAccessible(caret=None, char_count=None)
+
+    assert helper.insert_into(node, "hi") is False
+    assert node.inserted == []
+
+
+def test_run_reports_no_focus_when_insertion_point_unknown():
+    """A focused field whose position can't be read reports NO_FOCUS, not OK."""
+    target = FakeAccessible(states=["FOCUSED", "EDITABLE"], caret=None, char_count=None)
+    desktop = FakeAccessible(children=[target])
+
+    assert helper.run(FakeAtspi(desktop), "hi") == helper.NO_FOCUS
+    assert target.inserted == []
 
 
 # --- run / main ---

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -1,6 +1,6 @@
 """Tests for the browser plugin module."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from easyspeak.plugins import browser
@@ -599,6 +599,7 @@ def test_handle_browser_command_enters_mode(
     mock_browser_mode, mock_handle_cmd, mock_core
 ):
     """Test handle function enters browser mode after single command."""
+    mock_core.host_run.return_value = Mock(returncode=0)
     mock_handle_cmd.return_value = True
 
     result = browser.handle("back", mock_core)
@@ -634,7 +635,8 @@ def test_handle_declines_reserved_global_commands(mock_handle_cmd, command, mock
 
 @patch.object(browser, "handle_browser_command")
 def test_handle_unmatched_command(mock_handle_cmd, mock_core):
-    """Test handle function with unmatched command."""
+    """A running browser plus an unrecognised command falls through to None."""
+    mock_core.host_run.return_value = Mock(returncode=0)
     mock_handle_cmd.return_value = None
 
     result = browser.handle("unrelated command", mock_core)
@@ -648,6 +650,7 @@ def test_handle_browser_command_exception(
     mock_browser_mode, mock_handle_cmd, mock_core, readlog
 ):
     """Test handle function handles exceptions gracefully."""
+    mock_core.host_run.return_value = Mock(returncode=0)
     mock_handle_cmd.side_effect = Exception("Test error")
 
     result = browser.handle("back", mock_core)
@@ -655,6 +658,79 @@ def test_handle_browser_command_exception(
     assert result is True
     captured = readlog()
     assert "Browser error" in captured.out
+
+
+# Tests for the "only act when a browser is running" gate.
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["back", "down", "up", "top", "bottom", "reload", "02", "one"],
+)
+@patch.object(browser, "browser_mode")
+@patch.object(browser, "handle_browser_command")
+def test_handle_ignores_navigation_when_no_browser_running(
+    mock_handle_cmd, mock_browser_mode, command, mock_core
+):
+    """With no browser running, an ambiguous navigation word falls through
+    instead of launching qutebrowser and trapping the user in browser mode.
+
+    The lone host_run is the running-check itself, so nothing was launched.
+    """
+    mock_core.host_run.return_value = Mock(returncode=1)
+
+    result = browser.handle(command, mock_core)
+
+    assert result is None
+    mock_handle_cmd.assert_not_called()
+    mock_browser_mode.assert_not_called()
+    assert mock_core.host_run.call_count == 1
+    assert mock_core.host_run.call_args.args[0] == ["pgrep", "-f", "qutebrowser"]
+
+
+@patch.object(browser, "browser_mode")
+@patch.object(browser, "handle_browser_command", return_value=True)
+def test_handle_acts_on_navigation_when_browser_running(
+    mock_handle_cmd, mock_browser_mode, mock_core
+):
+    """With a browser running, a navigation word is handled as before."""
+    mock_core.host_run.return_value = Mock(returncode=0)
+
+    result = browser.handle("back", mock_core)
+
+    assert result is True
+    mock_handle_cmd.assert_called_once_with("back", mock_core)
+    mock_browser_mode.assert_called_once_with(mock_core)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["browser", "browser mode", "open browser", "launch browser"],
+)
+@patch.object(browser, "browser_mode")
+def test_handle_explicit_launch_bypasses_running_check(
+    mock_browser_mode, command, mock_core
+):
+    """Explicit "open browser" launches qutebrowser even when none is running."""
+    mock_core.host_run.return_value = Mock(returncode=1)
+
+    result = browser.handle(command, mock_core)
+
+    assert result is True
+    launch_calls = [
+        c for c in mock_core.host_run.call_args_list if c.args[0] == ["qutebrowser"]
+    ]
+    assert len(launch_calls) == 1
+    mock_browser_mode.assert_called_once_with(mock_core)
+
+
+@pytest.mark.parametrize("returncode, expected", [(0, True), (1, False)])
+def test_qutebrowser_running(returncode, expected, mock_core):
+    """_qutebrowser_running reflects pgrep's exit status."""
+    mock_core.host_run.return_value = Mock(returncode=returncode)
+
+    assert browser._qutebrowser_running(mock_core) is expected
+    assert mock_core.host_run.call_args.args[0] == ["pgrep", "-f", "qutebrowser"]
 
 
 # Tests for listen_for_hint function.

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -311,6 +311,38 @@ def test_handle_stop_notes_command(mock_insert, mock_core):
     assert not mock_insert.called
 
 
+@pytest.mark.parametrize(
+    "command",
+    ["notebook", "noted", "denote", "footnote", "notepad", "take notice"],
+)
+@patch("easyspeak.plugins.dictation.insert_text")
+def test_handle_ignores_words_merely_containing_note(mock_insert, command, mock_core):
+    """Words that only contain 'note' must not enter dictation mode.
+
+    Regression: a substring check fired dictation on 'notebook', 'noted', etc.
+    """
+    assert dictation.handle(command, mock_core) is None
+    mock_insert.assert_not_called()
+    mock_core.speak.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["notes", "note", "take notes", "new note", "notes please"],
+)
+@patch("easyspeak.plugins.dictation.insert_text")
+def test_handle_enters_dictation_on_note_word(
+    mock_insert, command, mock_core_with_audio
+):
+    """'note'/'notes' as a whole word still enters dictation mode."""
+    mock_core_with_audio.transcribe = Mock(return_value="stop notes")
+
+    assert dictation.handle(command, mock_core_with_audio) is True
+    assert ("Dictation",) in [
+        call.args for call in mock_core_with_audio.speak.call_args_list
+    ]
+
+
 @patch("easyspeak.plugins.dictation.insert_text", return_value=True)
 @patch("easyspeak.plugins.dictation.format_text", return_value="Hello")
 def test_handle_dictation_mode_single_input(


### PR DESCRIPTION
## What & why

An in-depth review of everything we touched since `0.3.0` (done with the `/python-code-reviewer` skill under Claude Code) turned up a handful of edge-case bugs that had gone unreviewed. This PR fixes them, with a regression test for each, plus a small test-suite consolidation.

Covers a genuinely painful day-to-day usability bug (browser plugin).

## Findings & fixes

### 1. Browser plugin launched qutebrowser from ambiguous words (the painful one)

Outside any browser context, a stray one-word command — `down`, `up`, `back`, `top`, `bottom`, `reload`, or a bare number — was matched as a browser command. Because `qb()` shells out to `qutebrowser :<cmd>`, that **spawned a fresh qutebrowser window and dropped the user into the 30s-listen browser-mode loop**, which is hard to escape.

Fix: `handle()` now only treats navigation commands as browser commands when a qutebrowser instance is actually running (`pgrep -f qutebrowser`, which matches wrapped launchers such as Nix's `.qutebrowser-wrapped`). Explicit `open browser` / `browser` still launches one from cold. `src/plugins/browser.py`.

### 2. AT-SPI insertion scrambled text when the caret offset was unreadable

`_atspi_insert.insert_into` started at `pos = -1` when `get_caret_offset()` raised, then advanced — so the first character landed at the end and the rest at the **start**, jumbling the text. Now it falls back to end-of-text (`get_character_count`) so insertion stays in order, and reports `NO_FOCUS` when no insertion point can be determined rather than corrupting the field. `src/plugins/_atspi_insert.py`.

### 3. Hotkey listener could raise on shutdown

`HotkeyListener.stop()` closed the device fds while the reader thread might still be blocked in `select()` on them. It now joins the thread (bounded by the poll timeout) before closing the devices. `src/core/hotkey.py`.

### 4. Dictation triggered on substrings of "note"

`("note" in cmd ...)` fired dictation on `notebook`, `noted`, `footnote`, etc. Now matched as whole words. Also removed an unreachable `return`. `src/plugins/dictation.py`.

### 5. `speak()` failed silently

After the retry loop gives up rebuilding a dead pipeline, it now logs at debug that the phrase was dropped. `src/core/speech.py`.

### 6. Docstring fix

`handle_browser_command` documented "False if not recognised" but returns `None`. `src/plugins/browser.py`.

## Tests

- Regression tests for each fix (the browser-launch gate, the caret fallback + no-focus reporting, the hotkey join-before-close ordering, the whole-word `note` matching).
- Consolidated the duplicated heavy-dependency import stubs (`pyaudio`/`openwakeword`/`faster_whisper`) that each core test module set up individually into `tests/unit/core/conftest.py`.

## Behaviour change to note

`go to <site>` / `search <query>` no longer auto-launch a browser when none is open — say `open browser` first. This is the deliberate trade-off behind fix of item 1 above: better than ambiguous words spawning windows unprompted.

## Checks

`ruff check`, `ruff format --check`, `mypy src` (23 files), and the unit suite (958 passing) all green, with coverage back at 100% (the 99% floor holds).