### PR TITLE
Serve latest docs at site root, check dead links in README

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,24 +48,48 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-    # Tags publish a named version and move the "latest" alias; pushes to the
-    # default branch publish the in-progress "dev" docs. Both deploy to the
-    # gh-pages branch via mike. --push lets GitHub Pages serve the result.
-    # Pull requests run the build above only — neither condition matches.
-    - name: Deploy release docs
+    # mike archives each build under its own /<version>/ path on the gh-pages
+    # branch; --push lets GitHub Pages serve it. Tags archive a named release,
+    # pushes to the default branch refresh the in-progress "dev" docs. Pull
+    # requests run the build above only — neither condition matches, so nothing
+    # deploys. The latest docs are served at the site root (see below), not via a
+    # /latest/ alias, so no alias or default-version redirect is set here.
+    - name: Archive release snapshot
       if: startsWith(github.ref, 'refs/tags/')
-      run: just docs-publish deploy --push --update-aliases "${GITHUB_REF_NAME}" latest
+      run: just docs-publish deploy --push "${GITHUB_REF_NAME}"
 
-    - name: Set default version to latest
-      if: startsWith(github.ref, 'refs/tags/')
-      run: just docs-publish set-default --push latest
-
-    - name: Deploy development docs
+    - name: Archive development snapshot
       if: github.ref == 'refs/heads/dev'
+      run: just docs-publish deploy --push dev
+
+    # Remove the obsolete "latest" alias an earlier deploy may have created; the
+    # latest docs now live at the root. Best-effort: it no longer exists once dropped.
+    - name: Drop obsolete latest alias
+      if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/dev'
+      run: just docs-publish delete --push latest || echo "no latest alias to remove"
+
+    # Publish the freshly built docs to the gh-pages root for clean, version-less
+    # URLs. The root tracks the most recent release; until the first release
+    # exists it tracks dev, so the root is never empty. sync-docs-root.py swaps in
+    # the new root pages while leaving mike's version snapshots and metadata intact.
+    - name: Publish latest docs to site root
+      if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/dev'
+      env:
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
       run: |
-        just docs-publish deploy --push dev
-        # Until the first release sets the default to "latest", point the
-        # site root at the dev docs so the Pages root resolves instead of 404.
-        if ! just docs-publish list | grep -q '\[latest\]'; then
-          just docs-publish set-default --push dev
+        git fetch origin gh-pages
+        if [ "$REF_TYPE" != "tag" ] && git show origin/gh-pages:versions.json \
+            | python -c 'import json,sys; sys.exit(0 if any(v["version"] != "dev" for v in json.load(sys.stdin)) else 1)'; then
+          echo "A release is published; leaving the root at the latest release."
+          exit 0
+        fi
+        git worktree add gh-pages-root origin/gh-pages
+        python packaging/sync-docs-root.py site gh-pages-root
+        git -C gh-pages-root add -A
+        if git -C gh-pages-root diff --cached --quiet; then
+          echo "Site root already up to date."
+        else
+          git -C gh-pages-root commit -m "Publish $REF_NAME docs to site root"
+          git -C gh-pages-root push origin HEAD:gh-pages
         fi

--- a/justfile
+++ b/justfile
@@ -109,12 +109,19 @@ benchmark *args:
 [group('docs')]
 check-docs: lint-docstrings lint-md check-links
 
-# Check built docs for dead external links (network; via the scheduled Links workflow, not the PR gate)
+# Check built docs and README/CONTRIBUTING for dead external links (network)
 [group('docs')]
 check-links *args: docs
+    # The README and CONTRIBUTING are GitHub-facing and link out to the live docs
+    # site; render them to HTML so linkchecker validates those links too (it can't
+    # parse Markdown). They live outside site/ so a docs deploy never picks them up.
+    mkdir -p build/linkcheck
+    uvx --from markdown markdown_py README.md > build/linkcheck/readme.html
+    uvx --from markdown markdown_py CONTRIBUTING.md > build/linkcheck/contributing.html
     # --ignore-url drops material's 404-page root-absolute links (only valid once served under the Pages path);
     # --user-agent avoids linkchecker's "Mozilla" default, which freedesktop.org's WAF answers with 418.
-    uvx linkchecker --check-extern --no-warnings --ignore-url '^file:///easyspeak/' --user-agent LinkChecker {{ args }} site/index.html
+    uvx linkchecker --check-extern --no-warnings --ignore-url '^file:///easyspeak/' --user-agent LinkChecker {{ args }} \
+        site/index.html build/linkcheck/readme.html build/linkcheck/contributing.html
 
 # Guard docstrings against reST markup (mkdocstrings renders Markdown, not reST)
 [group('docs')]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,11 @@
 site_name: EasySpeak
 site_description: Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
 # Docs are versioned with mike (see the `extra.version` block and the Docs
-# workflow); the live site only serves under a version path. Point site_url at
-# the stable `latest` alias so canonical URLs and the sitemap resolve instead
-# of 404ing on the unversioned root.
-site_url: https://ctsdownloads.github.io/easyspeak/latest/
+# workflow): each release/dev build is archived under its own `/<version>/`
+# path, while the latest docs are published to the site root for clean,
+# version-less URLs. Point site_url (canonical links, sitemap) at that root, so
+# the archived snapshots' canonical URLs reference the latest version.
+site_url: https://ctsdownloads.github.io/easyspeak/
 repo_url: https://github.com/ctsdownloads/easyspeak
 repo_name: ctsdownloads/easyspeak
 copyright: Copyright &copy; EasySpeak contributors — GPL-3.0

