### PR TITLE
Fix broken docs screenshots, skip demo video in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,14 @@ jobs:
       with:
         fetch-depth: 0  # mike needs the full history of the gh-pages branch
 
+    # Docs embed PNG/JPG assets tracked by Git LFS; without this CI publishes
+    # the LFS pointer files and the screenshots render broken. Pull them
+    # explicitly rather than via checkout's `lfs: true` so we can skip the
+    # large demo video (excluded from the built site anyway) and avoid the
+    # bandwidth. Local clones still fetch everything normally.
+    - name: Fetch LFS assets (excluding the large demo video)
+      run: git lfs pull --exclude="docs/media/demo.mp4"
+
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.12'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,12 @@ theme:
 # the root CONTRIBUTING.md is a short stub pointing here for GitHub.
 docs_dir: docs
 
+# These assets live under docs/media/ but are not referenced by any page, so
+# keep them out of the built site (the demo video is a 23 MB LFS object).
+exclude_docs: |
+  media/demo.mp4
+  media/log.txt
+
 nav:
 - Home: index.md
 - Installation: installation.md


### PR DESCRIPTION
CI checked out repo without LFS, so the Pages site published LFS pointer files instead of the real PNGs and [screenshots rendered broken](https://ctsdownloads.github.io/easyspeak/latest/screenshots/). Pull LFS assets explicitly, excluding the 23 MB demo video to save bandwidth; local clones still fetch everything.

Also exclude the unreferenced `demo.mp4` and `log.txt` from the built site via `exclude_docs`.

@ctsdownloads Would it make sense to attach the content of [`docs/media/log.txt`](https://github.com/ctsdownloads/easyspeak/blob/main/docs/media/log.txt) to an issue here on GitHub, and then delete the file from the repository?