### PR TITLE
feat(tray): add About dialog and Help to the tray menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Requirements: Linux with GNOME Shell 47+ on Wayland, Python 3.12, a microphone, 
 ```bash
 # 1. System packages (Fedora; see the docs for the full list)
 sudo dnf install python3.12 python3.12-devel gcc portaudio-devel \
-  pipewire-utils wireplumber at-spi2-core python3-gobject qutebrowser \
+  pipewire-utils wireplumber at-spi2-core python3-gobject libadwaita qutebrowser \
   glib2 ffmpeg-free pulseaudio-utils sound-theme-freedesktop
 
 # 2. Get EasySpeak and run it (uv manages the virtualenv for you)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -20,6 +20,7 @@ easyspeak/
 │   ├── core
 │   │   ├── __init__.py
 │   │   ├── __main__.py
+│   │   ├── about.py           # Standalone libadwaita "About" window
 │   │   ├── cli.py             # CLI entry point: argument parsing + logging
 │   │   ├── config.py          # Tuning constants + Whisper model factory
 │   │   ├── gnome_extension.py # Installs/refreshes/enables the extension

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,6 +25,7 @@ sudo dnf install \
   wireplumber \
   at-spi2-core \
   python3-gobject \
+  libadwaita \
   qutebrowser \
   glib2 \
   ffmpeg-free \
@@ -34,6 +35,10 @@ sudo dnf install \
   python3.12-devel \
   gcc
 ```
+
+`python3-gobject` and `libadwaita` power the tray menu's **About EasySpeak**
+window. They ship with any GNOME desktop, so they're usually already present;
+they're listed here for the sake of minimal or non-GNOME installs.
 
 ## 2. Python packages
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,10 @@ dependencies = [
   "onnxruntime<1.24 ; python_full_version < '3.11'",
   "pyaudio>=0.2.14",
 ]