--- a/packaging/sync-docs-root.py
+++ b/packaging/sync-docs-root.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Publish the latest MkDocs build to the gh-pages site root.
+
+mike archives every release/dev build under its own ``/<version>/`` path and
+maintains ``versions.json`` plus ``.nojekyll`` at the root. To serve the latest
+docs at clean, version-less URLs (``/easyspeak/installation/`` rather than
+``/easyspeak/latest/installation/``), this copies a freshly built site into the
+gh-pages root, replacing the previous canonical files but leaving mike's version
+directories and metadata untouched.
+
+Usage:
+    sync-docs-root.py <built-site-dir> <gh-pages-checkout>
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# Root entries mike owns; never delete these when refreshing the canonical docs.
+MIKE_FILES = {".nojekyll", "versions.json"}
+
+
+def preserved_names(gh_pages: Path) -> set[str]:
+    """Names of root entries to keep: git internals, mike metadata, versions."""
+    keep = {".git"} | MIKE_FILES
+    versions = gh_pages / "versions.json"
+    if versions.is_file():
+        keep |= {entry["version"] for entry in json.loads(versions.read_text())}
+    return keep
+
+
+def main(site: str, gh_pages: str) -> None:
+    site_dir, root = Path(site), Path(gh_pages)
+    keep = preserved_names(root)
+
+    # Drop the previous canonical files (home page, per-page dirs, assets, the
+    # old `latest` alias/redirect), keeping mike's version snapshots in place.
+    for entry in root.iterdir():
+        if entry.name in keep:
+            continue
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry)
+        else:
+            entry.unlink()
+
+    # Lay down the new canonical build at the root.
+    for entry in site_dir.iterdir():
+        target = root / entry.name
+        if entry.is_dir():
+            shutil.copytree(entry, target)
+        else:
+            shutil.copy2(entry, target)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__)
+    main(sys.argv[1], sys.argv[2])

--- a/packaging/sync-docs-root.py
+++ b/packaging/sync-docs-root.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Publish the latest MkDocs build to the gh-pages site root.
 
 mike archives every release/dev build under its own ``/<version>/`` path and
@@ -9,7 +8,7 @@ gh-pages root, replacing the previous canonical files but leaving mike's version
 directories and metadata untouched.
 
 Usage:
-    sync-docs-root.py <built-site-dir> <gh-pages-checkout>
+    python sync-docs-root.py <built-site-dir> <gh-pages-checkout>
 """
 
 import json
@@ -31,11 +30,15 @@ def preserved_names(gh_pages: Path) -> set[str]:
 
 
 def main(site: str, gh_pages: str) -> None:
+    """Replace the canonical root docs with a freshly built site.
+
+    Drops the previous canonical files (home page, per-page dirs, assets, the
+    old ``latest`` alias/redirect) while keeping mike's version snapshots in
+    place, then lays down the new build at the root.
+    """
     site_dir, root = Path(site), Path(gh_pages)
     keep = preserved_names(root)
 
-    # Drop the previous canonical files (home page, per-page dirs, assets, the
-    # old `latest` alias/redirect), keeping mike's version snapshots in place.
     for entry in root.iterdir():
         if entry.name in keep:
             continue
@@ -44,7 +47,6 @@ def main(site: str, gh_pages: str) -> None:
         else:
             entry.unlink()
 
-    # Lay down the new canonical build at the root.
     for entry in site_dir.iterdir():
         target = root / entry.name
         if entry.is_dir():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,11 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"packaging/**" = [
+  "INP001",  # standalone build scripts, run directly — not an importable package
+]
+"src/plugins/00_*.py" = ["N999"]    # numeric prefix sets plugin load order
+"src/plugins/zz_base.py" = ["N999"] # zz_ prefix loads the base plugin last
 "tests/**" = [
   "S101",    # asserts are the whole point of a test
   "D",       # docstrings enforced on src/, not on tests
@@ -174,8 +179,6 @@ ignore = [
   "TC003",   # no need to guard stdlib imports behind TYPE_CHECKING in tests
   "EM101", "TRY003",  # inline exception messages fine in tests
 ]
-"src/plugins/00_*.py" = ["N999"]    # numeric prefix sets plugin load order
-"src/plugins/zz_base.py" = ["N999"] # zz_ prefix loads the base plugin last
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
Restructure docs publishing so the most recent release (or dev, until the first release) is served at **version-less URLs** (/easyspeak/...) rather than under a `/latest/` alias. mike still archives every build under its own `/<version>/` path; a new `packaging/sync-docs-root.py` script swaps the canonical root pages in place while leaving mike's version snapshots and metadata (`versions.json`, `.nojekyll`) intact.

- `docs.yml`: archive each tag/dev build as a version snapshot, drop the obsolete "latest" alias, and publish the freshly built site to the gh-pages root (keeping the root on the latest release once one exists)
- `mkdocs.yml`: point site_url at the root so canonical URLs and the sitemap resolve there instead of the /latest/ alias

While overhauling the dead link check, it became apparent that there are links in the README and CONTRIBUTING documents that point to a 404 location at the moment and can outdate in future, so we're covering them too now.

> [!NOTE]  
> This PR is merged into the `main` branch, so we can continue with the changes there after merging #80.