### PR TITLE
Fix extension-refresh unit failing on a vanished uv interpreter

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,1 @@
+"""EasySpeak bundled data files, loaded at runtime via importlib.resources."""

--- a/data/easyspeak-extension-refresh.service.in
+++ b/data/easyspeak-extension-refresh.service.in
@@ -1,0 +1,17 @@
+[Unit]
+Description=Refresh the EasySpeak GNOME Shell extension before GNOME Shell loads it
+# Runs before the shell reads the extensions dir so a changed extension.js takes
+# effect on this login, not the next (on Wayland the shell only loads extensions
+# at login). Missing shell units are ignored.
+Before={target}
+Before=org.gnome.Shell@user.service
+Before=org.gnome.Shell@wayland.service
+Before=org.gnome.Shell@x11.service
+
+[Service]
+Type=oneshot
+# Quoted: systemd splits ExecStart on whitespace.
+ExecStart="{python}" "{script}"
+
+[Install]
+WantedBy={target}

--- a/justfile
+++ b/justfile
@@ -184,10 +184,12 @@ gate: (clean '--quiet') (package '--quiet')
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q plugins
     # Python package should bundle launcher and Shell extension assets.
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q easyspeak.desktop
+    tar tfz dist/easyspeak_linux-*.tar.gz | grep -q easyspeak-extension-refresh.service.in
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension-helpers.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q metadata.json
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak.desktop
+    unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak-extension-refresh.service.in
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension-helpers.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q metadata.json

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -130,9 +130,41 @@ def _unit_path():
     return Path.home() / ".config" / "systemd" / "user" / REFRESH_UNIT_NAME
 
 
+def _is_ephemeral_interpreter(executable):
+    """True when ``executable`` lives in a uv ephemeral build env.
+
+    uv builds an ephemeral interpreter under its build cache (…/uv/builds-*/…)
+    for each `uv run` / `nix run`, then garbage-collects it, so a unit pointing
+    at it fails `203/EXEC` at every login; see `_stable_interpreter`. Packaged
+    installs (Debian/RPM system python, a real venv) never live here, so this
+    marker only ever matches the dev/`nix run` path.
+    """
+    return "/uv/builds-" in str(executable)
+
+
+def _stable_interpreter():
+    """Return a persistent interpreter path to bake into the login unit.
+
+    `sys.executable` is fine for packaged installs but can point into a uv
+    ephemeral build env under `uv run` / `nix run`. When it does, fall back to
+    the base interpreter that env was built from (`sys._base_executable`, else
+    the symlink target) — it persists, and the refresh entry point imports only
+    the stdlib so a bare base interpreter runs it. Resolving deterministically
+    keeps the rendered unit byte-stable, so re-running converges instead of
+    flapping (and a unit left pointing at a vanished interpreter self-heals on
+    the next start).
+    """
+    if not _is_ephemeral_interpreter(sys.executable):
+        return sys.executable
+    base = getattr(sys, "_base_executable", None)
+    if base and not _is_ephemeral_interpreter(base):
+        return base
+    return str(Path(sys.executable).resolve())
+
+
 def _unit_text():
     """Render the systemd user unit, baking in the interpreter and module path."""
