### PR TITLE
refactor(extension): rename "EasySpeak Grid" to "EasySpeak"

### DIFF
--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -55,7 +55,7 @@ extensions directory (unless GNOME already sees it via a system-wide install).
 Files copied:
 
 ```
-~/.local/share/gnome-shell/extensions/easyspeak-grid@local/
+~/.local/share/gnome-shell/extensions/easyspeak@local/
 ├── extension.js
 ├── extension-helpers.js
 └── metadata.json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@
 
 You don't install the extension yourself — EasySpeak does it automatically on
 startup, copying it to
-`~/.local/share/gnome-shell/extensions/easyspeak-grid@local/` and keeping it up
+`~/.local/share/gnome-shell/extensions/easyspeak@local/` and keeping it up
 to date (look for an `easyspeak: installed ...` or `easyspeak: updated ...`
 message). On Wayland, GNOME Shell only scans for new extensions at login, so you
 typically have to **log out and back in** before it becomes loadable.
@@ -12,19 +12,19 @@ typically have to **log out and back in** before it becomes loadable.
 After re-login, enable it from the command line:
 
 ```bash
-gnome-extensions enable easyspeak-grid@local
+gnome-extensions enable easyspeak@local
 ```
 
-…or open the **Extensions** GNOME app and toggle *EasySpeak Grid* on.
+…or open the **Extensions** GNOME app and toggle *EasySpeak* on.
 
 To remove it later:
 
 ```bash