+# Not listed above: the "About" window (core.about) needs PyGObject + the GTK4
+# and libadwaita typelibs. On Linux those are system packages (PyGObject's own
+# recommended install path), not pip wheels, so they're a documented runtime
+# requirement rather than a dependency — the dialog simply no-ops without them.
 
 [project.optional-dependencies]
 acceptance = [

--- a/src/core/about.py
+++ b/src/core/about.py
@@ -1,0 +1,116 @@
+"""Standalone libadwaita "About EasySpeak" window.
+
+The daemon is headless and the panel indicator lives in a GNOME Shell extension
+(Clutter/St), which can't host GTK widgets; so the About dialog runs as its own
+short-lived process that the tray launches via ``python -m easyspeak.core.about``
+on the menu's "About" command. It uses libadwaita's ``AboutDialog`` (the modern,
+GNOME-recommended widget), falling back to the older ``AboutWindow`` on
+pre-1.5 libadwaita.
+
+Everything GUI is imported lazily inside :func:`main` so this module stays
+importable (for its metadata constants and version lookup) without PyGObject or
+a display present — which is how the unit suite exercises it.
+"""
+
+import importlib.metadata
+
+# --- Project metadata (single source of truth, shared with the tray) ---
+
+APP_ID = "io.github.ctsdownloads.EasySpeak"
+APPLICATION_NAME = "EasySpeak"
+# A themed icon that ships with every GNOME install; the project has no icon of
+# its own to bundle, and a microphone reads true for a voice assistant.
+APPLICATION_ICON = "audio-input-microphone"
+COMMENTS = "Voice control for Linux desktops. Fully local, no cloud, Wayland-native."
+COPYRIGHT = "© Matt Hartley and the EasySpeak contributors"
+
+REPO_URL = "https://github.com/ctsdownloads/easyspeak"
+DOCS_URL = "https://ctsdownloads.github.io/easyspeak/"
+ISSUES_URL = "https://github.com/ctsdownloads/easyspeak/issues"
+
+# The author/maintainer, shown as the headline developer.
+DEVELOPER_NAME = "Matt Hartley"
+DEVELOPERS = ["Matt Hartley <matt@matthartley.com>"]
+
+# Everyone else who has landed changes (bots excluded), shown in their own
+# credit section alongside the maintainer.
+CONTRIBUTORS = [
+    "Peter Bittner <peter@painless.software>",
+    "Tulip Blossom <tulilirockz@outlook.com>",
+    "Wolfgang Karl <kontakt@wkarl.net>",
+    "gband85 <gband85@mailfence.com>",
+]
+
+
+def app_version():
+    """Return the installed package version, or "" if it can't be determined.
+
+    Read at runtime (rather than hard-coded) so the dialog always shows the
+    version actually installed; an editable/source checkout without dist
+    metadata simply shows no version rather than failing.
+    """
+    try:
+        return importlib.metadata.version("easyspeak-linux")
+    except importlib.metadata.PackageNotFoundError:
+        return ""
+
+
+def main():  # pragma: no cover - needs libadwaita and a display; run live
+    """Show the About window and run until the user closes it."""
+    import gi
+
+    gi.require_version("Gtk", "4.0")
+    gi.require_version("Adw", "1")
+    from gi.repository import Adw, Gio
+
+    app = Adw.Application(application_id=APP_ID, flags=Gio.ApplicationFlags.FLAGS_NONE)
+    app.connect("activate", _present)
+    return app.run(None)
+
+
+def _present(app):  # pragma: no cover - needs libadwaita and a display; run live
+    """Build and present the About UI, quitting the app once it's dismissed."""
+    from gi.repository import Adw, Gtk
+
+    if hasattr(Adw, "AboutDialog"):
+        # libadwaita >= 1.5: the modern widget. A dialog attaches to a parent
+        # window; create a minimal host purely to own it, and quit on close.
+        dialog = Adw.AboutDialog(
+            application_name=APPLICATION_NAME,
+            application_icon=APPLICATION_ICON,
+            version=app_version(),
+            comments=COMMENTS,
+            website=REPO_URL,
+            issue_url=ISSUES_URL,
+            developer_name=DEVELOPER_NAME,
+            developers=DEVELOPERS,
+            copyright=COPYRIGHT,
+            license_type=Gtk.License.GPL_3_0,
+        )
+        dialog.add_link("Documentation", DOCS_URL)
+        dialog.add_credit_section("Contributors", CONTRIBUTORS)
+        host = Gtk.ApplicationWindow(application=app)
+        dialog.connect("closed", lambda *_: app.quit())
+        dialog.present(host)
+    else:
+        # libadwaita < 1.5: the older self-contained About window.
+        window = Adw.AboutWindow(
+            application=app,
+            application_name=APPLICATION_NAME,
+            application_icon=APPLICATION_ICON,
+            version=app_version(),
+            comments=COMMENTS,
+            website=REPO_URL,
+            issue_url=ISSUES_URL,
+            developer_name=DEVELOPER_NAME,
+            developers=DEVELOPERS,
+            copyright=COPYRIGHT,
+            license_type=Gtk.License.GPL_3_0,
+        )
+        window.add_link("Documentation", DOCS_URL)
+        window.add_credit_section("Contributors", CONTRIBUTORS)
+        window.present()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -21,8 +21,11 @@ import contextlib
 import enum
 import logging
 import subprocess
+import sys
 import time
 from pathlib import Path
+
+from .about import DOCS_URL
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,12 @@ STATE_MUTED = "muted"
 COMMAND_QUIT = "quit"
 COMMAND_MUTE = "mute"
 COMMAND_UNMUTE = "unmute"
+COMMAND_HELP = "help"  # open the documentation page in the default browser
+COMMAND_ABOUT = "about"  # open the libadwaita About window
+
+# The About window is its own process: the indicator lives in a GNOME Shell
+# extension that can't host GTK, so the daemon spawns this module instead.
+ABOUT_MODULE = "easyspeak.core.about"
 
 # Shared with the extension's ScreenshotManager, which creates ~/.cache/easyspeak.
 CONTROL_FILE = Path.home() / ".cache" / "easyspeak" / "control"
@@ -113,12 +122,43 @@ class Tray:
         command = self.take_command()
         if command == COMMAND_QUIT:
             return TrayAction.QUIT
+        if self._run_menu_action(command):
+            return TrayAction.CONTINUE
         if command == COMMAND_MUTE or self._sleep_requested:
             self._sleep_requested = False
             return self._sleep(release_mic, acquire_mic)
         return TrayAction.CONTINUE
 
     # --- internals ---
+
+    def _run_menu_action(self, command):
+        """Handle a fire-and-forget menu command (Help/About).
+
+        Returns True if it was one of those side-effect actions so callers can
+        carry on without touching the sleep/quit lifecycle. The indicator menu
+        is only shown while asleep, so in practice these fire from the idle loop
+        in :meth:`_sleep`; ``poll`` handles them too so the path isn't lifecycle-
+        dependent.
+        """
+        if command == COMMAND_HELP:
+            self._spawn(["xdg-open", DOCS_URL], "documentation page")
+            return True
+        if command == COMMAND_ABOUT:
+            self._spawn([sys.executable, "-m", ABOUT_MODULE], "About window")
+            return True
+        return False
+
+    def _spawn(self, cmd, what):
+        """Launch a detached helper process (best-effort).
+
+        Fire-and-forget: the daemon doesn't wait on or reap it, and a missing
+        binary just logs rather than disturbing the audio loop, mirroring the
+        rest of the controller's tolerance of a non-GNOME desktop.
+        """
+        try:
+            subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except OSError:
+            logger.warning("Couldn't open the %s.", what, exc_info=True)
 
     def _sleep(self, release_mic, acquire_mic):
         """Release the mic and idle until the tray asks to resume or quit.
@@ -154,6 +194,7 @@ class Tray:
                 acquire_mic()
                 self.set_state(STATE_LISTENING)
                 return TrayAction.RESUME
+            self._run_menu_action(command)
             if time.monotonic() >= next_repush:
                 self.set_state(STATE_MUTED)
                 next_repush = time.monotonic() + MUTED_REPUSH_INTERVAL

--- a/src/extension.js
+++ b/src/extension.js
@@ -554,6 +554,21 @@ class TrayIndicator extends PanelMenu.Button {
         reactivateItem.connect('activate', () => this._writeCommand('unmute'));
         this.menu.addMenuItem(reactivateItem);
 
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        // Help opens the docs and About shows the libadwaita window; both are
+        // handled by the daemon (which knows its own interpreter and the docs
+        // URL) via the same control-file channel as the other menu actions.
+        const helpItem = new PopupMenu.PopupMenuItem('Help');
+        helpItem.connect('activate', () => this._writeCommand('help'));
+        this.menu.addMenuItem(helpItem);
+
+        const aboutItem = new PopupMenu.PopupMenuItem('About EasySpeak');
+        aboutItem.connect('activate', () => this._writeCommand('about'));
+        this.menu.addMenuItem(aboutItem);
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
         const quitItem = new PopupMenu.PopupMenuItem('Quit EasySpeak');
         quitItem.connect('activate', () => {
             this._writeCommand('quit');

--- a/tests/unit/core/test_about.py
+++ b/tests/unit/core/test_about.py
@@ -1,0 +1,46 @@
+"""Tests for the standalone About window's metadata (core.about).
+
+The libadwaita UI itself can only run on a live GNOME session with a display,
+so it's excluded from coverage; these cover the gi-free parts: the version
+lookup and the credit constants the dialog is built from.
+"""
+
+import importlib.metadata
+from unittest.mock import patch
+
+from easyspeak.core import about
+
+
+class TestAppVersion:
+    """Tests for resolving the installed package version."""
+
+    @patch("easyspeak.core.about.importlib.metadata.version", return_value="1.2.3")
+    def test_returns_installed_version(self, mock_version):
+        """The dialog shows whatever version is actually installed."""
+        assert about.app_version() == "1.2.3"
+        assert mock_version.call_args.args[0] == "easyspeak-linux"
+
+    @patch(
+        "easyspeak.core.about.importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError,
+    )
+    def test_returns_empty_without_dist_metadata(self, mock_version):
+        """A source checkout with no dist metadata shows no version, not an error."""
+        assert about.app_version() == ""
+
+
+class TestCredits:
+    """Sanity checks on the metadata the About window advertises."""
+
+    def test_lists_author_and_contributors(self):
+        """The author headlines the developers; contributors are listed too."""
+        assert about.DEVELOPER_NAME == "Matt Hartley"
+        assert any("Matt Hartley" in d for d in about.DEVELOPERS)
+        assert about.CONTRIBUTORS
+        # No automated/bot accounts in the human credits.
+        assert not any("Copilot" in c for c in about.CONTRIBUTORS)
+
+    def test_links_out_to_the_project(self):
+        """The repo, docs and issues links are all real https URLs."""
+        for url in (about.REPO_URL, about.DOCS_URL, about.ISSUES_URL):
+            assert url.startswith("https://")

--- a/tests/unit/core/test_tray.py
+++ b/tests/unit/core/test_tray.py
@@ -2,9 +2,14 @@
 
 import itertools
 import subprocess
+import sys
 from unittest.mock import Mock, patch
 
+from easyspeak.core.about import DOCS_URL
 from easyspeak.core.tray import (
+    ABOUT_MODULE,
+    COMMAND_ABOUT,
+    COMMAND_HELP,
     COMMAND_QUIT,
     STATE_LISTENING,
     STATE_MUTED,
@@ -235,6 +240,72 @@ class TestPoll:
         ]
         # Entry push + at least one periodic re-push while idling.
         assert len(muted_pushes) >= 2
+
+
+class TestMenuActions:
+    """Tests for the fire-and-forget Help/About menu commands.
+
+    Both spawn a detached helper; ``subprocess.Popen`` is patched so nothing is
+    actually launched.
+    """
+
+    def _tray(self, commands):
+        tray = Tray(speak=Mock())
+        tray.take_command = Mock(side_effect=commands)
+        tray.set_state = Mock()
+        return tray
+
+    @patch("easyspeak.core.tray.subprocess.Popen")
+    def test_help_opens_docs_in_default_browser(self, mock_popen):
+        """A 'help' command opens the docs URL via xdg-open and carries on."""
+        tray = self._tray([COMMAND_HELP])
+
+        assert tray.poll(Mock(), Mock()) is TrayAction.CONTINUE
+        assert mock_popen.call_args.args[0] == ["xdg-open", DOCS_URL]
+
+    @patch("easyspeak.core.tray.subprocess.Popen")
+    def test_about_launches_the_about_module(self, mock_popen):
+        """An 'about' command spawns the About window with the daemon's own
+        interpreter and carries on."""
+        tray = self._tray([COMMAND_ABOUT])
+
+        assert tray.poll(Mock(), Mock()) is TrayAction.CONTINUE
+        cmd = mock_popen.call_args.args[0]
+        assert cmd[0] == sys.executable
+        assert cmd[1:] == ["-m", ABOUT_MODULE]
+
+    @patch("easyspeak.core.tray.subprocess.Popen")
+    def test_help_does_not_release_the_mic(self, mock_popen):
+        """Help is a side effect only; it never touches the sleep lifecycle."""
+        tray = self._tray([COMMAND_HELP])
+        release, acquire = Mock(), Mock()
+
+        tray.poll(release, acquire)
+
+        release.assert_not_called()
+        acquire.assert_not_called()
+
+    @patch("easyspeak.core.tray.subprocess.Popen")
+    def test_menu_actions_work_while_asleep(self, mock_popen):
+        """Help/About fire from the idle loop (where the menu is actually shown),
+        then a later 'unmute' wakes the daemon."""
+        tray = self._tray(["mute", COMMAND_HELP, COMMAND_ABOUT, "unmute"])
+        release, acquire = Mock(), Mock()
+
+        with patch("easyspeak.core.tray.time.sleep"):
+            action = tray.poll(release, acquire)
+
+        assert action is TrayAction.RESUME
+        spawned = [c.args[0][0] for c in mock_popen.call_args_list]
+        assert spawned == ["xdg-open", sys.executable]
+        acquire.assert_called_once()
+
+    @patch("easyspeak.core.tray.subprocess.Popen", side_effect=OSError("no xdg-open"))
+    def test_spawn_failure_is_swallowed(self, mock_popen):
+        """A missing helper binary logs but doesn't disturb the audio loop."""
+        tray = self._tray([COMMAND_HELP])
+
+        assert tray.poll(Mock(), Mock()) is TrayAction.CONTINUE
 
 
 class TestLifecycleHooks:


### PR DESCRIPTION
Adds two items to the tray menu (the GNOME Shell extension's panel indicator).

## What's new

- **Help** — opens the [documentation site](https://ctsdownloads.github.io/easyspeak/) in the system default browser.
- **About EasySpeak** — a libadwaita About window listing the author, maintainer and contributors, with links to the repo, docs and issues.

## How it works

- The shell extension runs in `gnome-shell` (Clutter/St) and **can't host GTK**, so the About window is a standalone process — `src/core/about.py` — that the daemon spawns via `python -m easyspeak.core.about`. It uses `Adw.AboutDialog` (falling back to `Adw.AboutWindow` on libadwaita < 1.5).
- Both menu items route through the **existing control-file channel** the daemon already polls (same path as Reactivate/Quit); the daemon opens the docs via `xdg-open` and launches the About process best-effort.

## Dependencies

PyGObject + the GTK4/libadwaita typelibs are a **documented system requirement**, not a pip dependency — that's PyGObject's recommended install path on Linux (no `pycairo` Linux wheels), it keeps the `uv`/CI workflow lean, and the dialog simply no-ops where they're absent. `python3-gobject` was already listed; `libadwaita` is added to the install docs.

## Tests & checks

- New unit tests for the tray commands (`Help`/`About` dispatch, spawn args, best-effort failure) and `core.about` metadata/version lookup.
- `ruff` (format + lint), `mypy`, `eslint`, the JS test suite, and the full unit suite all pass; **100% coverage** maintained (the GUI rendering is `# pragma: no cover` — it needs a live display).