-    python = sys.executable
+    python = _stable_interpreter()
     script = Path(__file__).resolve()
     return f"""\
 [Unit]

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -19,6 +19,7 @@ import logging
 import shutil
 import subprocess
 import sys
+from importlib import resources
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ EXTENSION_UUID = "easyspeak@local"
 # mouse grid). A leftover copy is cleaned up at startup; see migrate_legacy_extension.
 LEGACY_EXTENSION_UUID = "easyspeak-grid@local"
 REFRESH_UNIT_NAME = "easyspeak-extension-refresh.service"
+REFRESH_UNIT_TEMPLATE = REFRESH_UNIT_NAME + ".in"  # packaged template file
 PRE_SHELL_TARGET = "gnome-session-pre.target"  # reached before org.gnome.Shell@*
 
 # Cap each helper subprocess so a wedged session/user bus can't hang startup.
@@ -131,7 +133,7 @@ def _unit_path():
 
 
 def _is_ephemeral_interpreter(executable):
-    """True when ``executable`` lives in a uv ephemeral build env.
+    """True when `executable` lives in a uv ephemeral build env.
 
     uv builds an ephemeral interpreter under its build cache (…/uv/builds-*/…)
     for each `uv run` / `nix run`, then garbage-collects it, so a unit pointing
@@ -163,28 +165,18 @@ def _stable_interpreter():
 
 
 def _unit_text():
-    """Render the systemd user unit, baking in the interpreter and module path."""
-    python = _stable_interpreter()
-    script = Path(__file__).resolve()
-    return f"""\
-[Unit]
-Description=Refresh the EasySpeak GNOME Shell extension before GNOME Shell loads it
-# Runs before the shell reads the extensions dir so a changed extension.js takes
-# effect on this login, not the next (on Wayland the shell only loads extensions
-# at login). Missing shell units are ignored.
-Before={PRE_SHELL_TARGET}
-Before=org.gnome.Shell@user.service
-Before=org.gnome.Shell@wayland.service
-Before=org.gnome.Shell@x11.service
+    """Render the systemd user unit, baking in the interpreter and module path.
 
-[Service]
-Type=oneshot
-# Quoted: systemd splits ExecStart on whitespace.
-ExecStart="{python}" "{script}"
-
-[Install]
-WantedBy={PRE_SHELL_TARGET}
-"""
+    The unit body lives in a template shipped as package data (`easyspeak.data`)
+    so it reads as a service file, not a Python string. A missing template is a
+    broken install, so let the read error surface rather than masking it.
+    """
+    template = (resources.files("easyspeak.data") / REFRESH_UNIT_TEMPLATE).read_text()
+    return template.format(
+        target=PRE_SHELL_TARGET,
+        python=_stable_interpreter(),
+        script=Path(__file__).resolve(),
+    )
 
 
 def _run_systemctl(*args):

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -1,7 +1,6 @@
 """Tests for the easyspeak.core.gnome_extension module."""
 
 import subprocess
-import sys
 from unittest.mock import Mock, patch
 
 import pytest
@@ -230,7 +229,7 @@ def test_unit_text_contains_ordering_and_execstart():
     assert "Type=oneshot" in text
     # Both ExecStart arguments are quoted so a space in the interpreter or
     # module path can't make systemd mis-split the command.
-    assert f'ExecStart="{sys.executable}" "' in text
+    assert f'ExecStart="{gnome_extension._stable_interpreter()}" "' in text
     assert "gnome_extension.py" in text
 
 
@@ -281,12 +280,106 @@ def test_is_enabled_false_when_systemctl_times_out():
         assert gnome_extension._is_enabled() is False
 
 
+# --- interpreter resolution --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "executable, expected",
+    [
+        ("/usr/bin/python3", False),
+        ("/opt/easyspeak/venv/bin/python", False),
+        ("/home/u/.local/state/easyspeak/venv/bin/python", False),
+        # uv build-env interpreters (EASYSPEAK-scoped cache and uv's default).
+        ("/home/u/.cache/easyspeak/uv/builds-v0/.tmp7q/bin/python", True),
+        ("/home/u/.cache/uv/builds-v0/.tmpAB/bin/python3.12", True),
+    ],
+)
+def test_is_ephemeral_interpreter(executable, expected):
+    assert gnome_extension._is_ephemeral_interpreter(executable) is expected
+
+
+def test_stable_interpreter_keeps_stable_executable():
+    """A packaged install's interpreter is baked as-is."""
+    with patch.object(gnome_extension.sys, "executable", "/usr/bin/python3"):
+        assert gnome_extension._stable_interpreter() == "/usr/bin/python3"
+
+
+def test_stable_interpreter_falls_back_to_base_when_ephemeral():
+    """Under `nix run`, the ephemeral build-env interpreter is replaced by the
+    persistent base interpreter it was built from."""
+    ephemeral = "/home/u/.cache/uv/builds-v0/.tmpZZ/bin/python"
+    base = "/nix/store/abc-python3-3.12.13/bin/python3.12"
+    with (
+        patch.object(gnome_extension.sys, "executable", ephemeral),
+        patch.object(gnome_extension.sys, "_base_executable", base),
+    ):
+        assert gnome_extension._stable_interpreter() == base
+
+
+def test_stable_interpreter_resolves_symlink_when_base_unusable(tmp_path):
+    """With no usable `_base_executable`, the ephemeral interpreter is resolved
+    through its symlink to the persistent target."""
+    real = tmp_path / "store" / "python3.12"
+    real.parent.mkdir(parents=True)
+    real.write_text("")
+    ephemeral_dir = tmp_path / ".cache" / "uv" / "builds-v0" / ".tmpZZ" / "bin"
+    ephemeral_dir.mkdir(parents=True)
+    ephemeral = ephemeral_dir / "python"
+    ephemeral.symlink_to(real)
+
+    with (
+        patch.object(gnome_extension.sys, "executable", str(ephemeral)),
+        patch.object(gnome_extension.sys, "_base_executable", None),
+    ):
+        assert gnome_extension._stable_interpreter() == str(real)
+
+
 # --- install_refresh_unit ----------------------------------------------------
 
 
 def test_install_refresh_unit_no_systemd():
     with patch.object(gnome_extension.shutil, "which", return_value=None):
         assert gnome_extension.install_refresh_unit() is None