-gnome-extensions disable easyspeak-grid@local
-rm -rf ~/.local/share/gnome-shell/extensions/easyspeak-grid@local
+gnome-extensions disable easyspeak@local
+rm -rf ~/.local/share/gnome-shell/extensions/easyspeak@local
 ```
 
-…or click the trash icon next to *EasySpeak Grid* in the Extensions app.
+…or click the trash icon next to *EasySpeak* in the Extensions app.
 
 ## Dictation not working
 

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -22,7 +22,10 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-GRID_EXTENSION_UUID = "easyspeak-grid@local"
+EXTENSION_UUID = "easyspeak@local"
+# Pre-rename UUID (the extension was "easyspeak-grid@local" when it was just a
+# mouse grid). A leftover copy is cleaned up at startup; see migrate_legacy_extension.
+LEGACY_EXTENSION_UUID = "easyspeak-grid@local"
 REFRESH_UNIT_NAME = "easyspeak-extension-refresh.service"
 PRE_SHELL_TARGET = "gnome-session-pre.target"  # reached before org.gnome.Shell@*
 
@@ -51,16 +54,14 @@ def extension_source_dir():
     return Path(__file__).resolve().parents[1]
 
 
+def extensions_root():
+    """User-local directory GNOME Shell reads installed extensions from."""
+    return Path.home() / ".local" / "share" / "gnome-shell" / "extensions"
+
+
 def extension_dest_dir():
-    """User-local install location GNOME Shell reads extensions from."""
-    return (
-        Path.home()
-        / ".local"
-        / "share"
-        / "gnome-shell"
-        / "extensions"
-        / GRID_EXTENSION_UUID
-    )
+    """User-local install location for the bundled extension."""
+    return extensions_root() / EXTENSION_UUID
 
 
 def _staged_tmp(dest_dir, name):
@@ -212,6 +213,40 @@ def install_refresh_unit():
     )
 
 
+def migrate_legacy_extension():
+    """Remove the pre-rename extension install so it can't double-load.
+
+    The extension's UUID changed from ``easyspeak-grid@local`` to
+    ``easyspeak@local`` (it long outgrew being just a mouse grid). A leftover
+    copy under the old UUID would stay enabled and add a second panel indicator
+    and grid that the daemon no longer drives, so clean it up: disable it (so
+    GNOME drops it from the enabled set) then delete its directory. Best-effort
+    throughout — returns True if a legacy install was found and removed.
+
+    One-off migration shim: once users have had a release or two to upgrade past
+    ``easyspeak-grid@local`` this can be removed (call site and tests included).
+    """
+    legacy_dir = extensions_root() / LEGACY_EXTENSION_UUID
+    if not legacy_dir.is_dir():
+        return False
+    with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+        subprocess.run(
+            ["gnome-extensions", "disable", LEGACY_EXTENSION_UUID],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=SUBPROCESS_TIMEOUT,
+        )
+    shutil.rmtree(legacy_dir, ignore_errors=True)
+    logger.info(
+        "removed the legacy %s extension (renamed to %s) — log out and back in "
+        "to load the new one",
+        LEGACY_EXTENSION_UUID,
+        EXTENSION_UUID,
+    )
+    return True
+
+
 def ensure_extension():
     """Install, refresh, and enable the bundled extension, reporting what it did.
 
@@ -221,6 +256,8 @@ def ensure_extension():
     """
     if shutil.which("gnome-extensions") is None:
         return
+
+    migrate_legacy_extension()
 
     unit_status = install_refresh_unit()
     if unit_status:
@@ -246,12 +283,12 @@ def ensure_extension():
     if listed.returncode != 0:
         return
 
-    installed = GRID_EXTENSION_UUID in listed.stdout.split()
+    installed = EXTENSION_UUID in listed.stdout.split()
     # A failed --enabled probe leaves this False, so we fall through and try
     # enabling (a no-op when it's already on).
     already_enabled = (
         listed_enabled.returncode == 0
-        and GRID_EXTENSION_UUID in listed_enabled.stdout.split()
+        and EXTENSION_UUID in listed_enabled.stdout.split()
     )
     dest_dir = extension_dest_dir()
     root = extension_source_dir()
@@ -262,12 +299,12 @@ def ensure_extension():
             logger.info(
                 "updated GNOME extension %s to the bundled version — "
                 "log out and back in to load it",
-                GRID_EXTENSION_UUID,
+                EXTENSION_UUID,
             )
         elif result is RefreshResult.UNCHANGED:
             logger.info(
                 "GNOME extension %s already installed and enabled",
-                GRID_EXTENSION_UUID,
+                EXTENSION_UUID,
             )
         # ERROR was already noted by refresh_extension_files; stay quiet rather
         # than claim a healthy install.
@@ -297,7 +334,7 @@ def ensure_extension():
     # extension" until then — treated as "installed, log back in to use".
     try:
         enabled = subprocess.run(
-            ["gnome-extensions", "enable", GRID_EXTENSION_UUID],
+            ["gnome-extensions", "enable", EXTENSION_UUID],
             capture_output=True,
             text=True,
             check=False,
@@ -311,21 +348,21 @@ def ensure_extension():
         if ok:
             logger.info(
                 "enabled GNOME extension %s (was installed but disabled)",
-                GRID_EXTENSION_UUID,
+                EXTENSION_UUID,
             )
         else:
             logger.warning(
                 "GNOME extension %s is installed but disabled, and could not "
                 "be enabled. Try: gnome-extensions enable %s",
-                GRID_EXTENSION_UUID,
-                GRID_EXTENSION_UUID,
+                EXTENSION_UUID,
+                EXTENSION_UUID,
             )
         return
 
     if ok:
         logger.info(
             "installed and enabled GNOME extension %s at %s",
-            GRID_EXTENSION_UUID,
+            EXTENSION_UUID,
             dest_dir,
         )
     else:

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -1,7 +1,7 @@
 """GNOME panel-indicator bridge and asleep-state lifecycle for the daemon.
 
 The daemon is voice-first and otherwise headless; this module gives it a
-top-panel microphone icon (served by the bundled ``easyspeak-grid@local`` GNOME
+top-panel microphone icon (served by the bundled ``easyspeak@local`` GNOME
 Shell extension) and owns everything about it so the audio loop in ``core.main``
 stays about audio. It runs without a D-Bus server of its own via two
 one-directional channels:
@@ -209,9 +209,9 @@ class Tray:
             "--dest",
             "org.gnome.Shell",
             "--object-path",
-            "/org/easyspeak/Grid",
+            "/org/easyspeak/Desktop",
             "--method",
-            "org.easyspeak.Grid.SetState",
+            "org.easyspeak.Desktop.SetState",
             str(state),
         ]
         try:

--- a/src/extension.js
+++ b/src/extension.js
@@ -17,7 +17,7 @@ import {
 
 const DBUS_INTERFACE = `
 <node>
