### PR TITLE
feat(packaging): native .deb/.rpm with split language data

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: taiki-e/install-action@just
     - run: |
         sudo apt update
-        sudo apt install -y portaudio19-dev
+        sudo apt install -y portaudio19-dev desktop-file-utils
     - run: just ${{ matrix.task }}
 
   js:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # upload assets to the release
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build .deb and .rpm
+      # Reuses the same containerised build as `just package-native`, so local
+      # and CI builds are byte-for-byte the same path. Strips a leading "v".
+      run: |
+        tag='${{ github.event.release.tag_name }}'
+        bash packaging/build-in-docker.sh "${tag#v}"
+    - name: Attach packages to the release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload '${{ github.event.release.tag_name }}' dist/*.deb dist/*.rpm --clobber

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ uv run easyspeak
 
 You also need [Piper TTS](https://ctsdownloads.github.io/easyspeak/installation/#3-piper-tts) installed for voice feedback. See the **[Installation guide](https://ctsdownloads.github.io/easyspeak/installation/)** for the venv-based path, head tracking, and full details.
 
+Prefer prebuilt packages? Grab the `easyspeak` app `.deb`/`.rpm` **plus a language
+pack** (e.g. `easyspeak-lang-en`) from the
+[Releases page](https://github.com/ctsdownloads/easyspeak/releases) and install them
+together — a self-contained, offline install (Python runtime, `piper`, GNOME
+extension, and speech models). See the
+**[Packaging guide](https://ctsdownloads.github.io/easyspeak/packaging/)**.
+
 Then say "Hey Jarvis" followed by a command. Say "help" to list all commands.
 
 ## Documentation

--- a/data/easyspeak.desktop
+++ b/data/easyspeak.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=EasySpeak
+GenericName=Voice Control
+Comment=Voice control for Linux desktops — fully local, Wayland-native
+Exec=easyspeak
+Icon=audio-input-microphone
+Terminal=false
+Categories=Utility;Accessibility;
+Keywords=voice;speech;dictation;accessibility;wayland;
+StartupNotify=false

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -16,6 +16,7 @@ easyspeak/
 ├── pyproject.toml
 ├── src
 │   ├── extension.js           # GNOME Shell extension (bundled as package data)
+│   ├── extension-helpers.js   # Pure JS helpers imported by extension.js
 │   ├── metadata.json          # Extension metadata
 │   ├── core
 │   │   ├── __init__.py

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,136 @@
+# Packaging
+
+EasySpeak ships **native `.deb` and `.rpm` packages**, split into two:
+
+- **`easyspeak`** (amd64) — the application: a self-contained Python runtime
+  (standalone CPython + all wheels, including the `piper` engine and the
+  `hey_jarvis` wake word) under `/opt/easyspeak`. No `pip`/`uv` step and no compiler
+  at install time. Desktop integration (launcher, GNOME Shell extension, AT-SPI
+  dictation helper) is wired to your system's GTK4 / PyGObject / AT-SPI packages,
+  declared as dependencies.
+- **`easyspeak-lang-en`** (noarch) — English speech data: the Whisper `base.en`
+  recognition model and the Piper `en_US-amy-medium` voice, under
+  `/opt/easyspeak/models`. More languages ship as `easyspeak-lang-*` packages.
+
+Splitting keeps the app small and lets you pick (or add) languages independently
+without re-downloading the runtime. See [Language](#language).
+
+> EasySpeak integrates deeply with the host (raw input devices, the AT-SPI bus,
+> session D-Bus, a GNOME Shell extension, and spawning host binaries). That is why
+> the supported formats are **unconfined native packages** — sandboxed formats
+> (Flatpak/Snap) fight every one of those integration points.
+
+## Install
+
+Download the latest packages from the
+[Releases page](https://github.com/ctsdownloads/easyspeak/releases) — grab **both**
+the app and a language pack — and install them **together** (the language pack is a
+separate file, not auto-fetched from GitHub):
+
+=== "Debian / Ubuntu"
+
+    ```bash
+    sudo apt install ./easyspeak_*_amd64.deb ./easyspeak-lang-en_*_all.deb
+    ```
+
+=== "Fedora / RHEL"
+
+    ```bash
+    sudo dnf install ./easyspeak-*.x86_64.rpm ./easyspeak-lang-en-*.noarch.rpm
+    ```
+
+This is **fully offline** (assuming the system dependencies — GTK4, PortAudio,
+PyGObject, … — are already present, as on any GNOME desktop). Then launch
+**EasySpeak** from the applications menu, or run `easyspeak`.
+
+Installing the app **without** a language pack also works: the wake word is built
+in, the Whisper model then downloads automatically on first run, and voice feedback
+stays off until you add a Piper voice.
+
+One non-package step remains: **log out and back in once** after the first launch so
+GNOME loads the bundled Shell extension (mouse grid + panel indicator).
+
+To use hold-to-dictate, add yourself to the `input` group (raw `/dev/input`
+access) and log back in:
+
+```bash
+sudo usermod -aG input "$USER"
+```
+
+## Language
+
+The default `easyspeak-lang-en` pack is **US English** — Whisper `base.en`
+(recognition) and Piper `en_US-amy-medium` (feedback). The `hey_jarvis` wake word is
+built into the app (it ships inside the OpenWakeWord wheel), so it stays English
+regardless of language pack.
+
+When present, the English pack is wired up automatically. To use another language —
+**whether or not we provide a package for it** — install/drop its models and point
+these environment variables at them (an explicit value always wins; set them in a
+systemd user override or your shell profile):
+
+- `EASYSPEAK_WHISPER_MODEL` — a multilingual faster-whisper model name (e.g. `base`,
+  `small`) or a local model directory. The English-only `*.en` models can't
+  transcribe other languages.
+- `EASYSPEAK_PIPER_MODEL` — path to a Piper voice `.onnx` (with its `.onnx.json`
+  next to it).
+
+So adding a language needs no root and no package from us: download any
+faster-whisper model and Piper voice, then set the two variables. A different wake
+word, however, needs a custom-trained OpenWakeWord model.
+
+## Build the packages yourself
+
+The packages are built in a clean Ubuntu container, so the result is identical
+whether produced locally or in CI — handy on NixOS, where the bundle's standalone
+CPython and manylinux wheels can't run on the host:
+
+```bash
+just package-native            # -> ./dist/ : app + language .deb and .rpm
+just package-native 1.2.3      # set an explicit version
+```
+
+This produces the `easyspeak` app packages and every `easyspeak-lang-*` data
+package. CI builds them automatically: `.github/workflows/release.yml` runs the same
+script on every published GitHub Release and attaches all archives to it.
+
+## Other distributions
+
+These formats are maintained **outside this repository**. The notes below capture
+what each one needs.
+
+### Nix / NixOS
+
+The repository's `flake.nix` is a **development environment only** — a `uv run`
+wrapper. It is **not** a deployable package; treat it purely as a reference. A
+real Nix package belongs upstream (e.g. nixpkgs) and must, in particular,
+**prepare the GTK4/libadwaita "About" dialog separately**: on NixOS its PyGObject
+and the GTK4/libadwaita typelibs can't ride inside the app venv and must be wired
+in explicitly (the same pattern the flake already uses for the AT-SPI dictation
+helper via `atspiPython` / `giTypelibPath`).
+
+### Arch (AUR)
+
+A `PKGBUILD` can reproduce the bundled-venv layout under `/opt/easyspeak`, or
+build against Arch's own Python. Declare the same runtime dependencies as the
+`.deb`/`.rpm` (PortAudio, GTK4, libadwaita, PyGObject, AT-SPI, and the optional
+`piper`/`qutebrowser`/PipeWire/PulseAudio tooling).
+
+### Fedora COPR
+
+A source build from an RPM `.spec` — effectively the `.rpm` recipe, built on
+Fedora's infrastructure for multiple Fedora/EPEL targets.
+
+### openSUSE Build Service (OBS)
+
+OBS can build **both** `.deb` and `.rpm` for many distributions from a single
+recipe; a good option if broad distro coverage is wanted later.
+
+### Flatpak / Snap
+
+Not provided. EasySpeak needs raw `/dev/input`, the AT-SPI accessibility bus,
+broad session D-Bus access (Mutter RemoteDesktop, GNOME Shell, MPRIS), the ability
+to install a GNOME Shell extension into your home directory, and to spawn host
+binaries (`piper`, `qutebrowser`, `gnome-extensions`, `gsettings`, …). Granting all
+of that to a sandbox removes the confinement that is the whole point of those
+formats.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
             pkgs.just
             pkgs.eslint # JS linter for the GNOME Shell extension (see `just lint-js`)
             pkgs.nodejs # `node --test` for the extension's JS helpers (see `just test-js`)
+            pkgs.desktop-file-utils # desktop-file-validate for the launcher (see `just gate`)
           ]
           ++ runtimeTools
           ++ buildTools;

--- a/justfile
+++ b/justfile
@@ -149,6 +149,8 @@ gate: (clean '--quiet') (package '--quiet')
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension-helpers.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q metadata.json
+    # The desktop launcher shipped in the .deb/.rpm must be valid.
+    desktop-file-validate data/easyspeak.desktop
 
 # Verify package version is same as Git tag
 [group('release')]
@@ -166,3 +168,18 @@ ensure_version_matches tag:
 publish: package
     just ensure_version_matches ${GIT_TAG}
     uv publish
+
+# Build the /opt/easyspeak app bundle (CI/container only, not the host)
+[group('packaging')]
+stage-bundle:
+    bash packaging/stage-bundle.sh
+
+# Stage a language pack's speech models, e.g. `just stage-lang en`
+[group('packaging')]
+stage-lang code:
+    bash packaging/stage-lang.sh {{ code }}
+
+# Build .deb and .rpm locally in a clean ubuntu container -> ./dist
+[group('packaging')]
+package-native version='0.0.0':
+    bash packaging/build-in-docker.sh {{ version }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ docs_dir: docs
 nav:
   - Home: index.md
   - Installation: installation.md
+  - Packaging: packaging.md
   - Usage: usage.md
   - Commands: commands.md
   - Writing Plugins: plugins.md

--- a/packaging/build-in-docker.sh
+++ b/packaging/build-in-docker.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Build the EasySpeak .deb and .rpm locally inside a clean ubuntu:24.04 container
+# (mirrors the GitHub `release.yml` runner). Handy on NixOS, where the bundle's
+# standalone CPython/manylinux wheels can't run on the host. Outputs to ./dist.
+#
+#   packaging/build-in-docker.sh [VERSION]   (default VERSION: 0.0.0)
+set -euo pipefail
+
+VERSION="${1:-0.0.0}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="${IMAGE:-ubuntu:24.04}"
+
+command -v docker >/dev/null || { echo "error: docker is required" >&2; exit 1; }
+mkdir -p "$REPO_ROOT/dist"
+
+docker run --rm \
+  -e VERSION="$VERSION" \
+  -e SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX="$VERSION" \
+  -v "$REPO_ROOT:/src:ro" \
+  -v "$REPO_ROOT/dist:/out" \
+  "$IMAGE" bash -euo pipefail -c '
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq build-essential portaudio19-dev curl ca-certificates xz-utils >/dev/null
+    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1
+    export PATH="$HOME/.local/bin:$PATH"
+
+    # Install nfpm (static Go binary) from the latest GitHub release.
+    NFPM_VER=$(curl -fsSL https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep -oP "\"tag_name\":\s*\"v\K[^\"]+")
+    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VER}/nfpm_${NFPM_VER}_linux_x86_64.tar.gz" \
+      | tar -xz -C /usr/local/bin nfpm
+
+    cp -r /src /build && cd /build
+
+    # Application package (amd64).
+    PREFIX=/opt/easyspeak bash packaging/stage-bundle.sh
+    nfpm package -f packaging/nfpm.yaml -p deb -t /out
+    nfpm package -f packaging/nfpm.yaml -p rpm -t /out
+
+    # Language data packages (noarch). Add more languages here as they appear.
+    for lang in en; do
+      bash packaging/stage-lang.sh "$lang"
+      nfpm package -f "packaging/nfpm-lang-$lang.yaml" -p deb -t /out
+      nfpm package -f "packaging/nfpm-lang-$lang.yaml" -p rpm -t /out
+    done
+
+    chmod a+rw /out/*.deb /out/*.rpm
+  '
+
+echo "built:"
+ls -lh "$REPO_ROOT"/dist/*.deb "$REPO_ROOT"/dist/*.rpm

--- a/packaging/nfpm-lang-en.yaml
+++ b/packaging/nfpm-lang-en.yaml
@@ -1,0 +1,26 @@
+# nfpm config — English language data for EasySpeak (Whisper base.en recognition
+# model + Piper en_US-amy-medium voice). A noarch data package, built from the
+# tree staged by `packaging/stage-lang.sh en`.
+#   VERSION=1.2.3 nfpm package -f packaging/nfpm-lang-en.yaml -p deb
+#   VERSION=1.2.3 nfpm package -f packaging/nfpm-lang-en.yaml -p rpm
+name: easyspeak-lang-en
+arch: all                # architecture-independent: deb "all" / rpm "noarch"
+platform: linux
+version: ${VERSION}
+section: utils
+priority: optional
+maintainer: Matt Hartley <matt@matthartley.com>
+description: |
+  English speech models for EasySpeak: the Whisper base.en recognition model
+  (Systran/faster-whisper-base.en) and the Piper en_US-amy-medium voice
+  (rhasspy/piper-voices). Installed under /opt/easyspeak/models; see each source
+  for its model license.
+vendor: EasySpeak
+homepage: https://github.com/ctsdownloads/easyspeak
+
+provides:
+- easyspeak-language
+
+contents:
+- src: ./dist/stage-lang-en/opt/easyspeak/models
+  dst: /opt/easyspeak/models

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,75 @@
+# nfpm config — builds the EasySpeak .deb and .rpm from the staged /opt/easyspeak
+# bundle (see packaging/stage-bundle.sh). VERSION is injected from the release tag.
+#   VERSION=1.2.3 nfpm package -f packaging/nfpm.yaml -p deb
+#   VERSION=1.2.3 nfpm package -f packaging/nfpm.yaml -p rpm
+name: easyspeak
+arch: amd64
+platform: linux
+version: ${VERSION}
+section: utils
+priority: optional
+maintainer: Matt Hartley <matt@matthartley.com>
+description: |
+  Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
+  Say "Hey Jarvis" and control your GNOME desktop with your voice.
+vendor: EasySpeak
+homepage: https://github.com/ctsdownloads/easyspeak
+license: GPL-3.0-only
+
+contents:
+# The self-contained bundle (standalone CPython + venv + app + piper).
+- src: /opt/easyspeak
+  dst: /opt/easyspeak
+# Launcher on PATH: symlink to the console script pyproject installs in the venv.
+# The app finds its models and bundled `piper` from its own location, so no
+# wrapper/PATH setup is needed.
+- src: /opt/easyspeak/venv/bin/easyspeak
+  dst: /usr/bin/easyspeak
+  type: symlink
+# Desktop entry (uses the stock audio-input-microphone icon from adwaita-icon-theme).
+- src: ./data/easyspeak.desktop
+  dst: /usr/share/applications/easyspeak.desktop
+- src: ./LICENSE
+  dst: /usr/share/doc/easyspeak/LICENSE
+
+overrides:
+  deb:
+    depends:
+    - libportaudio2          # pyaudio runtime — microphone capture (core)
+    - python3                # runs the AT-SPI dictation helper
+    - python3-gi             # PyGObject for the helper + About dialog
+    - gir1.2-glib-2.0        # core GLib/Gio/DBus typelibs (Atspi typelib needs DBus-1.0)
+    - gir1.2-atspi-2.0       # Atspi typelib for dictation
+    - libgtk-4-1             # About dialog
+    - libadwaita-1-0         # About dialog
+    - gir1.2-gtk-4.0
+    - gir1.2-adw-1
+    - adwaita-icon-theme     # provides the launcher icon
+    recommends:
+    - easyspeak-lang-en      # default language data; repo installs pull it automatically
+    - gnome-shell            # provides `gnome-extensions` (mouse grid / indicator)
+    - qutebrowser            # browser plugin
+    - ffmpeg                 # ffplay TTS playback fallback
+    - pipewire-bin           # pw-play
+    - wireplumber            # wpctl volume control
+    - pulseaudio-utils       # paplay (chime + TTS fallback)
+    - sound-theme-freedesktop  # wake/error chime sounds
+  rpm:
+    depends:
+    - portaudio
+    - python3
+    - python3-gobject
+    - gobject-introspection  # DBus-1.0 typelib that the Atspi typelib depends on
+    - at-spi2-core
+    - gtk4
+    - libadwaita
+    - adwaita-icon-theme
+    recommends:
+    - easyspeak-lang-en
+    - gnome-shell
+    - qutebrowser
+    - ffmpeg-free
+    - pipewire-utils
+    - wireplumber
+    - pulseaudio-utils
+    - sound-theme-freedesktop

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build the EasySpeak application bundle that the `easyspeak` .deb/.rpm ship at
+# /opt/easyspeak. This is APP LOGIC ONLY — speech models live in separate
+# `easyspeak-lang-*` packages (see packaging/stage-lang.sh).
+#
+# Runs in a clean glibc build environment (CI ubuntu-latest, or a container — see
+# `just package-native`), NOT on the host directly. It materialises a standalone
+# CPython + venv at PREFIX; PREFIX must equal the final install path so the venv's
+# absolute paths (shebangs, interpreter symlinks) stay valid on the target machine.
+set -euo pipefail
+
+PREFIX="${PREFIX:-/opt/easyspeak}"
+# 3.12 is required: openwakeword pulls speexdsp-ns, which has no wheels for >=3.13.
+PY_VERSION="${PY_VERSION:-3.12}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+command -v uv >/dev/null || { echo "error: uv is required (https://astral.sh/uv)" >&2; exit 1; }
+
+echo ">> building wheel"
+( cd "$REPO_ROOT" && uv build --wheel --out-dir "$REPO_ROOT/dist" )
+WHEEL=$(ls -t "$REPO_ROOT"/dist/easyspeak_linux-*.whl | head -1)
+echo "   $WHEEL"
+
+echo ">> materialising standalone CPython $PY_VERSION at $PREFIX/python"
+uv python install "$PY_VERSION"
+SRC_PY=$(dirname "$(dirname "$(uv python find "$PY_VERSION")")")
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX/python"
+# -L dereferences symlinks so the REAL interpreter + libs land under $PREFIX.
+# (plain cp -r keeps symlinks pointing back into uv's cache, breaking relocation.)
+cp -rL "$SRC_PY"/. "$PREFIX/python/"
+
+echo ">> creating venv from the bundled interpreter"
+"$PREFIX/python/bin/python3" -m venv "$PREFIX/venv"
+
+echo ">> installing app + runtime extras into the venv"
+# openwakeword: imported at runtime but intentionally left out of pyproject deps.
+#   (its English wake-word models ship inside the wheel, so the wake word is part
+#    of the app — only recognition/feedback models are split into lang packages.)
+# piper-tts: provides the `piper` binary inside the venv (no system piper packaged).
+uv pip install --python "$PREFIX/venv/bin/python" "$WHEEL" openwakeword piper-tts
+
+# Where language packages drop their models; config.py discovers them here.
+mkdir -p "$PREFIX/models"
+
+echo ">> trimming byte-compiled caches"
+find "$PREFIX" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+find "$PREFIX" -type f -name '*.pyc' -delete 2>/dev/null || true
+
+# Fail loudly if anything in the bundle still points outside PREFIX — that would
+# break on the user's machine where uv's cache does not exist.
+echo ">> checking the bundle is self-contained"
+ESCAPES=$(find "$PREFIX" -type l -exec readlink -f {} \; 2>/dev/null | grep -v "^$PREFIX" | sort -u || true)
+if [ -n "$ESCAPES" ]; then
+  echo "error: bundle has symlinks escaping $PREFIX:" >&2
+  echo "$ESCAPES" | sed 's/^/  /' >&2
+  exit 1
+fi
+
+echo ">> app bundle ready at $PREFIX ($(du -sh "$PREFIX" | cut -f1))"

--- a/packaging/stage-lang.sh
+++ b/packaging/stage-lang.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Stage the speech models for one EasySpeak language pack into a tree that mirrors
+# the install layout (/opt/easyspeak/models/...), for nfpm to package as
+# easyspeak-lang-<code> (a noarch data package). No app build needed.
+#
+#   packaging/stage-lang.sh <code>     e.g. `en`
+set -euo pipefail
+
+CODE="${1:?usage: stage-lang.sh <language-code>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+command -v uv >/dev/null   || { echo "error: uv is required" >&2; exit 1; }
+command -v curl >/dev/null || { echo "error: curl is required" >&2; exit 1; }
+
+# Per-language model selection. faster-whisper models live in Systran HF repos;
+# Piper voices live under rhasspy/piper-voices at <path>/<voice>.onnx(.json).
+case "$CODE" in
+  en)
+    WHISPER_NAME="base.en"
+    WHISPER_REPO="Systran/faster-whisper-base.en"
+    PIPER_VOICE="en_US-amy-medium"
+    PIPER_PATH="en/en_US/amy/medium"
+    ;;
+  *)
+    echo "error: no model mapping for language '$CODE'" >&2
+    exit 1
+    ;;
+esac
+
+STAGE="$REPO_ROOT/dist/stage-lang-$CODE"
+MODELS="$STAGE/opt/easyspeak/models"
+rm -rf "$STAGE"
+mkdir -p "$MODELS/whisper" "$MODELS/piper"
+
+echo ">> [$CODE] downloading Whisper model ($WHISPER_NAME) from $WHISPER_REPO"
+uv run --no-project --with huggingface_hub python - "$WHISPER_REPO" "$MODELS/whisper/$WHISPER_NAME" <<'PY'
+import sys
+from huggingface_hub import snapshot_download
+repo, dest = sys.argv[1], sys.argv[2]
+# Only the files faster-whisper needs; skip README/.gitattributes.
+snapshot_download(repo, local_dir=dest, allow_patterns=["*.bin", "*.json", "*.txt"])
+PY
+rm -rf "$MODELS/whisper/$WHISPER_NAME/.cache"
+
+echo ">> [$CODE] downloading Piper voice ($PIPER_VOICE)"
+PIPER_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/$PIPER_PATH"
+curl -fsSL "$PIPER_BASE/$PIPER_VOICE.onnx"      -o "$MODELS/piper/$PIPER_VOICE.onnx"
+curl -fsSL "$PIPER_BASE/$PIPER_VOICE.onnx.json" -o "$MODELS/piper/$PIPER_VOICE.onnx.json"
+
+echo ">> [$CODE] language data staged at $STAGE ($(du -sh "$MODELS" | cut -f1))"

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -6,6 +6,8 @@ each plugin's own setup() hook, not here.
 """
 
 import os
+import sys
+from pathlib import Path
 
 from faster_whisper import WhisperModel
 
@@ -34,12 +36,36 @@ HOTKEY_ENABLED = os.environ.get("EASYSPEAK_HOTKEY", "1").lower() not in (
     "off",
 )
 
+
 # --- Models ---
-PIPER_MODEL = os.environ.get(
-    "EASYSPEAK_PIPER_MODEL",
-    os.path.expanduser("~/.local/share/piper/en_US-amy-medium.onnx"),
+def _bundled_model(*parts, default):
+    """Return a model path bundled beside the venv, or ``default`` if absent."""
+    path = Path(sys.prefix).parent.joinpath(*parts)
+    return str(path) if path.exists() else default
+
+
+def _bundled_bin(name, *, default):
+    """Return a binary path in this venv's ``bin/``, or ``default`` if absent."""
+    exe = Path(sys.executable).with_name(name)
+    return str(exe) if exe.exists() else default
+
+
+# The .deb/.rpm bundle the speech models beside the venv (under
+# /opt/easyspeak/models) and `piper` inside it. The defaults below locate them
+# from our own interpreter, so no launcher or PATH setup is needed; pip/source
+# installs have no such tree and fall back to a download name / the home dir.
+PIPER_MODEL = os.environ.get("EASYSPEAK_PIPER_MODEL") or _bundled_model(
+    "models",
+    "piper",
+    "en_US-amy-medium.onnx",
+    default=os.path.expanduser("~/.local/share/piper/en_US-amy-medium.onnx"),
 )
-WHISPER_MODEL = os.environ.get("EASYSPEAK_WHISPER_MODEL", "base.en")
+PIPER_BIN = os.environ.get("EASYSPEAK_PIPER_BIN") or _bundled_bin(
+    "piper", default="piper"
+)
+WHISPER_MODEL = os.environ.get("EASYSPEAK_WHISPER_MODEL") or _bundled_model(
+    "models", "whisper", "base.en", default="base.en"
+)
 WHISPER_COMPUTE_TYPE = os.environ.get("EASYSPEAK_WHISPER_COMPUTE_TYPE", "int8")
 try:
     # 0 == let CTranslate2 pick (uses all logical cores, which oversubscribes

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -16,7 +16,7 @@ import sys
 import time
 from subprocess import TimeoutExpired
 
-from .config import PIPER_MODEL
+from .config import PIPER_BIN, PIPER_MODEL
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +150,7 @@ class SpeechPipeline:
                 stderr=subprocess.DEVNULL,
             )
             self._piper = subprocess.Popen(
-                ["piper", "--model", PIPER_MODEL, "--output-raw"],
+                [PIPER_BIN, "--model", PIPER_MODEL, "--output-raw"],
                 stdin=subprocess.PIPE,
                 stdout=self._player.stdin,
                 stderr=subprocess.DEVNULL,

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -21,6 +21,7 @@ def _restore_config(monkeypatch):
         "EASYSPEAK_WHISPER_MODEL",
         "EASYSPEAK_WHISPER_COMPUTE_TYPE",
         "EASYSPEAK_PIPER_MODEL",
+        "EASYSPEAK_PIPER_BIN",
     ]:
         monkeypatch.delenv(var, raising=False)
     importlib.reload(config)
@@ -94,3 +95,45 @@ def test_whisper_compute_type_env_override(monkeypatch):
     monkeypatch.setenv("EASYSPEAK_WHISPER_COMPUTE_TYPE", "float16")
     importlib.reload(config)
     assert config.WHISPER_COMPUTE_TYPE == "float16"
+
+
+def test_bundled_model_found(monkeypatch, tmp_path):
+    """A model present beside the venv (<prefix>/../models/...) is used."""
+    (tmp_path / "models" / "whisper" / "base.en").mkdir(parents=True)
+    monkeypatch.setattr(config.sys, "prefix", str(tmp_path / "venv"))
+    assert config._bundled_model(
+        "models", "whisper", "base.en", default="base.en"
+    ) == str(tmp_path / "models" / "whisper" / "base.en")
+
+
+def test_bundled_model_missing_falls_back(monkeypatch, tmp_path):
+    """With no bundled tree, the default (download name / path) is kept."""
+    monkeypatch.setattr(config.sys, "prefix", str(tmp_path / "venv"))
+    assert (
+        config._bundled_model("models", "whisper", "base.en", default="base.en")
+        == "base.en"
+    )
+
+
+def test_bundled_bin_found(monkeypatch, tmp_path):
+    """A binary present next to the interpreter is used by absolute path."""
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "piper").touch()
+    monkeypatch.setattr(config.sys, "executable", str(venv_bin / "python"))
+    assert config._bundled_bin("piper", default="piper") == str(venv_bin / "piper")
+
+
+def test_bundled_bin_missing_falls_back(monkeypatch, tmp_path):
+    """With no co-located binary, the bare name (resolved via PATH) is kept."""
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    monkeypatch.setattr(config.sys, "executable", str(venv_bin / "python"))
+    assert config._bundled_bin("piper", default="piper") == "piper"
+
+
+def test_piper_bin_env_override(monkeypatch):
+    """EASYSPEAK_PIPER_BIN overrides the discovered/default binary."""
+    monkeypatch.setenv("EASYSPEAK_PIPER_BIN", "/opt/voices/piper")
+    importlib.reload(config)
+    assert config.PIPER_BIN == "/opt/voices/piper"


### PR DESCRIPTION
## What & why

Adds automated **native `.deb`/`.rpm` packages** so users get a one-step, fully offline install instead of the clone + `uv` path. Built with [nfpm](https://nfpm.goreleaser.com/) and attached to every published GitHub Release.

Part of #76.

## Design: split app + language data

| Package | Arch | Contents |
|---|---|---|
| `easyspeak` | amd64 | self-contained bundle under `/opt/easyspeak` — standalone CPython + all wheels (incl. the `piper` engine and the `hey_jarvis` wake word) + `.desktop` launcher; `/usr/bin/easyspeak` is a symlink to the `pyproject` console script |
| `easyspeak-lang-en` | **noarch** | English speech data — Whisper `base.en` + Piper `en_US-amy-medium` — under `/opt/easyspeak/models` |

- The app **`Recommends: easyspeak-lang-en`**, so repo installs are turn-key; for GitHub-Release file installs you grab both and install them together.
- System integration (GTK4, libadwaita, PyGObject, AT-SPI, PortAudio) is declared as distro dependencies (per-distro name overrides).
- Other languages need **no package and no root**: install/drop a faster-whisper model + Piper voice and set `EASYSPEAK_WHISPER_MODEL` / `EASYSPEAK_PIPER_MODEL` (these always win).
- **No launcher wrapper.** `config.py`/`speech.py` discover the bundled models and the `piper` binary from the interpreter's own location (`sys.prefix` / `sys.executable`), so the install relies on on-board Python mechanics rather than a shell script + PATH setup. 100% test coverage maintained.

## How it's built

`nfpm` runs in a clean `ubuntu:24.04` container (`just package-native`, reused by `.github/workflows/release.yml`), so local and CI builds are identical. Handy on NixOS, where the bundle's standalone CPython/manylinux wheels can't run on the host.

## Verification (clean containers)

- **Ubuntu, app + lang-en**: co-install cleanly, Whisper loads offline, Piper synthesizes ✅
- **Fedora, app + lang-en**: same + AT-SPI / GTK4+Adw typelibs resolve ✅
- **Ubuntu, app-only**: models dir empty, wrapper skips forcing the model env (graceful fallback), app runs ✅
- `desktop-file-validate` passes; docs build under `--strict`.

Two real bugs were caught and fixed during container testing: interpreter symlinks escaping `/opt` (fixed with `cp -rL`), and a Fedora-only missing `gobject-introspection` (the DBus typelib AT-SPI needs).

## Docs

- New `docs/packaging.md` (install, language management, build, and the Flatpak/Nix/AUR/COPR/OBS rationale — sandboxed formats don't fit this system-integrated app).
- README install note; `how-it-works.md` file-tree fix.

## Not in scope (tracked in #76)

arm64 packages, additional language packs, a branded app icon, and publishing to a real APT/DNF repo (for true `apt install easyspeak` by name) or AUR/COPR/Flathub.
