### PR TITLE
Fix docstring markup (reStructuredText ➜ MarkDown)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,31 @@
+name: Links
+
+# Check the docs for dead external links. Scheduled (and manually dispatchable)
+# rather than part of the PR gate: external links rot independently of our own
+# changes and can fail transiently, so this must never block a merge.
+on:
+  schedule:
+  - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: '3.12'
+
+    - uses: taiki-e/install-action@just
+
+    # `just check-links` builds the docs first (via the `docs` dependency), and
+    # `uv run` installs the project, which depends on pyaudio — that needs the
+    # PortAudio headers (mirrors the docs workflow).
+    - run: |
+        sudo apt update
+        sudo apt install -y portaudio19-dev
+
+    - name: Check external links in the built docs
+      run: just check-links

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,6 +18,7 @@ jobs:
         task:
         - format --diff
         - lint --diff
+        - lint-docstrings
         - lint-md
         - lint-yaml
         - types

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,8 +31,8 @@ and install them together:
 This bundles the Python runtime, Piper, the GNOME Shell extension, and the speech
 models — no `pip`/`uv` step and no compiler. **Log out and back in once** after
 the first launch so GNOME loads the bundled extension. See the
-**[Packaging guide](packaging.md#install)** for offline notes, more languages,
-and hold-to-dictate setup.
+[Packaging guide](packaging.md#install) for offline notes, more languages, and
+hold-to-dictate setup.
 
 ## Install from source
 

--- a/justfile
+++ b/justfile
@@ -7,21 +7,16 @@
 
 # Run codestyle and safety checks, tests, packaging checks and cleanup
 [group('lifecycle')]
-all: codestyle safety test gate clean
+all: codestyle safety test gate check-docs clean
 
 # Remove build artifacts and reports (use -v for verbose, -n for dry-run)
 [group('lifecycle')]
 clean *args:
     uvx pyclean . {{ args }} --debris all --erase .benchmarks result results.json 'site/**/*' site --yes
 
-# Run all code style checks (format, lint, lint-js, lint-md, lint-yaml)
+# Run all code style checks (format, lint, js, yaml)
 [group('codestyle')]
-codestyle:
-    -just format
-    -just lint
-    -just lint-js
-    -just lint-md
-    -just lint-yaml
+codestyle: format lint lint-js lint-yaml
 
 # Check Python code style (use -- to apply, --diff to preview)
 [group('codestyle')]
@@ -38,11 +33,6 @@ lint *args=('--statistics'):
 lint-js *args:
     eslint src/extension.js src/extension-helpers.js {{ args }}
 
-# Check Markdown: structure only, lenient on style (config in pyproject.toml)
-[group('codestyle')]
-lint-md *args:
-    git ls-files '*.md' | xargs uvx --from pymarkdownlnt pymarkdown {{ args }} scan
-
 # Check YAML formatting: minimal indent, final newline (config in .yamllint.yaml)
 [group('codestyle')]
 lint-yaml *args:
@@ -55,10 +45,7 @@ types *args:
 
 # Run all safety checks (types, requirements, audit)
 [group('safety')]
-safety:
-    -just types
-    -just requirements
-    -just audit
+safety: types requirements audit
 
 # Check project dependencies for known vulnerabilities
 [group('safety')]
@@ -117,6 +104,32 @@ acceptance *args=('-v'):
 benchmark *args:
     uv run --extra=benchmark pytest tests/benchmarks/ \
         --benchmark-json=results.json {{ args }}
+
+# Run all QA checks for the generated documentation (docstrings, markdown, links)
+[group('docs')]
+check-docs: lint-docstrings lint-md check-links
+
+# Check built docs for dead external links (network; via the scheduled Links workflow, not the PR gate)
+[group('docs')]
+check-links *args: docs
+    # --ignore-url drops material's 404-page root-absolute links (only valid once served under the Pages path);
+    # --user-agent avoids linkchecker's "Mozilla" default, which freedesktop.org's WAF answers with 418.
+    uvx linkchecker --check-extern --no-warnings --ignore-url '^file:///easyspeak/' --user-agent LinkChecker {{ args }} site/index.html
+
+# Guard docstrings against reST markup (mkdocstrings renders Markdown, not reST)
+[group('docs')]
+lint-docstrings:
+    #!/usr/bin/env sh
+    bt=$(printf '\140')
+    if git ls-files 'src/**/*.py' | xargs grep -nE ":(func|meth|class|mod|data|attr|ref|exc|obj):$bt|$bt$bt"; then
+        echo "error: reST markup in docstrings — use Markdown: backtick-code and [text][full.path] links." >&2
+        exit 1
+    fi
+
+# Lint Markdown structure in all tracked *.md (lenient on style; config in pyproject.toml)
+[group('docs')]
+lint-md *args:
+    git ls-files '*.md' | xargs uvx --from pymarkdownlnt pymarkdown {{ args }} scan
 
 # Build the docs (use `serve` to serve at http://127.0.0.1:8000 with live-reload)
 [group('docs')]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,10 @@
 site_name: EasySpeak
 site_description: Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
-site_url: https://ctsdownloads.github.io/easyspeak/
+# Docs are versioned with mike (see the `extra.version` block and the Docs
+# workflow); the live site only serves under a version path. Point site_url at
+# the stable `latest` alias so canonical URLs and the sitemap resolve instead
+# of 404ing on the unversioned root.
+site_url: https://ctsdownloads.github.io/easyspeak/latest/
 repo_url: https://github.com/ctsdownloads/easyspeak
 repo_name: ctsdownloads/easyspeak
 copyright: Copyright &copy; EasySpeak contributors — GPL-3.0

--- a/src/core/about.py
+++ b/src/core/about.py
@@ -2,14 +2,14 @@
 
 The daemon is headless and the panel indicator lives in a GNOME Shell extension
 (Clutter/St), which can't host GTK widgets; so the About dialog runs as its own
-short-lived process that the tray launches via ``python -m easyspeak.core.about``
-on the menu's "About" command. It uses libadwaita's ``AboutDialog`` (the modern,
-GNOME-recommended widget), falling back to the older ``AboutWindow`` on
-pre-1.5 libadwaita.
+short-lived process that the tray launches via `python -m easyspeak.core.about` on the
+menu's "About" command. It uses libadwaita's `AboutDialog` (the modern,
+GNOME-recommended widget), falling back to the older `AboutWindow` on pre-1.5
+libadwaita.
 
-Everything GUI is imported lazily inside :func:`main` so this module stays
-importable (for its metadata constants and version lookup) without PyGObject or
-a display present — which is how the unit suite exercises it.
+Everything GUI is imported lazily inside [`main`][core.about.main] so this module stays
+importable (for its metadata constants and version lookup) without PyGObject or a
+display present — which is how the unit suite exercises it.
 """
 
 import importlib.metadata
@@ -39,9 +39,9 @@ CONTRIBUTORS = [
 def app_version():
     """Return the installed package version, or "" if it can't be determined.
 
-    Read at runtime (rather than hard-coded) so the dialog always shows the
-    version actually installed; an editable/source checkout without dist
-    metadata simply shows no version rather than failing.
+    Read at runtime (rather than hard-coded) so the dialog always shows the version
+    actually installed; an editable/source checkout without dist metadata simply shows
+    no version rather than failing.
     """
     try:
         return importlib.metadata.version("easyspeak-linux")
@@ -65,10 +65,9 @@ def main():  # pragma: no cover - needs libadwaita and a display; run live
 def _present(app):  # pragma: no cover - needs libadwaita and a display; run live
     """Build and present the About UI, quitting the app once it's dismissed.
 
-    We need to distinguish between the modern widget (libadwaita >= 1.5)
-    and the older self-contained About window (libadwaita < 1.5).
-    For the former, we must attach the dialog to a parent window, a minimal
-    host purely to own it, and quit on close.
+    We need to distinguish between the modern widget (libadwaita >= 1.5) and the older
+    self-contained About window (libadwaita < 1.5). For the former, we must attach the
+    dialog to a parent window, a minimal host purely to own it, and quit on close.
     """
     from gi.repository import Adw, Gtk
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,8 +1,8 @@
 """Tuning constants and model factory for EasySpeak.
 
-Override the EASYSPEAK_* environment variables to customise behaviour
-without editing source. Plugin-specific host-environment setup lives in
-each plugin's own setup() hook, not here.
+Override the EASYSPEAK_* environment variables to customise behaviour without editing
+source. Plugin-specific host-environment setup lives in each plugin's own setup() hook,
+not here.
 """
 
 import os
@@ -39,13 +39,13 @@ HOTKEY_ENABLED = os.environ.get("EASYSPEAK_HOTKEY", "1").lower() not in (
 
 # --- Models ---
 def _bundled_model(*parts, default):
-    """Return a model path bundled beside the venv, or ``default`` if absent."""
+    """Return a model path bundled beside the venv, or `default` if absent."""
     path = Path(sys.prefix).parent.joinpath(*parts)
     return str(path) if path.exists() else default
 
 
 def _bundled_bin(name, *, default):
-    """Return a binary path in this venv's ``bin/``, or ``default`` if absent."""
+    """Return a binary path in this venv's `bin/`, or `default` if absent."""
     exe = Path(sys.executable).with_name(name)
     return str(exe) if exe.exists() else default
 

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -1,14 +1,15 @@
 """Install, refresh, and enable the bundled GNOME Shell extension.
 
-Core owns the extension's lifecycle because both the mousegrid plugin and
-``core.tray`` drive it over D-Bus; :func:`ensure_extension` runs once at startup.
-The extension ships as package data — ``extension.js``, the
-``extension-helpers.js`` it imports, and ``metadata.json`` — copied into the
-user's extensions dir as a set. On Wayland GNOME only loads extension code at
-login, so the startup copy is always one login behind; a ``oneshot`` systemd
-*user* unit ordered before the shell re-copies it at the start of every login to
-close that gap. The unit runs as the user, writes only to ``$HOME``, and needs
-no privileges.
+Core owns the extension's lifecycle because both the mousegrid plugin and `core.tray`
+drive it over D-Bus; [`ensure_extension`][core.gnome_extension.ensure_extension] runs
+once at startup. The extension ships as package data — `extension.js`, the
+`extension-helpers.js` it imports, and `metadata.json` — copied into the user's
+extensions dir as a set. On Wayland GNOME only loads extension code at login, so the
+startup copy is always one login behind; [a `oneshot` systemd user unit][systemd]
+ordered before the shell re-copies it at the start of every login to close that gap. The
+unit runs as the user, writes only to `$HOME`, and needs no privileges.
+
+[systemd]: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
 """
 
 import contextlib
@@ -38,7 +39,10 @@ EXTENSION_ASSETS = ("extension.js", "extension-helpers.js", "metadata.json")
 
 
 class RefreshResult(enum.Enum):
-    """Outcome of a single :func:`refresh_extension_files` attempt."""
+    """Outcome of a single refresh attempt.
+
+    See [`refresh_extension_files`][core.gnome_extension.refresh_extension_files].
+    """
 
     REFRESHED = "refreshed"
     UNCHANGED = "unchanged"
@@ -48,8 +52,8 @@ class RefreshResult(enum.Enum):
 def extension_source_dir():
     """Return the package dir holding the bundled assets.
 
-    Resolved relative to this module (``src/``) so it works in both editable
-    and wheel installs.
+    Resolved relative to this module (`src/`) so it works in both editable and wheel
+    installs.
     """
     return Path(__file__).resolve().parents[1]
 
@@ -69,17 +73,17 @@ def _staged_tmp(dest_dir, name):
 
 
 def _discard_staged(dest_dir):
-    """Remove any ``.<asset>.tmp`` files a previous refresh may have left."""
+    """Remove any `.<asset>.tmp` files a previous refresh may have left."""
     for name in EXTENSION_ASSETS:
         with contextlib.suppress(OSError):
             _staged_tmp(dest_dir, name).unlink()
 
 
 def refresh_extension_files(src_dir, dest_dir):
-    """Copy the bundled assets into ``dest_dir`` when they differ from it.
+    """Copy the bundled assets into `dest_dir` when they differ from it.
 
-    Best-effort: returns ``REFRESHED`` if written, ``UNCHANGED`` if already
-    current, or ``ERROR`` (noted on stderr) when a source is missing or a copy
+    Best-effort: returns `REFRESHED` if written, `UNCHANGED` if already
+    current, or `ERROR` (noted on stderr) when a source is missing or a copy
     fails. Assets are staged then moved into place (extension.js last), so a
     failure leaves any working install untouched and never installs extension.js
     without the helper it imports.
@@ -152,10 +156,10 @@ WantedBy={PRE_SHELL_TARGET}
 
 
 def _run_systemctl(*args):
-    """Run a ``systemctl --user`` command, or return None if it can't be run.
+    """Run a `systemctl --user` command, or return None if it can't be run.
 
-    An un-execable systemctl raises OSError despite ``check=False``, and the
-    refresh-unit install must stay non-fatal.
+    An un-execable systemctl raises OSError despite `check=False`, and the refresh-unit
+    install must stay non-fatal.
     """
     try:
         return subprocess.run(
@@ -181,8 +185,8 @@ def _is_enabled():
 def install_refresh_unit():
     """Install and enable the pre-shell refresh unit, idempotently.
 
-    Returns a short status string, or None when nothing changed or it isn't
-    applicable (no systemd, write/enable failure).
+    Returns a short status string, or None when nothing changed or it isn't applicable
+    (no systemd, write/enable failure).
     """
     if shutil.which("systemctl") is None:
         return None
@@ -216,15 +220,15 @@ def install_refresh_unit():
 def migrate_legacy_extension():
     """Remove the pre-rename extension install so it can't double-load.
 
-    The extension's UUID changed from ``easyspeak-grid@local`` to
-    ``easyspeak@local`` (it long outgrew being just a mouse grid). A leftover
+    The extension's UUID changed from `easyspeak-grid@local` to
+    `easyspeak@local` (it long outgrew being just a mouse grid). A leftover
     copy under the old UUID would stay enabled and add a second panel indicator
     and grid that the daemon no longer drives, so clean it up: disable it (so
     GNOME drops it from the enabled set) then delete its directory. Best-effort
     throughout — returns True if a legacy install was found and removed.
 
     One-off migration shim: once users have had a release or two to upgrade past
-    ``easyspeak-grid@local`` this can be removed (call site and tests included).
+    `easyspeak-grid@local` this can be removed (call site and tests included).
     """
     legacy_dir = extensions_root() / LEGACY_EXTENSION_UUID
     if not legacy_dir.is_dir():
@@ -250,9 +254,8 @@ def migrate_legacy_extension():
 def ensure_extension():
     """Install, refresh, and enable the bundled extension, reporting what it did.
 
-    Installs it if missing, keeps the installed copy current, and enables it.
-    Skipped on non-GNOME desktops; non-fatal on missing sources or write
-    failures.
+    Installs it if missing, keeps the installed copy current, and enables it. Skipped on
+    non-GNOME desktops; non-fatal on missing sources or write failures.
     """
     if shutil.which("gnome-extensions") is None:
         return

--- a/src/core/hotkey.py
+++ b/src/core/hotkey.py
@@ -1,15 +1,14 @@
 """Hold-to-dictate keyboard activation via evdev (the silent-activation path).
 
-On Wayland an ordinary process can't grab global keys, and only raw evdev
-events from ``/dev/input`` expose key *release* — which "hold the keys to
-dictate, release to stop" needs. This listener reads every keyboard device in a
-background thread and tracks whether a configured modifier combo (default
-Ctrl+Shift) is fully held, so the audio loop can start dictation on press and
-end it the moment the keys come up.
+On Wayland an ordinary process can't grab global keys, and only raw evdev events from
+`/dev/input` expose key *release* — which "hold the keys to dictate, release to stop"
+needs. This listener reads every keyboard device in a background thread and tracks
+whether a configured modifier combo (default Ctrl+Shift) is fully held, so the audio
+loop can start dictation on press and end it the moment the keys come up.
 
-It is best-effort: if python-evdev isn't installed or ``/dev/input`` isn't
-readable (the user isn't in the ``input`` group), the listener logs how to
-enable it and stays inert, so the daemon runs normally without the hotkey.
+It is best-effort: if python-evdev isn't installed or `/dev/input` isn't readable (the
+user isn't in the `input` group), the listener logs how to enable it and stays inert, so
+the daemon runs normally without the hotkey.
 """
 
 import contextlib
@@ -35,16 +34,16 @@ _MODIFIER_ALIASES = {
 
 
 def parse_combo(spec: str) -> tuple[frozenset[str], ...]:
-    """Parse a ``'+'``-separated combo string into groups of accepted key names.
+    """Parse a `'+'`-separated combo string into groups of accepted key names.
 
     Each element becomes a group of evdev key names of which any one satisfies
-    that part of the combo, so ``"ctrl+shift"`` matches either Ctrl together
+    that part of the combo, so `"ctrl+shift"` matches either Ctrl together
     with either Shift. Names that aren't known aliases fall through as a single
-    literal evdev key name (``"rightctrl"`` -> ``"KEY_RIGHTCTRL"``) so less
+    literal evdev key name (`"rightctrl"` -> `"KEY_RIGHTCTRL"`) so less
     common combos still work.
 
     Args:
-        spec: A combo such as ``"ctrl+shift"`` or ``"super+space"``.
+        spec: A combo such as `"ctrl+shift"` or `"super+space"`.
 
     Returns:
         A tuple of frozensets, one per combo element; the combo is held when
@@ -68,19 +67,19 @@ def parse_combo(spec: str) -> tuple[frozenset[str], ...]:
 class HotkeyListener:
     """Track whether a key combo is held, off a background evdev reader.
 
-    The audio loop calls :meth:`take_activation` once per iteration to learn
-    when the combo was just pressed, then drives a dictation session gated on
-    :meth:`is_held` so releasing the keys ends it. All evdev/threading state is
-    kept behind a lock; the event-processing logic in :meth:`_process` is pure
-    and the I/O lives in :meth:`_grab_devices`/:meth:`_drain`, so the behaviour
-    is unit-testable without a real keyboard.
+    The audio loop calls [`take_activation`][core.hotkey.HotkeyListener.take_activation]
+    once per iteration to learn when the combo was just pressed, then drives a dictation
+    session gated on [`is_held`][core.hotkey.HotkeyListener.is_held] so releasing the
+    keys ends it. All evdev/threading state is kept behind a lock; the event-processing
+    logic in `_process` is pure and the I/O lives in `_grab_devices`/`_drain`, so the
+    behaviour is unit-testable without a real keyboard.
     """
 
     def __init__(self, combo="ctrl+shift", enabled=True):
-        """Set up the listener for ``combo`` (e.g. ``"ctrl+shift"``).
+        """Set up the listener for `combo` (e.g. `"ctrl+shift"`).
 
-        An unparseable or empty combo, or ``enabled=False``, leaves the
-        listener disabled so :meth:`start` is a no-op.
+        An unparseable or empty combo, or `enabled=False`, leaves the listener disabled
+        so [`start`][core.hotkey.HotkeyListener.start] is a no-op.
         """
         self._spec = combo
         self._groups = parse_combo(combo)
@@ -103,8 +102,8 @@ class HotkeyListener:
     def take_activation(self):
         """Return True once per press of the combo, clearing the edge.
 
-        The audio loop polls this each iteration; a True means "the user just
-        pressed the combo — start dictation now".
+        The audio loop polls this each iteration; a True means "the user just pressed
+        the combo — start dictation now".
         """
         with self._lock:
             fired = self._activation
@@ -116,9 +115,8 @@ class HotkeyListener:
     def start(self):
         """Begin watching the keyboard, unless disabled or no device is readable.
 
-        Logs and stays inert (no thread) when the feature is turned off, evdev
-        is missing, or ``/dev/input`` can't be read, so the daemon runs normally
-        either way.
+        Logs and stays inert (no thread) when the feature is turned off, evdev is
+        missing, or `/dev/input` can't be read, so the daemon runs normally either way.
         """
         if not self._enabled:
             logger.debug("Keyboard activation disabled.")
@@ -135,9 +133,9 @@ class HotkeyListener:
     def stop(self):
         """Stop the reader thread, then release the keyboard devices.
 
-        Joins the thread first so it leaves its ``select()`` loop before the fds
-        close under it — closing a fd mid-select can raise in the thread. The
-        loop wakes within one POLL_TIMEOUT, so the join returns promptly.
+        Joins the thread first so it leaves its `select()` loop before the fds close
+        under it — closing a fd mid-select can raise in the thread. The loop wakes
+        within one POLL_TIMEOUT, so the join returns promptly.
         """
         self._stop.set()
         thread, self._thread = self._thread, None
@@ -153,8 +151,8 @@ class HotkeyListener:
     def _grab_devices(self):
         """Open every readable keyboard device, or return [] if unavailable.
 
-        Missing python-evdev or an unreadable ``/dev/input`` (no ``input`` group
-        membership) is reported with how to fix it, then treated as "no hotkey".
+        Missing python-evdev or an unreadable `/dev/input` (no `input` group membership)
+        is reported with how to fix it, then treated as "no hotkey".
         """
         try:
             import evdev
@@ -206,8 +204,8 @@ class HotkeyListener:
     def _event_keyname(self, event):
         """Return the evdev key name for a key event, or None if not a key.
 
-        ``ecodes.KEY[code]`` is a list when a code has aliases; the first name
-        is the canonical one and the only form our combos use.
+        `ecodes.KEY[code]` is a list when a code has aliases; the first name is the
+        canonical one and the only form our combos use.
         """
         import evdev
 
@@ -221,9 +219,9 @@ class HotkeyListener:
     def _process(self, keyname, value):
         """Update held state from one key event (value: 0=up, 1=down, 2=repeat).
 
-        Only keys that belong to the combo move the state. The rising edge to
-        "fully held" arms :meth:`take_activation`; releasing any key clears the
-        held state so the dictation session ends.
+        Only keys that belong to the combo move the state. The rising edge to "fully
+        held" arms [`take_activation`][core.hotkey.HotkeyListener.take_activation];
+        releasing any key clears the held state so the dictation session ends.
         """
         if not any(keyname in group for group in self._groups):
             return

--- a/src/core/log.py
+++ b/src/core/log.py
@@ -1,9 +1,9 @@
 """Logging setup for EasySpeak's terminal output.
 
-Output is message-only (no level or timestamp prefixes) so the CLI reads
-nicely for humans; the level only gates which lines appear. Only the
-``easyspeak`` and ``plugins`` logger hierarchies are configured, so
-importing the package as a library leaves the root logger untouched.
+Output is message-only (no level or timestamp prefixes) so the CLI reads nicely for
+humans; the level only gates which lines appear. Only the `easyspeak` and `plugins`
+logger hierarchies are configured, so importing the package as a library leaves the root
+logger untouched.
 """
 
 import logging

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -52,8 +52,10 @@ class EasySpeak:
 
     Owns the audio pipeline (wake word -> Whisper), the loaded plugins, the
     text-to-speech pipeline, and the panel indicator, and exposes the small
-    plugin-facing API (:meth:`speak`, :meth:`host_run`, :meth:`transcribe`, ...)
-    that plugins use to act on commands.
+    plugin-facing API ([`speak`][core.main.EasySpeak.speak],
+    [`host_run`][core.main.EasySpeak.host_run],
+    [`transcribe`][core.main.EasySpeak.transcribe], ...) that plugins use to act on
+    commands.
     """
 
     def __init__(self):
@@ -91,16 +93,19 @@ class EasySpeak:
         return subprocess.run(cmd, capture_output=True, text=True)
 
     def speak(self, text):
-        """Speak a phrase. Stable plugin-facing API; delegates to the pipeline."""
+        """Speak a phrase.
+
+        Stable plugin-facing API; delegates to the pipeline.
+        """
         self.spoke = True
         self.speech.speak(text)
 
     def tap_key(self, keycode):
         """Replay a multimedia key so the desktop renders its native feedback.
 
-        Returns True if the key was injected, False if unavailable (e.g. a
-        non-GNOME session) so the caller can fall back to a silent change.
-        jeepney is imported lazily so the dependency isn't needed to load.
+        Returns True if the key was injected, False if unavailable (e.g. a non-GNOME
+        session) so the caller can fall back to a silent change. jeepney is imported
+        lazily so the dependency isn't needed to load.
         """
         try:
             from . import mediakeys
@@ -113,10 +118,9 @@ class EasySpeak:
     def deactivate(self):
         """Request the assistant go to sleep (plugin-facing).
 
-        Releases the mic and stops wake detection until reactivated from the
-        tray. The actual release happens at the next main-loop iteration
-        (handled by the tray controller) so the triggering command can finish,
-        and speak, first.
+        Releases the mic and stops wake detection until reactivated from the tray. The
+        actual release happens at the next main-loop iteration (handled by the tray
+        controller) so the triggering command can finish, and speak, first.
         """
         self.tray.request_sleep()
 
@@ -125,7 +129,7 @@ class EasySpeak:
 
         Plugin-facing: the dictation plugin registers here in its setup() so core
         can drive keyboard (silent) activation without importing a plugin
-        directly. ``handler`` takes one ``should_continue`` predicate and runs
+        directly. `handler` takes one `should_continue` predicate and runs
         until it returns False (the keys are released).
         """
         self._push_to_talk = handler
@@ -133,12 +137,12 @@ class EasySpeak:
     # --- Plugin management ---
 
     def load_plugins(self):
-        """Discover and import every plugin module from the ``plugins/`` dir.
+        """Discover and import every plugin module from the `plugins/` dir.
 
-        Files are loaded in sorted order (numeric prefixes set load order);
-        names starting with ``_`` are skipped. A module is registered only if it
-        exposes ``NAME`` and ``handle``; its optional ``setup`` hook runs once.
-        Import or setup failures are logged and skipped, never fatal.
+        Files are loaded in sorted order (numeric prefixes set load order); names
+        starting with `_` are skipped. A module is registered only if it exposes `NAME`
+        and `handle`; its optional `setup` hook runs once. Import or setup failures are
+        logged and skipped, never fatal.
         """
         plugins_dir = Path(__file__).parent.parent / "plugins"
         if not plugins_dir.exists():
@@ -177,7 +181,10 @@ class EasySpeak:
         return commands
 
     def route_command(self, cmd):
-        """Route command to appropriate plugin. Returns False to exit."""
+        """Route command to appropriate plugin.
+
+        Returns False to exit.
+        """
         cmd = cmd.lower()
         for wake in [
             "hey jarvis",
@@ -242,8 +249,8 @@ class EasySpeak:
     def _show_help(self):
         """Display the command list via the plugin that owns it.
 
-        Delegates to the base plugin's ``show_help`` so the help text isn't
-        duplicated here.
+        Delegates to the base plugin's `show_help` so the help text isn't duplicated
+        here.
         """
         for plugin in self.plugins:
             if hasattr(plugin, "show_help"):
@@ -255,9 +262,9 @@ class EasySpeak:
     def _open_stream(self):
         """Open the microphone input stream.
 
-        PortAudio probes every ALSA/JACK device on open, spamming stderr about
-        hardware this machine lacks; hide that C-level noise while keeping our
-        own Python output intact.
+        PortAudio probes every ALSA/JACK device on open, spamming stderr about hardware
+        this machine lacks; hide that C-level noise while keeping our own Python output
+        intact.
         """
         with suppressed_c_stderr():
             self.stream = self.audio.open(
@@ -271,8 +278,8 @@ class EasySpeak:
     def _close_stream(self):
         """Release the microphone so other apps see it as free.
 
-        Also clears GNOME's privacy mic indicator. The PyAudio instance is kept
-        for reopening.
+        Also clears GNOME's privacy mic indicator. The PyAudio instance is kept for
+        reopening.
         """
         if self.stream is None:
             return
@@ -297,9 +304,9 @@ class EasySpeak:
     def record_until_silence(self, should_continue=None):
         """Record mic audio until a short silence, capped at five seconds.
 
-        Returns the captured PCM bytes. Plugin-facing. ``should_continue``
-        (used by push-to-talk) lets a key release cut the recording short
-        instead of waiting out the silence window.
+        Returns the captured PCM bytes. Plugin-facing. `should_continue` (used by
+        push-to-talk) lets a key release cut the recording short instead of waiting out
+        the silence window.
         """
         frames = []
         silent_chunks = 0
@@ -324,9 +331,9 @@ class EasySpeak:
     def wait_for_speech(self, timeout=5, should_continue=None):
         """Block until speech is heard, returning its first PCM chunk.
 
-        Returns None if nothing is heard within ``timeout`` seconds.
-        Plugin-facing. ``should_continue`` (used by push-to-talk) returns None
-        early once it goes False, so a key release ends the wait.
+        Returns None if nothing is heard within `timeout` seconds. Plugin-facing.
+        `should_continue` (used by push-to-talk) returns None early once it goes False,
+        so a key release ends the wait.
         """
         for _ in range(int(timeout * 16000 / 1600)):
             if should_continue is not None and not should_continue():
@@ -339,8 +346,7 @@ class EasySpeak:
     def transcribe(self, audio_data, prompt=None):
         """Transcribe raw PCM audio to text with Whisper.
 
-        ``prompt`` biases recognition (defaults to the command vocabulary).
-        Plugin-facing.
+        `prompt` biases recognition (defaults to the command vocabulary). Plugin-facing.
         """
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
             with wave.open(f.name, "wb") as wf:
@@ -370,8 +376,8 @@ class EasySpeak:
     def _play_wake_chime(self):
         """Play the wake acknowledgement sound, then flush the mic.
 
-        Flushing drops the chime audio that bled into the mic so it isn't
-        mistaken for the user speaking.
+        Flushing drops the chime audio that bled into the mic so it isn't mistaken for
+        the user speaking.
         """
         subprocess.run(
             ["paplay", "/usr/share/sounds/freedesktop/stereo/message.oga"],
@@ -382,9 +388,9 @@ class EasySpeak:
     def _drain_feedback(self):
         """Wait for the "didn't understand" feedback to finish, then flush the mic.
 
-        speak() is non-blocking, so flushing alone leaves the still-playing tail
-        for the open mic to transcribe into the next escalation (e.g. opening
-        help) with no one having spoken.
+        speak() is non-blocking, so flushing alone leaves the still-playing tail for the
+        open mic to transcribe into the next escalation (e.g. opening help) with no one
+        having spoken.
         """
         self.speech.drain()
         self.flush_stream()
@@ -393,11 +399,10 @@ class EasySpeak:
         """Run a hotkey-triggered dictation session for as long as the keys are held.
 
         Triggered from the main loop when the silent-activation combo fires.
-        Acknowledges with the wake chime — but speaks no prompt, this being the
-        *silent* path — then hands off to the registered dictation handler,
-        gating it on the still-held key state so releasing the keys ends it.
-        Warns and does nothing if no handler is registered (e.g. the dictation
-        plugin didn't load).
+        Acknowledges with the wake chime — but speaks no prompt, this being the *silent*
+        path — then hands off to the registered dictation handler, gating it on the
+        still-held key state so releasing the keys ends it. Warns and does nothing if no
+        handler is registered (e.g. the dictation plugin didn't load).
         """
         if self._push_to_talk is None:
             logger.warning("Hotkey pressed but no dictation handler is registered.")
@@ -410,14 +415,14 @@ class EasySpeak:
     def _capture_command_session(self):
         """Capture and route commands after a wake, staying open for follow-ups.
 
-        After a recognized command that gave no spoken reply (e.g. volume), the
-        mic stays open so the user can chain commands ("louder", "louder") at
-        their own pace without repeating the wake word; the session ends once a
-        couple of quiet listens (FOLLOWUP_IDLE_ROUNDS) pass, the wake-time
-        silence times out, or a command speaks (whose reply the open mic would
-        otherwise hear). A repeated misunderstanding still re-arms keep_listening
-        for the help retry, and its feedback is drained before listening again.
-        Returns True if a command asked the daemon to exit.
+        After a recognized command that gave no spoken reply (e.g. volume), the mic
+        stays open so the user can chain commands ("louder", "louder") at their own pace
+        without repeating the wake word; the session ends once a couple of quiet listens
+        (FOLLOWUP_IDLE_ROUNDS) pass, the wake-time silence times out, or a command
+        speaks (whose reply the open mic would otherwise hear). A repeated
+        misunderstanding still re-arms keep_listening for the help retry, and its
+        feedback is drained before listening again. Returns True if a command asked the
+        daemon to exit.
         """
         self.keep_listening = True
         awake = True
@@ -453,8 +458,8 @@ class EasySpeak:
     def run(self):
         """Load models and plugins, then run the wake-word listen loop forever.
 
-        Blocks until the user quits (voice command, tray, or Ctrl-C), always
-        releasing the microphone and draining speech on the way out.
+        Blocks until the user quits (voice command, tray, or Ctrl-C), always releasing
+        the microphone and draining speech on the way out.
         """
         logger.info("Loading OpenWakeWord...")
         self.wakeword = WakeWordModel()

--- a/src/core/mediakeys.py
+++ b/src/core/mediakeys.py
@@ -1,13 +1,12 @@
 """Replay multimedia keys through GNOME (Mutter) for native desktop feedback.
 
-This lets the desktop render its own volume OSD and chime rather than imitating
-them. Pressing a volume key does not run any command: gnome-settings-daemon grabs the
-raw evdev key and handles the volume change, OSD and chime itself. The only way
-to reproduce that exactly is to replay the key. We inject it through Mutter's
-RemoteDesktop interface, which needs no special privileges. A RemoteDesktop
-session lives only as long as the D-Bus connection that created it, so the whole
-CreateSession -> Start -> NotifyKeyboardKeycode -> Stop sequence runs on one
-connection.
+This lets the desktop render its own volume OSD and chime rather than imitating them.
+Pressing a volume key does not run any command: gnome-settings-daemon grabs the raw
+evdev key and handles the volume change, OSD and chime itself. The only way to reproduce
+that exactly is to replay the key. We inject it through Mutter's RemoteDesktop
+interface, which needs no special privileges. A RemoteDesktop session lives only as long
+as the D-Bus connection that created it, so the whole CreateSession -> Start ->
+NotifyKeyboardKeycode -> Stop sequence runs on one connection.
 """
 
 from jeepney import DBusAddress, new_method_call
@@ -25,8 +24,8 @@ _REMOTE_DESKTOP = DBusAddress(
 def tap_key(keycode):
     """Press and release one evdev keycode via Mutter RemoteDesktop.
 
-    Raises if RemoteDesktop is unavailable (e.g. a non-GNOME session) so the
-    caller can fall back to a silent change.
+    Raises if RemoteDesktop is unavailable (e.g. a non-GNOME session) so the caller can
+    fall back to a silent change.
     """
     conn = open_dbus_connection(bus="SESSION")
     try:

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -1,9 +1,9 @@
 """Text-to-speech playback pipeline and audio-device noise suppression.
 
-Extracted from core.main so the orchestration loop isn't tangled up with the
-subprocess plumbing that keeps a piper voice model warm. `SpeechPipeline` owns
-a persistent `piper -> player` pair; `suppressed_c_stderr` hides the unrelated
-ALSA/JACK probe spew PortAudio emits when the input side (PyAudio) starts up.
+Extracted from core.main so the orchestration loop isn't tangled up with the subprocess
+plumbing that keeps a piper voice model warm. `SpeechPipeline` owns a persistent `piper
+-> player` pair; `suppressed_c_stderr` hides the unrelated ALSA/JACK probe spew
+PortAudio emits when the input side (PyAudio) starts up.
 """
 
 import contextlib
@@ -71,11 +71,11 @@ def suppressed_c_stderr():
 
 
 class SpeechPipeline:
-    """A persistent ``piper -> audio player`` pipeline for low-latency speech.
+    """A persistent `piper -> audio player` pipeline for low-latency speech.
 
-    Keeping piper alive avoids reloading its voice model (~2s) on every phrase,
-    and streaming raw PCM straight to the player means playback starts as soon
-    as synthesis does instead of after a temp WAV is fully written.
+    Keeping piper alive avoids reloading its voice model (~2s) on every phrase, and
+    streaming raw PCM straight to the player means playback starts as soon as synthesis
+    does instead of after a temp WAV is fully written.
     """
 
     def __init__(self):
@@ -135,8 +135,8 @@ class SpeechPipeline:
     def ensure(self):
         """Spawn the persistent piper -> player pipeline if not already running.
 
-        Raises OSError if the pipeline can't be brought up (missing binary, bad
-        model), so callers can warn once rather than silently failing per phrase.
+        Raises OSError if the pipeline can't be brought up (missing binary, bad model),
+        so callers can warn once rather than silently failing per phrase.
         """
         if self._alive(self._piper) and self._alive(self._player):
             return
@@ -197,13 +197,12 @@ class SpeechPipeline:
     def _reap(proc):
         """Kill a process, close its parent-side pipes, and wait for it, best-effort.
 
-        Both pipeline processes are spawned with stdin=PIPE, so the parent holds
-        a pipe fd for each; without closing them here, a repeatedly rebuilt
-        pipeline would leak two fds per cycle until it hits the fd limit. kill()
-        polls first and suppresses the PID-reuse race internally on Python 3.10+,
-        but ProcessLookupError is named anyway to stay safe on other versions;
-        AttributeError covers a malformed process handle and TimeoutExpired a
-        process that refuses to die.
+        Both pipeline processes are spawned with stdin=PIPE, so the parent holds a pipe
+        fd for each; without closing them here, a repeatedly rebuilt pipeline would leak
+        two fds per cycle until it hits the fd limit. kill() polls first and suppresses
+        the PID-reuse race internally on Python 3.10+, but ProcessLookupError is named
+        anyway to stay safe on other versions; AttributeError covers a malformed process
+        handle and TimeoutExpired a process that refuses to die.
         """
         for name in ("stdin", "stdout", "stderr"):
             handle = getattr(proc, name, None)  # tolerate a handle missing these
@@ -235,8 +234,8 @@ class SpeechPipeline:
     def drain(self):
         """Flush pending speech, wait for playback, then stop the pipeline.
 
-        Used on shutdown so a final phrase (e.g. "Goodbye.") is heard in full
-        before the process exits.
+        Used on shutdown so a final phrase (e.g. "Goodbye.") is heard in full before the
+        process exits.
         """
         piper, player = self._piper, self._player
         self._piper = self._player = None

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -1,12 +1,12 @@
 """GNOME panel-indicator bridge and asleep-state lifecycle for the daemon.
 
 The daemon is voice-first and otherwise headless; this module gives it a
-top-panel microphone icon (served by the bundled ``easyspeak@local`` GNOME
-Shell extension) and owns everything about it so the audio loop in ``core.main``
+top-panel microphone icon (served by the bundled `easyspeak@local` GNOME
+Shell extension) and owns everything about it so the audio loop in `core.main`
 stays about audio. It runs without a D-Bus server of its own via two
 one-directional channels:
 
-* daemon -> icon: state is pushed for display via a one-shot ``gdbus call``
+* daemon -> icon: state is pushed for display via a one-shot `gdbus call`
   (the same path the mouse-grid plugin uses to drive the extension).
 * icon -> daemon: the extension's menu writes a single command to a control
   file; the controller consumes it. The audio loop already wakes every ~80ms on
@@ -45,8 +45,8 @@ COMMAND_ABOUT = "about"  # open the libadwaita About window
 
 # The About window is its own process: the indicator lives in a GNOME Shell
 # extension that can't host GTK, so the daemon spawns this script instead. It's
-# run by file path (not ``-m``) because the PyGObject interpreter it runs in (see
-# _run_menu_action) doesn't have the ``easyspeak`` package installed; about.py is
+# run by file path (not `-m`) because the PyGObject interpreter it runs in (see
+# _run_menu_action) doesn't have the `easyspeak` package installed; about.py is
 # self-contained, so a plain path works there and in our own interpreter alike.
 ABOUT_HELPER = str(Path(__file__).with_name("about.py"))
 
@@ -78,7 +78,7 @@ HELPER_STARTUP_GRACE = 1.5
 
 
 class TrayAction(enum.Enum):
-    """What ``Tray.poll`` is telling the audio loop to do next."""
+    """What `Tray.poll` is telling the audio loop to do next."""
 
     CONTINUE = "continue"  # nothing happened; read audio as usual
     RESUME = "resume"  # woke from sleep; restart the listen iteration
@@ -88,25 +88,25 @@ class TrayAction(enum.Enum):
 class Tray:
     """Owns the EasySpeak panel indicator and the asleep (deactivated) lifecycle.
 
-    The audio loop calls :meth:`poll` once per iteration; the controller pushes
-    display state, consumes menu commands, and — when deactivated — runs the
-    idle loop itself, using caller-supplied callbacks to release and reacquire
+    The audio loop calls [`poll`][core.tray.Tray.poll] once per iteration; the
+    controller pushes display state, consumes menu commands, and — when deactivated —
+    runs the idle loop itself, using caller-supplied callbacks to release and reacquire
     the microphone. It never touches audio directly.
 
-    Best-effort throughout: on a non-GNOME desktop (no ``gdbus``/extension) the
-    state pushes simply fail and the daemon carries on, mirroring how the
-    mouse-grid plugin tolerates a missing extension.
+    Best-effort throughout: on a non-GNOME desktop (no `gdbus`/extension) the state
+    pushes simply fail and the daemon carries on, mirroring how the mouse-grid plugin
+    tolerates a missing extension.
     """
 
     def __init__(self, control_file=CONTROL_FILE, speak=None):
         """Set up the controller, optionally with a spoken-feedback callback.
 
-        ``speak`` defaults to a no-op so the tray works headless and in tests.
+        `speak` defaults to a no-op so the tray works headless and in tests.
 
-        For the spoken feedback callback (core.speak) the plugin only announces
-        the *attempt* ("Going to sleep."); the tray confirms or, when it can't
-        actually sleep, explains — since only it knows whether sleep engaged.
-        Defaults to a no-op so the tray works headless and in tests.
+        For the spoken feedback callback (core.speak) the plugin only announces the
+        *attempt* ("Going to sleep."); the tray confirms or, when it can't actually
+        sleep, explains — since only it knows whether sleep engaged. Defaults to a no-op
+        so the tray works headless and in tests.
         """
         self._control_file = Path(control_file)
         self._sleep_requested = False
@@ -117,11 +117,11 @@ class Tray:
     def started(self):
         """Daemon is up and listening; ensure the indicator is hidden.
 
-        Also drop any command left in the control file from before startup. It's
-        a one-shot channel for *live* menu clicks, so a stale 'about'/'help'/
-        'quit' written during a previous session (or before the daemon was
-        running to consume it) must not fire the moment we begin polling — which
-        otherwise pops the About window open on launch.
+        Also drop any command left in the control file from before startup. It's a
+        one-shot channel for *live* menu clicks, so a stale 'about'/'help'/ 'quit'
+        written during a previous session (or before the daemon was running to consume
+        it) must not fire the moment we begin polling — which otherwise pops the About
+        window open on launch.
         """
         self.take_command()
         self.set_state(STATE_LISTENING)
@@ -133,18 +133,18 @@ class Tray:
     def request_sleep(self):
         """Queue a deactivate (e.g. the "go to sleep" voice command).
 
-        The mic is released at the audio loop's next :meth:`poll`, after the
-        current command finishes.
+        The mic is released at the audio loop's next [`poll`][core.tray.Tray.poll],
+        after the current command finishes.
         """
         self._sleep_requested = True
 
     def poll(self, release_mic, acquire_mic):
         """Act on any pending menu command or queued sleep request.
 
-        ``release_mic`` / ``acquire_mic`` are zero-arg callbacks that close and
-        reopen the input stream; the controller calls them around the asleep
-        idle loop so this module stays out of the audio internals. Returns a
-        :class:`TrayAction` for the audio loop to dispatch on.
+        `release_mic` / `acquire_mic` are zero-arg callbacks that close and reopen the
+        input stream; the controller calls them around the asleep idle loop so this
+        module stays out of the audio internals. Returns a
+        [`TrayAction`][core.tray.TrayAction] for the audio loop to dispatch on.
         """
         command = self.take_command()
         if command == COMMAND_QUIT:
@@ -161,16 +161,15 @@ class Tray:
     def _run_menu_action(self, command):
         """Handle a fire-and-forget menu command (Help/About).
 
-        Returns True if it was one of those side-effect actions so callers can
-        carry on without touching the sleep/quit lifecycle. The indicator menu
-        is only shown while asleep, so in practice these fire from the idle loop
-        in :meth:`_sleep`; ``poll`` handles them too so the path isn't lifecycle-
-        dependent.
+        Returns True if it was one of those side-effect actions so callers can carry on
+        without touching the sleep/quit lifecycle. The indicator menu is only shown
+        while asleep, so in practice these fire from the idle loop in `_sleep`; `poll`
+        handles them too so the path isn't lifecycle- dependent.
 
-        The About dialog needs PyGObject + GTK4/libadwaita, which aren't in
-        the daemon's own (uv) venv. Reuse the PyGObject-equipped interpreter
-        the dictation AT-SPI helper already runs in, falling back to our own
-        interpreter when it isn't set (e.g. a plain pip install).
+        The About dialog needs PyGObject + GTK4/libadwaita, which aren't in the daemon's
+        own (uv) venv. Reuse the PyGObject-equipped interpreter the dictation AT-SPI
+        helper already runs in, falling back to our own interpreter when it isn't set
+        (e.g. a plain pip install).
         """
         if command == COMMAND_HELP:
             self._spawn(["xdg-open", DOCS_URL], "documentation page")
@@ -184,17 +183,17 @@ class Tray:
     def _spawn(self, cmd, what):
         """Launch a helper process, reporting it if it fails to start.
 
-        Fire-and-forget for the success case: a helper whose window opens keeps
-        running and is left detached (never waited on or reaped). But a helper
-        that *can't* start — a bad interpreter, missing GTK/libadwaita, no
-        display, no ``xdg-open`` handler — exits within
-        :data:`HELPER_STARTUP_GRACE`; that's caught here so the menu click isn't
-        silently lost, with the cause logged and an audible apology spoken.
+        Fire-and-forget for the success case: a helper whose window opens keeps running
+        and is left detached (never waited on or reaped). But a helper that *can't*
+        start — a bad interpreter, missing GTK/libadwaita, no display, no `xdg-open`
+        handler — exits within [`HELPER_STARTUP_GRACE`][core.tray.HELPER_STARTUP_GRACE];
+        that's caught here so the menu click isn't silently lost, with the cause logged
+        and an audible apology spoken.
 
-        stderr is captured to an anonymous temp file rather than a pipe: a
-        long-lived helper keeps writing to it (GTK logs to stderr) without ever
-        blocking on a full pipe buffer we've stopped draining, and the file is
-        reclaimed by the OS once the helper exits.
+        stderr is captured to an anonymous temp file rather than a pipe: a long-lived
+        helper keeps writing to it (GTK logs to stderr) without ever blocking on a full
+        pipe buffer we've stopped draining, and the file is reclaimed by the OS once the
+        helper exits.
         """
         with tempfile.TemporaryFile() as errlog:
             try:
@@ -218,9 +217,9 @@ class Tray:
     def _await_startup(self, proc):
         """Return the helper's exit code if it dies during startup, else None.
 
-        Waits up to :data:`HELPER_STARTUP_GRACE`; a helper still running past
-        that is taken to have opened its window, so this returns None ("started,
-        leave it") rather than reaping a GUI that may stay up for minutes.
+        Waits up to [`HELPER_STARTUP_GRACE`][core.tray.HELPER_STARTUP_GRACE]; a helper
+        still running past that is taken to have opened its window, so this returns None
+        ("started, leave it") rather than reaping a GUI that may stay up for minutes.
         """
         try:
             return proc.wait(timeout=HELPER_STARTUP_GRACE)
@@ -243,7 +242,7 @@ class Tray:
         reactivation only ever arrives via the extension's menu, so releasing
         the mic while the indicator is missing (no GNOME/extension) would strand
         the daemon with no way back. While asleep the muted state is re-asserted
-        every ``MUTED_REPUSH_INTERVAL`` seconds so the icon recovers if GNOME
+        every `MUTED_REPUSH_INTERVAL` seconds so the icon recovers if GNOME
         Shell or the extension reloads (it would otherwise come back hidden).
 
         Freeing the stream also clears GNOME's privacy microphone indicator, an

--- a/src/plugins/00_eyetrack.py
+++ b/src/plugins/00_eyetrack.py
@@ -59,7 +59,7 @@ class OneEuroFilter:
         return 1.0 / (1.0 + tau / te)
 
     def __call__(self, x):
-        """Filter the next sample ``x`` and return the smoothed value."""
+        """Filter the next sample `x` and return the smoothed value."""
         if self.x_prev is None:
             self.x_prev = x
             return x

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -180,7 +180,10 @@ atexit.register(cleanup)
 
 
 def parse_number_sequence(text):
-    """Extract ALL numbers from text as a sequence. '3 7 5' -> [3, 7, 5]."""
+    """Extract ALL numbers from text as a sequence.
+
+    '3 7 5' -> [3, 7, 5].
+    """
     # Replace word numbers with digits
     text_lower = text.lower()
     for word, num in WORD_TO_NUM.items():
@@ -191,7 +194,10 @@ def parse_number_sequence(text):
 
 
 def parse_count(text):
-    """Extract a repeat count (for nudge/scroll). Returns single number or 1."""
+    """Extract a repeat count (for nudge/scroll).
+
+    Returns single number or 1.
+    """
     text_lower = text.lower()
     for word, num in WORD_TO_NUM.items():
         text_lower = re.sub(rf"\b{word}\b", str(num), text_lower)
@@ -249,7 +255,10 @@ def close_grid():
 
 
 def update_grid(zone):
-    """Zoom to a single zone. Returns True if successful."""
+    """Zoom to a single zone.
+
+    Returns True if successful.
+    """
     global grid_bounds
 
     if not grid_active or not grid_bounds:
@@ -293,7 +302,10 @@ def update_grid(zone):
 
 
 def process_zones(zones):
-    """Process a sequence of zones. 'three seven five' zooms 3 times."""
+    """Process a sequence of zones.
+
+    'three seven five' zooms 3 times.
+    """
     for zone in zones:
         update_grid(zone)
 
@@ -325,7 +337,7 @@ def do_click(click_type="click"):
 
 
 def do_scroll(direction, count=1):
-    """Scroll ``count`` steps at the current cell center; False if no grid."""
+    """Scroll `count` steps at the current cell center; False if no grid."""
     global grid_bounds, grid_active, last_bounds
 
     center = get_center()
@@ -342,7 +354,7 @@ def do_scroll(direction, count=1):
 
 
 def nudge_grid(direction, count=1):
-    """Shift the current cell ``count`` steps in a direction; False if no grid."""
+    """Shift the current cell `count` steps in a direction; False if no grid."""
     global grid_bounds
 
     if not grid_bounds:
@@ -369,8 +381,8 @@ def nudge_grid(direction, count=1):
 def start_drag():
     """Press at the current cell center and reset the grid to full screen.
 
-    Leaves a drag in progress so a later :func:`end_drag` releases at the new
-    target. False if no grid is active.
+    Leaves a drag in progress so a later [`end_drag`][plugins.00_mousegrid.end_drag]
+    releases at the new target. False if no grid is active.
     """
     global drag_start, grid_bounds
     center = get_center()
@@ -388,8 +400,9 @@ def start_drag():
 
 
 def end_drag():
-    """Release a drag started by :func:`start_drag` and close the grid.
+    """Release a drag and close the grid.
 
+    Releases a drag started by [`start_drag`][plugins.00_mousegrid.start_drag].
     False if no drag is in progress or no grid is active.
     """
     global drag_start, grid_bounds, grid_active, last_bounds

--- a/src/plugins/_atspi_insert.py
+++ b/src/plugins/_atspi_insert.py
@@ -1,13 +1,13 @@
 """Standalone AT-SPI caret-insertion helper.
 
-The dictation plugin runs this as a script (see ``dictation.atspi_python``) in
+The dictation plugin runs this as a script (see `dictation.atspi_python`) in
 an interpreter that has PyGObject and the AT-SPI typelib — which the app's own
-venv usually lacks. It is a real module rather than an embedded ``python3 -c``
+venv usually lacks. It is a real module rather than an embedded `python3 -c`
 string so Ruff lints it and the unit tests can import and exercise it; an
-unlinted string is exactly how the earlier ``contextlib`` NameError slipped in.
+unlinted string is exactly how the earlier `contextlib` NameError slipped in.
 
 It communicates with the parent purely through stdout tokens:
-``OK`` (text inserted), ``NO_FOCUS`` (no editable field), ``NO_BACKEND``
+`OK` (text inserted), `NO_FOCUS` (no editable field), `NO_BACKEND`
 (PyGObject/AT-SPI not importable). Kept out of plugin discovery by the leading
 underscore in the filename.
 """
@@ -24,7 +24,7 @@ BACKSPACE = chr(8)
 
 
 def load_atspi():
-    """Return PyGObject's ``Atspi`` namespace, or ``None`` if unavailable.
+    """Return PyGObject's `Atspi` namespace, or `None` if unavailable.
 
     The detail of why it failed is written to stderr so the parent can log it.
     """
@@ -40,7 +40,7 @@ def load_atspi():
 
 
 def find_focused_editable(atspi, obj, depth=0):
-    """Depth-first search for the focused, editable accessible under ``obj``."""
+    """Depth-first search for the focused, editable accessible under `obj`."""
     if depth > MAX_DEPTH:
         return None
     # AT-SPI nodes can raise while being queried (apps closing, slow a11y
@@ -61,9 +61,9 @@ def find_focused_editable(atspi, obj, depth=0):
 def _insertion_point(target):
     """Where to start inserting: the caret, else end-of-text, else None.
 
-    Falling back to the end keeps multi-character insertion in order; the old
-    code advanced from a bogus ``-1``, scattering later characters to the start.
-    None means neither the caret nor the character count was readable.
+    Falling back to the end keeps multi-character insertion in order; the old code
+    advanced from a bogus `-1`, scattering later characters to the start. None means
+    neither the caret nor the character count was readable.
     """
     with contextlib.suppress(Exception):
         pos = target.get_caret_offset()
@@ -75,11 +75,11 @@ def _insertion_point(target):
 
 
 def insert_into(target, text):
-    """Type ``text`` into ``target`` at the caret, honouring backspaces.
+    """Type `text` into `target` at the caret, honouring backspaces.
 
-    Returns True once the text is inserted, or False if no usable insertion
-    point could be found — so the caller reports "no focus" rather than
-    scattering characters across the field.
+    Returns True once the text is inserted, or False if no usable insertion point could
+    be found — so the caller reports "no focus" rather than scattering characters across
+    the field.
     """
     pos = _insertion_point(target)
     if pos is None:
@@ -97,7 +97,7 @@ def insert_into(target, text):
 
 
 def run(atspi, text):
-    """Insert ``text`` into the focused editable; return an OK/NO_FOCUS token."""
+    """Insert `text` into the focused editable; return an OK/NO_FOCUS token."""
     desktop = atspi.get_desktop(0)
     for i in range(desktop.get_child_count()):
         target = find_focused_editable(atspi, desktop.get_child_at_index(i))

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -87,13 +87,12 @@ def _has(binary, core):
 def _register_terminal(core):
     """Discover the default terminal and register it under the "terminal" key.
 
-    The freedesktop launcher xdg-terminal-exec knows the user's configured
-    default terminal but execs into it, so its own name never appears in the
-    process list (which would break closing via pkill); ask it which binary it
-    would actually run. If it is not installed, fall back to the first known
-    terminal in PATH. When nothing is found no entry is added, so "open
-    terminal" falls through to the normal unrecognized-command handling rather
-    than trying to launch a missing binary.
+    The freedesktop launcher xdg-terminal-exec knows the user's configured default
+    terminal but execs into it, so its own name never appears in the process list (which
+    would break closing via pkill); ask it which binary it would actually run. If it is
+    not installed, fall back to the first known terminal in PATH. When nothing is found
+    no entry is added, so "open terminal" falls through to the normal
+    unrecognized-command handling rather than trying to launch a missing binary.
     """
     if _has(TERMINAL_LAUNCHER, core):
         result = core.host_run([TERMINAL_LAUNCHER, "--print-cmd"])

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -160,10 +160,9 @@ REQUIRED_QUTEBROWSER_LINES = [
 def ensure_qutebrowser_config():
     """Append any missing required lines to qutebrowser's config.py.
 
-    Preserves everything else the user has written. Tolerates read-only
-    configs (e.g. Nix Home-Manager symlinks into /nix/store): on a write
-    failure we emit a polite note telling the user which lines to add
-    themselves, rather than crashing startup.
+    Preserves everything else the user has written. Tolerates read-only configs (e.g.
+    Nix Home-Manager symlinks into /nix/store): on a write failure we emit a polite note
+    telling the user which lines to add themselves, rather than crashing startup.
     """
     cfg = Path.home() / ".config" / "qutebrowser" / "config.py"
 
@@ -318,7 +317,10 @@ def parse_hint_number(cmd):
 
 
 def parse_spoken_url(spoken):
-    """Convert spoken URL to actual URL. 'claude dot ai' -> 'https://claude.ai'."""
+    """Convert spoken URL to actual URL.
+
+    'claude dot ai' -> 'https://claude.ai'.
+    """
     url = spoken.lower().strip()
 
     # Replace spoken elements
@@ -442,10 +444,10 @@ def _is_reserved_global(cmd_lower):
 def _qutebrowser_running(core):
     """Whether a qutebrowser instance is already running.
 
-    Used by :func:`handle` to gate ambiguous navigation commands: we only act
-    on them when there is actually a browser to receive them. ``pgrep -f``
-    (rather than ``-x``) matches however the binary is wrapped — e.g. a Nix
-    ``.qutebrowser-wrapped`` launcher — so an open browser isn't missed.
+    Used by [`handle`][plugins.browser.handle] to gate ambiguous navigation commands: we
+    only act on them when there is actually a browser to receive them. `pgrep -f`
+    (rather than `-x`) matches however the binary is wrapped — e.g. a Nix
+    `.qutebrowser-wrapped` launcher — so an open browser isn't missed.
     """
     result = core.host_run(["pgrep", "-f", "qutebrowser"])
     return getattr(result, "returncode", 1) == 0
@@ -455,9 +457,9 @@ def handle(cmd, core):
     """Enter browser mode on a browser command; return None otherwise.
 
     A matching command launches qutebrowser (if needed) and runs the continuous
-    browser-mode loop; reserved global commands (sleep/quit) are passed through.
-    Outside the explicit "open browser", navigation commands are only acted on
-    when a browser is already running, so ambiguous words can't open one.
+    browser-mode loop; reserved global commands (sleep/quit) are passed through. Outside
+    the explicit "open browser", navigation commands are only acted on when a browser is
+    already running, so ambiguous words can't open one.
     """
     cmd_lower = cmd.lower().strip(".,!? ")
 

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -33,9 +33,9 @@ DICTATION_PROMPT = (
 def ensure_gnome_accessibility():
     """Enable GNOME's toolkit-accessibility for the AT-SPI bridge.
 
-    Silently skipped if gsettings isn't on PATH or the schema isn't
-    installed (i.e. user isn't on GNOME). Warns if it's present but the
-    flip fails. Tells the user to re-login when newly enabled.
+    Silently skipped if gsettings isn't on PATH or the schema isn't installed (i.e. user
+    isn't on GNOME). Warns if it's present but the flip fails. Tells the user to
+    re-login when newly enabled.
     """
     if shutil.which("gsettings") is None:
         return
@@ -99,11 +99,10 @@ ATSPI_HELPER = str(Path(__file__).with_name("_atspi_insert.py"))
 def atspi_python():
     """Path to the interpreter that runs the AT-SPI helper.
 
-    The helper needs PyGObject and the AT-SPI typelib, which the app's own
-    venv usually lacks. ``EASYSPEAK_ATSPI_PYTHON`` lets the packaging point at
-    an interpreter that has them (the Nix flake sets it); otherwise we fall
-    back to the system ``python3``, where distro packages like ``python3-gi``
-    typically live.
+    The helper needs PyGObject and the AT-SPI typelib, which the app's own venv usually
+    lacks. `EASYSPEAK_ATSPI_PYTHON` lets the packaging point at an interpreter that has
+    them (the Nix flake sets it); otherwise we fall back to the system `python3`, where
+    distro packages like `python3-gi` typically live.
     """
     return os.environ.get("EASYSPEAK_ATSPI_PYTHON") or "python3"
 
@@ -111,8 +110,8 @@ def atspi_python():
 def insert_text(text):
     """Insert text via AT-SPI.
 
-    Returns one of INSERTED, NO_FOCUS or BACKEND_ERROR so the caller can give
-    feedback that matches the real cause instead of always blaming focus.
+    Returns one of INSERTED, NO_FOCUS or BACKEND_ERROR so the caller can give feedback
+    that matches the real cause instead of always blaming focus.
     """
     cmd = [atspi_python(), ATSPI_HELPER, text]
     try:
@@ -229,10 +228,10 @@ def format_text(text):
 def _dictate_utterance(core, text):
     """Format one transcribed utterance, insert it, and give error feedback.
 
-    Shared by the voice ``notes`` flow and the push-to-talk hotkey. Returns True
-    when dictation should stop because insertion failed and the user was told
-    why (no focused field, or the backend isn't set up); False to keep going.
-    Text that formats to nothing is a silent no-op.
+    Shared by the voice `notes` flow and the push-to-talk hotkey. Returns True when
+    dictation should stop because insertion failed and the user was told why (no focused
+    field, or the backend isn't set up); False to keep going. Text that formats to
+    nothing is a silent no-op.
     """
     formatted = format_text(text)
     if not formatted:
@@ -259,11 +258,11 @@ PTT_LISTEN_TIMEOUT = 2
 def run_push_to_talk(core, should_continue):
     """Dictate while the activation keys are held (the silent-activation path).
 
-    Mirrors the voice ``notes`` loop but is gated on ``should_continue`` — a
-    predicate that is True while the keys remain held — instead of a spoken
-    "stop notes": each utterance captured from ``core`` is formatted and
-    inserted until the keys are released. The capture waits re-check
-    ``should_continue`` so releasing stops dictation promptly.
+    Mirrors the voice `notes` loop but is gated on `should_continue` — a predicate that
+    is True while the keys remain held — instead of a spoken "stop notes": each
+    utterance captured from `core` is formatted and inserted until the keys are
+    released. The capture waits re-check `should_continue` so releasing stops dictation
+    promptly.
     """
     logger.info("🎙️ Push-to-talk dictation — release to end")
     while should_continue():
@@ -284,9 +283,9 @@ def run_push_to_talk(core, should_continue):
 def handle(cmd, core):
     """Enter dictation mode on a whole-word "note"/"notes"; return None otherwise.
 
-    Matching whole words (not substrings) keeps unrelated words like "notebook"
-    or "noted" from triggering it. While in dictation mode it loops, transcribing
-    speech and inserting it into the focused field until "stop notes" is heard.
+    Matching whole words (not substrings) keeps unrelated words like "notebook" or
+    "noted" from triggering it. While in dictation mode it loops, transcribing speech
+    and inserting it into the focused field until "stop notes" is heard.
     """
     words = cmd.split()
     if ("notes" in words or "note" in words) and "stop" not in words:

--- a/src/plugins/system.py
+++ b/src/plugins/system.py
@@ -44,8 +44,8 @@ def setup(c):
 def _media_key(core, keycode, fallback):
     """Replay a multimedia key for the desktop's native OSD (and chime for volume).
 
-    Falls back to the given command if key injection is unavailable (e.g. a
-    non-GNOME session); the setting still changes, just without the feedback.
+    Falls back to the given command if key injection is unavailable (e.g. a non-GNOME
+    session); the setting still changes, just without the feedback.
     """
     if not core.tap_key(keycode):
         core.host_run(fallback)

--- a/src/plugins/zz_base.py
+++ b/src/plugins/zz_base.py
@@ -20,8 +20,8 @@ def setup(c):
 def handle(cmd, core):
     """Handle the help and exit commands; return None to pass others through.
 
-    Returns False to signal the daemon to exit, True if help was shown, or None
-    when the command is for another plugin.
+    Returns False to signal the daemon to exit, True if help was shown, or None when the
+    command is for another plugin.
     """
     cmd_lower = cmd.lower().strip()
 


### PR DESCRIPTION
MkDocs with mkdocstrings expects MarkDown instead of reStructuredText (Sphinx).

We add additional checks to ensure documentation is correctly assembled, and a link checker that verifies that external links keep working.