-  <interface name="org.easyspeak.Grid">
+  <interface name="org.easyspeak.Desktop">
     <!-- Grid overlay -->
     <method name="Show">
       <arg type="i" direction="in" name="width"/>
@@ -673,7 +673,7 @@ export default class EasySpeakGridExtension {
             SetState: (state) => this._tray.setState(state),
         });
 
-        this._dbus.export(Gio.DBus.session, '/org/easyspeak/Grid');
+        this._dbus.export(Gio.DBus.session, '/org/easyspeak/Desktop');
     }
 
     disable() {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,7 +1,7 @@
 {
-  "name": "EasySpeak Grid",
-  "description": "Voice-controlled navigation: window management, OCR click, and mouse grid",
-  "uuid": "easyspeak-grid@local",
+  "name": "EasySpeak",
+  "description": "Voice control for Linux — EasySpeak's GNOME Shell integration (panel indicator and on-screen surfaces).",
+  "uuid": "easyspeak@local",
   "shell-version": ["47", "48", "49", "50"],
-  "version": 2
+  "version": 3
 }

--- a/src/plugins/00_eyetrack.py
+++ b/src/plugins/00_eyetrack.py
@@ -103,9 +103,9 @@ def dbus_call(method, *args):
         "--dest",
         "org.gnome.Shell",
         "--object-path",
-        "/org/easyspeak/Grid",
+        "/org/easyspeak/Desktop",
         "--method",
-        f"org.easyspeak.Grid.{method}",
+        f"org.easyspeak.Desktop.{method}",
     ]
     cmd.extend(str(a) for a in args)
     result = host_run(cmd)
@@ -122,9 +122,9 @@ def get_screen_size():
             "--dest",
             "org.gnome.Shell",
             "--object-path",
-            "/org/easyspeak/Grid",
+            "/org/easyspeak/Desktop",
             "--method",
-            "org.easyspeak.Grid.GetScreenSize",
+            "org.easyspeak.Desktop.GetScreenSize",
         ]
     )
 

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -122,9 +122,9 @@ def dbus_call(method, *args):
         "--dest",
         "org.gnome.Shell",
         "--object-path",
-        "/org/easyspeak/Grid",
+        "/org/easyspeak/Desktop",
         "--method",
-        f"org.easyspeak.Grid.{method}",
+        f"org.easyspeak.Desktop.{method}",
     ]
     cmd.extend(str(a) for a in args)
     result = host_run(cmd)
@@ -141,9 +141,9 @@ def get_screen_size():
             "--dest",
             "org.gnome.Shell",
             "--object-path",
-            "/org/easyspeak/Grid",
+            "/org/easyspeak/Desktop",
             "--method",
-            "org.easyspeak.Grid.GetScreenSize",
+            "org.easyspeak.Desktop.GetScreenSize",
         ]
     )
 

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -193,7 +193,7 @@ def test_extension_dest_dir(tmp_path):
         / "share"
         / "gnome-shell"
         / "extensions"
-        / gnome_extension.GRID_EXTENSION_UUID
+        / gnome_extension.EXTENSION_UUID
     )
 
 
@@ -468,16 +468,87 @@ def test_main_refreshes_and_returns_zero():
 # --- ensure_extension --------------------------------------------------------
 
 