+
+
+def test_install_refresh_unit_heals_unit_left_on_vanished_interpreter(tmp_path):
+    """A unit poisoned by an earlier `nix run` (ExecStart on a since-deleted uv
+    build-env interpreter) converges to a stable one on the next start, and a
+    second call is then a no-op — i.e. the install is idempotent."""
+    unit = tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
+    unit.parent.mkdir(parents=True)
+    stale = (
+        '[Service]\nExecStart="/home/u/.cache/easyspeak/uv/builds-v0/'
+        '.tmpgone/bin/python" "/x/gnome_extension.py"\n'
+    )
+    unit.write_text(stale)
+
+    ephemeral = "/home/u/.cache/easyspeak/uv/builds-v0/.tmpnew/bin/python"
+    base = "/nix/store/abc-python3-3.12.13/bin/python3.12"
+    with (
+        patch.object(
+            gnome_extension.shutil, "which", return_value="/usr/bin/systemctl"
+        ),
+        patch.object(gnome_extension.Path, "home", return_value=tmp_path),
+        patch.object(gnome_extension.sys, "executable", ephemeral),
+        patch.object(gnome_extension.sys, "_base_executable", base),
+        patch.object(
+            gnome_extension.subprocess,
+            "run",
+            return_value=Mock(returncode=0, stdout="enabled\n"),
+        ),
+    ):
+        first = gnome_extension.install_refresh_unit()
+        healed = unit.read_text()
+        expected = gnome_extension._unit_text()
+        # Second run sees its own output and changes nothing.
+        second = gnome_extension.install_refresh_unit()
+
+    assert first == f"installed systemd user unit {UNIT_NAME}"
+    assert "/uv/builds-" not in healed
+    assert f'ExecStart="{base}"' in healed
+    assert healed == expected
+    assert second is None  # already current and enabled → no rewrite
 
 
 def test_install_refresh_unit_new_install(tmp_path):

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -345,14 +345,20 @@ def test_install_refresh_unit_no_systemd():
 def test_install_refresh_unit_heals_unit_left_on_vanished_interpreter(tmp_path):
     """A unit poisoned by an earlier `nix run` (ExecStart on a since-deleted uv
     build-env interpreter) converges to a stable one on the next start, and a
-    second call is then a no-op — i.e. the install is idempotent."""
+    second call is then a no-op — i.e. the install is idempotent.
+
+    The poisoned unit is the real template rendered with an interpreter that has
+    since been garbage-collected, which also checks the packaged template reads.
+    """
     unit = tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
     unit.parent.mkdir(parents=True)
-    stale = (
-        '[Service]\nExecStart="/home/u/.cache/easyspeak/uv/builds-v0/'
-        '.tmpgone/bin/python" "/x/gnome_extension.py"\n'
-    )
-    unit.write_text(stale)
+
+    gone = "/home/u/.cache/easyspeak/uv/builds-v0/.tmpgone/bin/python"
+    with (
+        patch.object(gnome_extension.sys, "executable", gone),
+        patch.object(gnome_extension.sys, "_base_executable", gone),
+    ):
+        unit.write_text(gnome_extension._unit_text())
 
     ephemeral = "/home/u/.cache/easyspeak/uv/builds-v0/.tmpnew/bin/python"
     base = "/nix/store/abc-python3-3.12.13/bin/python3.12"
@@ -497,12 +503,23 @@ def test_install_refresh_unit_read_error_treated_as_changed(tmp_path):
     unit.parent.mkdir(parents=True)
     unit.write_text("whatever")
 
+    # Fail only on the existing unit's read, not on _unit_text reading its
+    # template — autospec passes the instance so we can tell them apart.
+    real_read_text = gnome_extension.Path.read_text
+
+    def read_text(self, *args, **kwargs):
+        if self == unit:
+            raise OSError("boom")
+        return real_read_text(self, *args, **kwargs)
+
     with (
         patch.object(
             gnome_extension.shutil, "which", return_value="/usr/bin/systemctl"
         ),
         patch.object(gnome_extension.Path, "home", return_value=tmp_path),
-        patch.object(gnome_extension.Path, "read_text", side_effect=OSError("boom")),
+        patch.object(
+            gnome_extension.Path, "read_text", autospec=True, side_effect=read_text
+        ),
         patch.object(
             gnome_extension.subprocess, "run", return_value=Mock(returncode=0)
         ),


### PR DESCRIPTION
Fixes the Python interpreter path of the pre-shell systemd unit that refreshes the bundled GNOME Shell extension at login, and makes the service configuration more visible by extracting it from the Python source code.

## Fix the unit baking a vanishing interpreter

The unit rendered its `ExecStart` from `sys.executable`, which under `uv run` / `nix run` points into a uv ephemeral build environment (`…/uv/builds-*/…`) that uv later garbage-collects — so the unit failed `203/EXEC` at every login and the installed extension silently stopped updating. It now resolves a persistent interpreter: `sys.executable` for packaged installs, falling back to the base interpreter the build env was built from (`sys._base_executable`, else the symlink target) when that path is ephemeral. The refresh entry point imports only the stdlib, so a bare base interpreter runs it. Resolution is deterministic, so `install_refresh_unit` converges and a unit left pointing at a vanished interpreter self-heals on the next start.

## Extract the unit body to a packaged template

The systemd unit was an inline f-string in `_unit_text()`; it now lives in `data/easyspeak-extension-refresh.service.in` and is loaded via `importlib.resources` so it reads as a real service file. The template ships in the wheel (existing package-data glob) and the sdist (MANIFEST graft); a new `data/__init__.py` makes `easyspeak.data` a regular package so `importlib.resources` resolves it, and the packaging gate now asserts the template is present in both artifacts.