### PR TITLE
Fail gracefully when audio device or gdbus is missing

### DIFF
--- a/src/core/main.py
+++ b/src/core/main.py
@@ -264,16 +264,28 @@ class EasySpeak:
 
         PortAudio probes every ALSA/JACK device on open, spamming stderr about hardware
         this machine lacks; hide that C-level noise while keeping our own Python output
-        intact.
+        intact. When there is no capture device at all PortAudio raises a bare OSError
+        (e.g. errno -9996); surface that as an actionable message instead of a raw
+        traceback, since it commonly means a headless host such as WSL with no
+        microphone bridged in.
         """
-        with suppressed_c_stderr():
-            self.stream = self.audio.open(
-                format=pyaudio.paInt16,
-                channels=1,
-                rate=16000,
-                input=True,
-                frames_per_buffer=1280,
+        try:
+            with suppressed_c_stderr():
+                self.stream = self.audio.open(
+                    format=pyaudio.paInt16,
+                    channels=1,
+                    rate=16000,
+                    input=True,
+                    frames_per_buffer=1280,
+                )
+        except OSError as exc:
+            logger.error(  # noqa: TRY400
+                "No microphone input device found (%s). EasySpeak needs a working "
+                "PipeWire/PulseAudio or ALSA capture device; this is typically "
+                "missing under WSL, which bridges no microphone by default.",
+                exc,
             )
+            raise SystemExit(1) from exc
 
     def _close_stream(self):
         """Release the microphone so other apps see it as free.

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -109,8 +109,20 @@ def setup(c):
 
 
 def host_run(cmd):
-    """Run a command and capture its output (the plugin's own subprocess seam)."""
-    return subprocess.run(cmd, capture_output=True, text=True)
+    """Run a command and capture its output (the plugin's own subprocess seam).
+
+    A missing executable returns a failed result (returncode 1) rather than
+    raising, so callers treat an absent `gdbus`—e.g. on a headless host such as
+    WSL with no GNOME session—as a plain D-Bus failure. Without this the atexit
+    cleanup would raise FileNotFoundError on exit.
+    """
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        logger.debug("Command not found: %s", exc)
+        return subprocess.CompletedProcess(
+            cmd, returncode=1, stdout="", stderr=str(exc)
+        )
 
 
 def dbus_call(method, *args):

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -1612,3 +1612,29 @@ class TestEasySpeakPushToTalk:
         chime.assert_called_once_with()
         handler.assert_called_once_with(easy.hotkey.is_held)
         easy.speak.assert_not_called()
+
+
+class TestOpenStream:
+    """Tests for opening the microphone input stream."""
+
+    def test_open_stream_success(self):
+        """A working capture device stores the opened stream."""
+        easy = EasySpeak()
+        easy.audio = Mock()
+        stream = easy.audio.open.return_value
+
+        easy._open_stream()
+
+        assert easy.stream is stream
+
+    def test_open_stream_no_device_exits_cleanly(self):
+        """A missing capture device exits with a message, not a raw traceback."""
+        easy = EasySpeak()
+        easy.audio = Mock()
+        easy.audio.open.side_effect = OSError(-9996, "Invalid input device")
+
+        with pytest.raises(SystemExit) as exc_info:
+            easy._open_stream()
+
+        assert exc_info.value.code == 1
+        assert easy.stream is None

--- a/tests/unit/plugins/test_mousegrid.py
+++ b/tests/unit/plugins/test_mousegrid.py
@@ -50,6 +50,14 @@ def test_host_run(mock_subprocess_run):
     assert result.returncode == 0
 
 
+@patch("subprocess.run", side_effect=FileNotFoundError(2, "No such file or directory"))
+def test_host_run_missing_executable(_mock_subprocess_run):
+    """A missing executable (e.g. gdbus on headless WSL) returns a failed result."""
+    result = mousegrid_plugin.host_run(["gdbus", "call"])
+
+    assert result.returncode == 1
+
+
 @patch.object(mousegrid_plugin, "dbus_call", return_value=True)
 def test_cleanup(mock_dbus_call):
     """When cleanup is called then it hides the grid via dbus."""


### PR DESCRIPTION
EasySpeak crashed with a raw traceback on headless hosts (e.g. NixOS under WSL) that have no microphone capture device and no GNOME session.

- `_open_stream` now catches PortAudio's `OSError` for a missing capture device and exits with an actionable message instead of a traceback.
- `host_run` treats a missing executable (e.g. `gdbus`) as a failed result, so the atexit cleanup no longer raises `FileNotFoundError` on exit and other D-Bus callers degrade gracefully.

Discovered in #82.