+class TestMigrateLegacyExtension:
+    """Tests for cleaning up the pre-rename (easyspeak-grid@local) install."""
+
+    def _legacy_dir(self, tmp_path):
+        return (
+            tmp_path
+            / ".local"
+            / "share"
+            / "gnome-shell"
+            / "extensions"
+            / gnome_extension.LEGACY_EXTENSION_UUID
+        )
+
+    def test_noop_when_no_legacy_install(self, tmp_path, readlog):
+        """Nothing to migrate: no subprocess, no deletion, no log, returns False."""
+        with (
+            patch.object(gnome_extension.Path, "home", return_value=tmp_path),
+            patch.object(gnome_extension.subprocess, "run") as mock_run,
+        ):
+            assert gnome_extension.migrate_legacy_extension() is False
+
+        mock_run.assert_not_called()
+        assert readlog().err == ""
+
+    def test_disables_and_removes_legacy_install(self, tmp_path, readlog):
+        """A leftover old install is disabled and its directory deleted."""
+        legacy = self._legacy_dir(tmp_path)
+        legacy.mkdir(parents=True)
+        (legacy / "extension.js").write_text("old")
+
+        with (
+            patch.object(gnome_extension.Path, "home", return_value=tmp_path),
+            patch.object(
+                gnome_extension.subprocess, "run", return_value=Mock(returncode=0)
+            ) as mock_run,
+        ):
+            assert gnome_extension.migrate_legacy_extension() is True
+
+        assert mock_run.call_args.args[0] == [
+            "gnome-extensions",
+            "disable",
+            gnome_extension.LEGACY_EXTENSION_UUID,
+        ]
+        assert not legacy.exists()
+        captured = readlog()
+        assert "removed the legacy" in captured.err
+        assert "log out and back in" in captured.err
+
+    def test_removes_dir_even_if_disable_fails(self, tmp_path):
+        """A missing/erroring `gnome-extensions disable` still deletes the dir."""
+        legacy = self._legacy_dir(tmp_path)
+        legacy.mkdir(parents=True)
+
+        with (
+            patch.object(gnome_extension.Path, "home", return_value=tmp_path),
+            patch.object(
+                gnome_extension.subprocess, "run", side_effect=OSError("no binary")
+            ),
+        ):
+            assert gnome_extension.migrate_legacy_extension() is True
+
+        assert not legacy.exists()
+
+
 class TestEnsureExtension:
     """Tests for the GNOME-extension install/enable lifecycle.
 
     The pre-shell refresh unit is stubbed here so these tests never touch real
     systemctl or the user's home; install_refresh_unit has its own tests above.
+    The legacy-install migration is likewise stubbed (it has its own tests) so it
+    neither deletes a real old install nor adds subprocess calls these tests count.
     """
 
     @pytest.fixture(autouse=True)
     def _stub_refresh_unit(self):
         with patch.object(gnome_extension, "install_refresh_unit", return_value=None):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def _stub_migrate(self):
+        with patch.object(gnome_extension, "migrate_legacy_extension"):
             yield
 
     @patch.object(gnome_extension.shutil, "which", return_value=None)
@@ -529,10 +600,10 @@ class TestEnsureExtension:
     def test_already_installed_and_enabled(self, mock_which, readlog):
         """UUID in both `list` and `list --enabled`, bundle unchanged: announce."""
         listed = Mock(
-            returncode=0, stdout="other@one.com\neasyspeak-grid@local\nthird@two.org\n"
+            returncode=0, stdout="other@one.com\neasyspeak@local\nthird@two.org\n"
         )
         listed_enabled = Mock(
-            returncode=0, stdout="easyspeak-grid@local\nother-on@two.org\n"
+            returncode=0, stdout="easyspeak@local\nother-on@two.org\n"
         )
         with (
             patch.object(
@@ -550,7 +621,7 @@ class TestEnsureExtension:
 
         captured = readlog()
         assert "already installed and enabled" in captured.err
-        assert "easyspeak-grid@local" in captured.err
+        assert "easyspeak@local" in captured.err
         # No `enable` call needed — only the two probe calls.
         assert mock_run.call_count == 2
 
@@ -560,8 +631,8 @@ class TestEnsureExtension:
     def test_already_installed_refreshes_changed_bundle(self, mock_which, readlog):
         """Installed+enabled but the bundled extension changed: refresh and tell
         the user to re-login so GNOME loads the new code."""
-        listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
-        listed_enabled = Mock(returncode=0, stdout="easyspeak-grid@local\n")
+        listed = Mock(returncode=0, stdout="easyspeak@local\n")
+        listed_enabled = Mock(returncode=0, stdout="easyspeak@local\n")
         with (
             patch.object(
                 gnome_extension.subprocess,
@@ -577,7 +648,7 @@ class TestEnsureExtension:
             gnome_extension.ensure_extension()
 
         captured = readlog()
-        assert "updated GNOME extension easyspeak-grid@local" in captured.err
+        assert "updated GNOME extension easyspeak@local" in captured.err
         assert "log out and back in" in captured.err
         # Still only the two probe calls — refresh is file I/O, not a subprocess.
         assert mock_run.call_count == 2
@@ -587,8 +658,8 @@ class TestEnsureExtension:
     )
     def test_reports_unit_install(self, mock_which, readlog):
         """ensure_extension surfaces whatever install_refresh_unit reports."""
-        listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
-        listed_enabled = Mock(returncode=0, stdout="easyspeak-grid@local\n")
+        listed = Mock(returncode=0, stdout="easyspeak@local\n")
+        listed_enabled = Mock(returncode=0, stdout="easyspeak@local\n")
         with (
             patch.object(
                 gnome_extension.subprocess,
@@ -616,7 +687,7 @@ class TestEnsureExtension:
     )
     def test_installed_but_disabled_enable_succeeds(self, mock_which, readlog):
         """UUID in `list` but not in `list --enabled`: flip it on and announce."""
-        listed = Mock(returncode=0, stdout="other@one.com\neasyspeak-grid@local\n")
+        listed = Mock(returncode=0, stdout="other@one.com\neasyspeak@local\n")
         listed_enabled = Mock(returncode=0, stdout="other-on@two.org\n")
         enabled = Mock(returncode=0, stdout="")
         with patch.object(
@@ -627,13 +698,13 @@ class TestEnsureExtension:
             gnome_extension.ensure_extension()
 
         captured = readlog()
-        assert "enabled GNOME extension easyspeak-grid@local" in captured.err
+        assert "enabled GNOME extension easyspeak@local" in captured.err
         assert "was installed but disabled" in captured.err
         assert mock_run.call_count == 3
         assert mock_run.call_args_list[2].args[0] == [
             "gnome-extensions",
             "enable",
-            "easyspeak-grid@local",
+            "easyspeak@local",
         ]
 
     @patch.object(
@@ -641,7 +712,7 @@ class TestEnsureExtension:
     )
     def test_installed_but_disabled_enable_fails(self, mock_which, readlog):
         """Installed-but-disabled and `enable` fails: hint, no log-out wording."""
-        listed = Mock(returncode=0, stdout="easyspeak-grid@local\n")
+        listed = Mock(returncode=0, stdout="easyspeak@local\n")
         listed_enabled = Mock(returncode=0, stdout="")
         enabled = Mock(returncode=1, stdout="")
         with patch.object(
@@ -653,7 +724,7 @@ class TestEnsureExtension:
 
         captured = readlog()
         assert "installed but disabled, and could not be enabled" in captured.err
-        assert "gnome-extensions enable easyspeak-grid@local" in captured.err
+        assert "gnome-extensions enable easyspeak@local" in captured.err
         # The "log out and back in" hint is only for fresh installs.
         assert "log out" not in captured.err
 
@@ -727,7 +798,7 @@ class TestEnsureExtension:
             / "share"
             / "gnome-shell"
             / "extensions"
-            / "easyspeak-grid@local"
+            / "easyspeak@local"
         )
         for name in gnome_extension.EXTENSION_ASSETS:
             assert not (dest / name).is_file()
@@ -759,7 +830,7 @@ class TestEnsureExtension:
             / "share"
             / "gnome-shell"
             / "extensions"
-            / "easyspeak-grid@local"
+            / "easyspeak@local"
         )
         assert (dest / "extension.js").is_file()
         assert (dest / "metadata.json").is_file()

--- a/tests/unit/core/test_tray.py
+++ b/tests/unit/core/test_tray.py
@@ -31,8 +31,8 @@ class TestSetState:
         cmd = mock_run.call_args.args[0]
         assert cmd[0] == "gdbus"
         assert "org.gnome.Shell" in cmd
-        assert "/org/easyspeak/Grid" in cmd
-        assert "org.easyspeak.Grid.SetState" in cmd
+        assert "/org/easyspeak/Desktop" in cmd
+        assert "org.easyspeak.Desktop.SetState" in cmd
         assert cmd[-1] == STATE_LISTENING
 
     @patch("easyspeak.core.tray.subprocess.run")

--- a/tests/unit/plugins/test_eyetrack.py
+++ b/tests/unit/plugins/test_eyetrack.py
@@ -72,9 +72,9 @@ def test_dbus_call(mock_host_run, method, args, expected_returncode, expected_re
     assert call_args[3] == "--dest"
     assert call_args[4] == "org.gnome.Shell"
     assert call_args[5] == "--object-path"
-    assert call_args[6] == "/org/easyspeak/Grid"
+    assert call_args[6] == "/org/easyspeak/Desktop"
     assert call_args[7] == "--method"
-    assert call_args[8] == f"org.easyspeak.Grid.{method}"
+    assert call_args[8] == f"org.easyspeak.Desktop.{method}"
     assert call_args[9:] == [str(a) for a in args]
 
 
@@ -99,8 +99,8 @@ def test_get_screen_size(mock_host_run, stdout, expected_size):
     call_args = mock_host_run.call_args.args[0]
     assert call_args[0] == "gdbus"
     assert call_args[4] == "org.gnome.Shell"
-    assert call_args[6] == "/org/easyspeak/Grid"
-    assert call_args[8] == "org.easyspeak.Grid.GetScreenSize"
+    assert call_args[6] == "/org/easyspeak/Desktop"
+    assert call_args[8] == "org.easyspeak.Desktop.GetScreenSize"
 
 
 @patch.object(eyetrack_plugin, "host_run", return_value=Mock(returncode=1, stdout=""))

--- a/tests/unit/plugins/test_mousegrid.py
+++ b/tests/unit/plugins/test_mousegrid.py
@@ -83,9 +83,9 @@ def test_dbus_call(mock_host_run, method, args, expected_returncode, expected_re
     assert call_args[3] == "--dest"
     assert call_args[4] == "org.gnome.Shell"
     assert call_args[5] == "--object-path"
-    assert call_args[6] == "/org/easyspeak/Grid"
+    assert call_args[6] == "/org/easyspeak/Desktop"
     assert call_args[7] == "--method"
-    assert call_args[8] == f"org.easyspeak.Grid.{method}"
+    assert call_args[8] == f"org.easyspeak.Desktop.{method}"
     assert call_args[9:] == [str(a) for a in args]
 
 


### PR DESCRIPTION
The bundled GNOME Shell extension is EasySpeak's **desktop-integration core**, not a single feature. It provides the always-present **panel indicator** (tray menu) and the **on-screen surfaces** that plugins drive. Naming it "Grid" tied the whole extension to one exchangeable plugin (the mouse grid) — and since features are plugins and more will come, it makes sense to name the extension after the app.

## What changed

| Identifier | Before | After |
|---|---|---|
| Display name (`metadata.json`) | `EasySpeak Grid` | `EasySpeak` |
| Description | feature list (`window management, OCR click, …`) | stable, core-focused tagline |
| UUID / install dir | `easyspeak-grid@local` | `easyspeak@local` |
| D-Bus interface + path | `org.easyspeak.Grid` `/org/easyspeak/Grid` | `org.easyspeak.Desktop` `/org/easyspeak/Desktop` |

Daemon-side callers (`tray.py`, `00_mousegrid.py`, `00_eyetrack.py`) and docs are updated to match. (`Desktop` replaces the placeholder `Shell` — the interface is the generic desktop-control surface EasySpeak drives, not GNOME Shell itself.)

## Migration

Since the UUID is the on-disk identity, a leftover old install would stay enabled and add a **second, daemon-less** panel indicator. `ensure_extension()` now runs a new `migrate_legacy_extension()` at startup that **disables and deletes** the old `easyspeak-grid@local` directory (best-effort, like the rest of the module). It's a one-off shim, slated for removal a couple of releases out.

⚠️ As with any extension change on Wayland, the new extension only loads at the **next login** — so after updating, log out and back in.

## Tests & checks

- New `TestMigrateLegacyExtension` covers the cleanup (present / absent / `disable` failing); existing `ensure_extension` tests stub the migration so they neither delete a real install nor miscount subprocess calls.
- `ruff` (format + lint), `mypy`, `eslint`, the JS suite (incl. the D-Bus contract test), and the full unit suite (970) all pass; **100% coverage** maintained.

Stacks on top of #73 (already merged); the two touch overlapping files on non-overlapping lines.