### PR TITLE
Add extension Settings dialog, desktop integration, and Website link

### DIFF
--- a/data/easyspeak-autostart.desktop
+++ b/data/easyspeak-autostart.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=EasySpeak
+Comment=Voice control for Linux desktops — fully local, Wayland-native
+Exec=easyspeak
+Icon=audio-input-microphone
+Terminal=false
+StartupNotify=false
+X-GNOME-Autostart-enabled=true

--- a/data/easyspeak-extension-refresh.service.in
+++ b/data/easyspeak-extension-refresh.service.in
@@ -1,8 +1,5 @@
 [Unit]
 Description=Refresh the EasySpeak GNOME Shell extension before GNOME Shell loads it
-# Runs before the shell reads the extensions dir so a changed extension.js takes
-# effect on this login, not the next (on Wayland the shell only loads extensions
-# at login). Missing shell units are ignored.
 Before={target}
 Before=org.gnome.Shell@user.service
 Before=org.gnome.Shell@wayland.service
@@ -10,7 +7,6 @@ Before=org.gnome.Shell@x11.service
 
 [Service]
 Type=oneshot
-# Quoted: systemd splits ExecStart on whitespace.
 ExecStart="{python}" "{script}"
 
 [Install]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@
 // (undefined names, unused vars) without trying to resolve modules.
 export default [
   {
-    files: ["src/extension.js", "src/extension-helpers.js"],
+    files: ["src/extension.js", "src/extension-helpers.js", "src/prefs.js"],
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ pytest *args:
 # Display test coverage report
 [group('tests')]
 coverage:
-    uvx coverage[toml] xml
+    -uvx coverage[toml] xml
     uvx coverage[toml] report
 
 # Run integration tests (exercise external commands for real)
@@ -184,11 +184,13 @@ gate: (clean '--quiet') (package '--quiet')
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q plugins
     # Python package should bundle launcher and Shell extension assets.
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q easyspeak.desktop
+    tar tfz dist/easyspeak_linux-*.tar.gz | grep -q easyspeak-autostart.desktop
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q easyspeak-extension-refresh.service.in
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension-helpers.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q metadata.json
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak.desktop
+    unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak-autostart.desktop
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak-extension-refresh.service.in
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension-helpers.js

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ lint *args=('--statistics'):
 # Lint the GNOME Shell extension JS (use --fix to autocorrect)
 [group('codestyle')]
 lint-js *args:
-    eslint src/extension.js src/extension-helpers.js {{ args }}
+    eslint src/extension.js src/extension-helpers.js src/prefs.js {{ args }}
 
 # Check YAML formatting: minimal indent, final newline (config in .yamllint.yaml)
 [group('codestyle')]
@@ -188,12 +188,14 @@ gate: (clean '--quiet') (package '--quiet')
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q easyspeak-extension-refresh.service.in
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q extension-helpers.js
+    tar tfz dist/easyspeak_linux-*.tar.gz | grep -q prefs.js
     tar tfz dist/easyspeak_linux-*.tar.gz | grep -q metadata.json
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak.desktop
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak-autostart.desktop
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q easyspeak-extension-refresh.service.in
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q extension-helpers.js
+    unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q prefs.js
     unzip -l dist/easyspeak_linux-*-py3-none-any.whl | grep -q metadata.json
     @echo "✔  Python packaging looks good."
 

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -29,6 +29,18 @@ contents:
 # Desktop entry (uses the stock audio-input-microphone icon from adwaita-icon-theme).
 - src: ./data/easyspeak.desktop
   dst: /usr/share/applications/easyspeak.desktop
+# Start at login by default; users can turn this off in the extension's Settings
+# (which writes an overriding ~/.config/autostart/easyspeak.desktop).
+- src: ./data/easyspeak-autostart.desktop
+  dst: /etc/xdg/autostart/easyspeak.desktop
+# Pre-shell GNOME-extension refresh unit, rendered for the bundled interpreter by
+# stage-bundle.sh and enabled for every user via the .wants symlink below — so the
+# extension is current at the first post-install login without launching EasySpeak.
+- src: ./dist/easyspeak-extension-refresh.service
+  dst: /usr/lib/systemd/user/easyspeak-extension-refresh.service
+- src: ../easyspeak-extension-refresh.service
+  dst: /usr/lib/systemd/user/gnome-session-pre.target.wants/easyspeak-extension-refresh.service
+  type: symlink
 - src: ./LICENSE
   dst: /usr/share/doc/easyspeak/LICENSE
 

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -40,6 +40,14 @@ echo ">> installing app + runtime extras into the venv"
 # piper-tts: provides the `piper` binary inside the venv (no system piper packaged).
 uv pip install --python "$PREFIX/venv/bin/python" "$WHEEL" openwakeword piper-tts
 
+echo ">> rendering the GNOME-extension refresh unit for the bundled interpreter"
+# `--show service` prints the unit the bundled interpreter would install, so the
+# packaged file is byte-identical to the runtime-generated one — baked with the
+# bundle's stable interpreter and module paths (PREFIX is the final install path,
+# so they're valid on the target). nfpm ships this to /usr/lib/systemd/user.
+"$PREFIX/venv/bin/easyspeak" --show service \
+  > "$REPO_ROOT/dist/easyspeak-extension-refresh.service"
+
 # Where language packages drop their models; config.py discovers them here.
 mkdir -p "$PREFIX/models"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ packages = [
 "easyspeak" = [
   "extension.js",
   "extension-helpers.js",
+  "prefs.js",
   "metadata.json",
 ]
 "easyspeak.data" = ["*"]

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -3,11 +3,13 @@
 import argparse
 
 from . import log
-from .main import EasySpeak
 
 
 def parse_args(argv=None):
     """Parse EasySpeak's command-line arguments."""
+    config_items = {"extension", "service", "autostart", "desktop"}
+    config_defaults = {"extension", "service"}
+
     parser = argparse.ArgumentParser(
         prog="easyspeak", description="Voice control for Linux desktops."
     )
@@ -18,11 +20,53 @@ def parse_args(argv=None):
     verbosity.add_argument(
         "-q", "--quiet", action="store_true", help="show only warnings and errors"
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--configure",
+        nargs="*",
+        choices=config_items,
+        help=(
+            "set up the listed activities and exit "
+            f"(default: {' '.join(config_defaults)})"
+        ),
+    )
+    parser.add_argument(
+        "--show",
+        nargs="*",
+        choices=config_items,
+        help="print the listed items' files to stdout and exit (default: all)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.configure is not None:
+        args.configure = set(args.configure) or config_defaults
+    if args.show is not None:
+        args.show = set(args.show) or config_items
+
+    return args
 
 
 def run(argv=None):
-    """Start the application."""
+    """Start the application, or run a one-shot subcommand and exit.
+
+    `EasySpeak` is imported lazily so the one-shot subcommands work without the
+    audio stack (openwakeword, pyaudio, …) that `core.main` pulls in.
+    """
     args = parse_args(argv)
+
+    if args.show is not None:
+        from .desktop_integration import show
+
+        show(args.show)
+        return
+
     log.configure(log.resolve_level(verbose=args.verbose, quiet=args.quiet))
+
+    if args.configure is not None:
+        from .desktop_integration import configure
+
+        configure(args.configure)
+        return
+
+    from .main import EasySpeak
+
     EasySpeak().run()

--- a/src/core/desktop_integration.py
+++ b/src/core/desktop_integration.py
@@ -1,0 +1,113 @@
+"""Optional desktop integration for non-packaged (pip / dev) installs.
+
+Debian/RPM packages ship the launcher, autostart entry, and refresh service as
+system files, so users there need do nothing. A pip or `uv` install has no such
+hooks, so `easyspeak --configure` writes the per-user equivalents under `$HOME`.
+
+The GNOME extension and its refresh service are always set up — they're what
+makes the panel/tray icon work — while the launcher and autostart entries are
+opt-in, since not everyone wants EasySpeak in their menu or starting at login.
+"""
+
+import logging
+import sys
+from importlib import resources
+from pathlib import Path
+
+from .gnome_extension import (
+    activate_extension,
+    extension_source_dir,
+    install_refresh_unit,
+    unit_text,
+)
+
+logger = logging.getLogger(__name__)
+
+# Bundled desktop files (package data), and the basename they install under. The
+# autostart copy keeps the launcher's basename so a per-user file can override a
+# packaged /etc/xdg/autostart entry of the same name.
+AUTOSTART_TEMPLATE = "easyspeak-autostart.desktop"
+DESKTOP_TEMPLATE = "easyspeak.desktop"
+INSTALLED_DESKTOP_NAME = "easyspeak.desktop"
+
+
+def autostart_path():
+    """User-local autostart entry, read by the session at login."""
+    return Path.home() / ".config" / "autostart" / INSTALLED_DESKTOP_NAME
+
+
+def desktop_path():
+    """User-local application launcher (app grid / menu)."""
+    return Path.home() / ".local" / "share" / "applications" / INSTALLED_DESKTOP_NAME
+
+
+def _data_text(name):
+    """Read a bundled data file (package data) as text."""
+    return (resources.files("easyspeak.data") / name).read_text()
+
+
+def _install_data_file(template, dest):
+    """Copy a bundled desktop file into `dest`, best-effort."""
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(_data_text(template))
+    except OSError as e:
+        logger.warning("could not write %s (%s)", dest, e)
+        return False
+    logger.info("installed %s", dest)
+    return True
+
+
+def install_autostart_file():
+    """Write the per-user autostart entry so EasySpeak starts at login."""
+    return _install_data_file(AUTOSTART_TEMPLATE, autostart_path())
+
+
+def install_desktop_file():
+    """Write the per-user application launcher."""
+    return _install_data_file(DESKTOP_TEMPLATE, desktop_path())
+
+
+def configure(items: set[str]):
+    """Run the requested setup activities, then return.
+
+    Each activity in `items` is independent, so callers get exactly what they ask
+    for and nothing implicitly. The CLI fills in its own default set, so an empty
+    `items` here simply does nothing.
+    """
+    if "extension" in items:
+        activate_extension()
+    if "service" in items:
+        # install_refresh_unit only reports when it changes something; say so
+        # either way, so this item is never silent.
+        logger.info(install_refresh_unit() or "refresh service already configured")
+    if "desktop" in items:
+        install_desktop_file()
+    if "autostart" in items:
+        install_autostart_file()
+
+
+def item_text(item):
+    """Return the text a configure item creates or uses, for inspection.
+
+    Backs `--show`, and lets packaging capture e.g. the refresh-service unit as
+    rendered for the running interpreter — without installing anything.
+    """
+    if item == "service":
+        return unit_text()
+    if item == "autostart":
+        return _data_text(AUTOSTART_TEMPLATE)
+    if item == "desktop":
+        return _data_text(DESKTOP_TEMPLATE)
+    # extension: its metadata.json manifest is the one representative file.
+    return (extension_source_dir() / "metadata.json").read_text()
+
+
+def show(items):
+    """Print each item's text to stdout, header-separated only when several."""
+    labelled = len(items) > 1
+    for item in items:
+        if labelled:
+            sys.stdout.write(f"# {item}\n")
+        text = item_text(item)
+        sys.stdout.write(text if text.endswith("\n") else text + "\n")

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -164,12 +164,18 @@ def _stable_interpreter():
     return str(Path(sys.executable).resolve())
 
 
-def _unit_text():
+def unit_text():
     """Render the systemd user unit, baking in the interpreter and module path.
 
     The unit body lives in a template shipped as package data (`easyspeak.data`)
     so it reads as a service file, not a Python string. A missing template is a
     broken install, so let the read error surface rather than masking it.
+
+    Two non-obvious choices in the rendered unit: it's ordered before
+    `gnome-session-pre.target` and the `org.gnome.Shell@*` services (missing ones
+    are ignored) so a changed extension takes effect on this login, not the next
+    — on Wayland the shell only loads extensions at login. And both ExecStart
+    arguments are quoted, since systemd splits ExecStart on whitespace.
     """
     template = (resources.files("easyspeak.data") / REFRESH_UNIT_TEMPLATE).read_text()
     return template.format(
@@ -206,17 +212,45 @@ def _is_enabled():
     )
 
 
+def _system_unit_exists():
+    """True when a packaged install provides the refresh unit system-wide.
+
+    A packaged (Debian/RPM) install drops the unit in one of systemd's system
+    directories and owns its lifecycle (enabling it via a
+    gnome-session-pre.target.wants symlink), so the per-user generator stands
+    down when one is present.
+    """
+    system_dirs = (
+        "/usr/lib/systemd/user",
+        "/usr/local/lib/systemd/user",
+        "/etc/systemd/user",
+    )
+    return any((Path(d) / REFRESH_UNIT_NAME).is_file() for d in system_dirs)
+
+
 def install_refresh_unit():
     """Install and enable the pre-shell refresh unit, idempotently.
 
     Returns a short status string, or None when nothing changed or it isn't applicable
-    (no systemd, write/enable failure).
+    (no systemd, a packaged system unit already present, write/enable failure).
     """
     if shutil.which("systemctl") is None:
         return None
 
     unit_path = _unit_path()
-    desired = _unit_text()
+
+    if _system_unit_exists():
+        # The package owns the unit; don't shadow it with a user copy. Clear out a
+        # stale one a prior pip/dev install left — `~/.config/systemd/user` takes
+        # precedence over the packaged path and would point at a vanished
+        # interpreter, so it must go for the packaged unit to take effect.
+        if unit_path.is_file():
+            _run_systemctl("disable", REFRESH_UNIT_NAME)
+            with contextlib.suppress(OSError):
+                unit_path.unlink()
+        return None
+
+    desired = unit_text()
     try:
         current = unit_path.read_text() if unit_path.is_file() else None
     except OSError:
@@ -276,6 +310,20 @@ def migrate_legacy_extension():
 
 
 def ensure_extension():
+    """Startup hook: install the refresh service and activate the extension.
+
+    Composes the two independently-runnable activities `core.desktop_integration`
+    also exposes. Skipped on non-GNOME desktops.
+    """
+    if shutil.which("gnome-extensions") is None:
+        return
+    unit_status = install_refresh_unit()
+    if unit_status:
+        logger.info("%s", unit_status)
+    activate_extension()
+
+
+def activate_extension():
     """Install, refresh, and enable the bundled extension, reporting what it did.
 
     Installs it if missing, keeps the installed copy current, and enables it. Skipped on
@@ -285,10 +333,6 @@ def ensure_extension():
         return
 
     migrate_legacy_extension()
-
-    unit_status = install_refresh_unit()
-    if unit_status:
-        logger.info("%s", unit_status)
 
     try:
         listed = subprocess.run(

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -37,7 +37,12 @@ SUBPROCESS_TIMEOUT = 5.0
 
 # Bundled assets, installed as a set: extension.js imports extension-helpers.js,
 # so they must travel together or the extension fails to load.
-EXTENSION_ASSETS = ("extension.js", "extension-helpers.js", "metadata.json")
+EXTENSION_ASSETS = (
+    "extension.js",
+    "extension-helpers.js",
+    "prefs.js",
+    "metadata.json",
+)
 
 
 class RefreshResult(enum.Enum):

--- a/src/extension-helpers.js
+++ b/src/extension-helpers.js
@@ -58,3 +58,25 @@ export function gridGeometry(bx, by, bw, bh) {
 export function indicatorVisibleForState(state) {
     return state === 'muted';
 }
+
+// Build the per-user autostart entry (~/.config/autostart/easyspeak.desktop) for
+// the given enabled state. Written with the flag false, it overrides a packaged
+// /etc/xdg/autostart entry of the same name — the way gnome-tweaks disables one.
+export function autostartDesktopEntry(enabled) {
+    return [
+        '[Desktop Entry]',
+        'Type=Application',
+        'Name=EasySpeak',
+        'Exec=easyspeak',
+        `X-GNOME-Autostart-enabled=${enabled ? 'true' : 'false'}`,
+        '',
+    ].join('\n');
+}
+
+// Read the autostart-enabled flag from a .desktop file's text. A missing key
+// counts as enabled: the file's presence means autostart unless it's explicitly
+// turned off with X-GNOME-Autostart-enabled=false.
+export function autostartEnabledFromText(text) {
+    const match = text.match(/^X-GNOME-Autostart-enabled\s*=\s*(\S+)/m);
+    return match ? match[1].toLowerCase() !== 'false' : true;
+}

--- a/src/extension.js
+++ b/src/extension.js
@@ -8,6 +8,7 @@ import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import {
     clampToWorkArea,
     scrollDirectionDelta,
@@ -533,9 +534,10 @@ const CONTROL_FILE = CACHE_DIR + '/control';
 // wake the assistant back up.
 const TrayIndicator = GObject.registerClass(
 class TrayIndicator extends PanelMenu.Button {
-    _init() {
+    _init(openPreferences) {
         super._init(0.0, 'EasySpeak');
         this.visible = false;  // hidden until the daemon reports "muted"
+        this._openPreferences = openPreferences;
 
         this._icon = new St.Icon({
             icon_name: 'microphone-disabled-symbolic',  // mic with a slash
@@ -544,21 +546,19 @@ class TrayIndicator extends PanelMenu.Button {
         });
         this.add_child(this._icon);
 
-        const statusItem = new PopupMenu.PopupMenuItem('EasySpeak: Deactivated', {
-            reactive: false,
-        });
-        this.menu.addMenuItem(statusItem);
-        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-
-        const reactivateItem = new PopupMenu.PopupMenuItem('Reactivate');
+        const reactivateItem = new PopupMenu.PopupMenuItem('Reactivate EasySpeak');
         reactivateItem.connect('activate', () => this._writeCommand('unmute'));
         this.menu.addMenuItem(reactivateItem);
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-        // Help opens the docs and About shows the libadwaita window; both are
-        // handled by the daemon (which knows its own interpreter and the docs
-        // URL) via the same control-file channel as the other menu actions.
+        // Settings opens this extension's own prefs window (prefs.js) in-process.
+        // Help and About route through the daemon (which knows its interpreter
+        // and the docs URL) via the same control-file channel as the other items.
+        const settingsItem = new PopupMenu.PopupMenuItem('Settings…');
+        settingsItem.connect('activate', () => this._openPreferences());
+        this.menu.addMenuItem(settingsItem);
+
         const helpItem = new PopupMenu.PopupMenuItem('Help');
         helpItem.connect('activate', () => this._writeCommand('help'));
         this.menu.addMenuItem(helpItem);
@@ -596,20 +596,12 @@ class TrayIndicator extends PanelMenu.Button {
     }
 });
 
-export default class EasySpeakGridExtension {
-    constructor() {
-        this._dbus = null;
-        this._grid = null;
-        this._winMgr = null;
-        this._screenMgr = null;
-        this._tray = null;
-    }
-
+export default class EasySpeakGridExtension extends Extension {
     enable() {
         this._grid = new GridOverlay();
         this._winMgr = new WindowManager();
         this._screenMgr = new ScreenshotManager();
-        this._tray = new TrayIndicator();
+        this._tray = new TrayIndicator(() => this.openPreferences());
         Main.panel.addToStatusArea('easyspeak', this._tray);
         // addToStatusArea drops new indicators at the LEFT end of the status
         // area (the "application content" zone). Move ours to the RIGHT end of

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,7 +1,8 @@
 {
   "name": "EasySpeak",
-  "description": "Voice control for Linux — EasySpeak's GNOME Shell integration (panel indicator and on-screen surfaces).",
+  "description": "Voice control for Linux — panel indicator and on-screen surfaces.",
+  "url": "https://ctsdownloads.github.io/easyspeak/",
   "uuid": "easyspeak@local",
   "shell-version": ["47", "48", "49", "50"],
-  "version": 3
+  "version": 4
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,0 +1,93 @@
+// EasySpeak GNOME Shell extension preferences (gjs / GTK4 / libadwaita).
+//
+// Backs the "Settings" button the GNOME Extensions app shows for any extension
+// that ships a prefs.js. It toggles whether EasySpeak starts at login — by
+// writing the per-user autostart entry — and opens an About dialog. The pure
+// autostart text handling lives in extension-helpers.js so it can be unit-tested;
+// this file is the Gio/Adw glue, which only runs inside the prefs process.
+
+import Adw from 'gi://Adw';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk';
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+import {
+    autostartDesktopEntry,
+    autostartEnabledFromText,
+} from './extension-helpers.js';
+
+// ~/.config/autostart/easyspeak.desktop, matching core.desktop_integration.
+const AUTOSTART_SUBPATH = ['autostart', 'easyspeak.desktop'];
+
+const ABOUT = {
+    application_name: 'EasySpeak',
+    application_icon: 'audio-input-microphone',
+    developer_name: 'Matt Hartley',
+    comments:
+        'Voice control for Linux desktops. Fully local, no cloud, Wayland-native.',
+    website: 'https://ctsdownloads.github.io/easyspeak/',
+    issue_url: 'https://github.com/ctsdownloads/easyspeak/issues',
+    copyright: '© Matt Hartley and the EasySpeak contributors',
+};
+
+export default class EasySpeakPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const page = new Adw.PreferencesPage();
+        const group = new Adw.PreferencesGroup({ title: 'EasySpeak' });
+        page.add(group);
+
+        const autostart = new Adw.SwitchRow({
+            title: 'Start EasySpeak on login',
+            subtitle: 'Launch EasySpeak automatically when you log in',
+            active: this._autostartEnabled(),
+        });
+        autostart.connect('notify::active', (row) =>
+            this._setAutostartEnabled(row.active));
+        group.add(autostart);
+
+        const about = new Adw.ActionRow({
+            title: 'About EasySpeak',
+            activatable: true,
+        });
+        about.add_suffix(new Gtk.Image({ icon_name: 'go-next-symbolic' }));
+        about.connect('activated', () => this._presentAbout(window));
+        group.add(about);
+
+        window.add(page);
+    }
+
+    _autostartFile() {
+        return Gio.File.new_for_path(
+            GLib.build_filenamev([GLib.get_user_config_dir(), ...AUTOSTART_SUBPATH]));
+    }
+
+    _autostartEnabled() {
+        const file = this._autostartFile();
+        if (!file.query_exists(null))
+            return true;
+        const [ok, contents] = file.load_contents(null);
+        return ok ? autostartEnabledFromText(new TextDecoder().decode(contents)) : true;
+    }
+
+    _setAutostartEnabled(enabled) {
+        const file = this._autostartFile();
+        const dir = file.get_parent();
+        if (!dir.query_exists(null))
+            dir.make_directory_with_parents(null);
+        const data = new TextEncoder().encode(autostartDesktopEntry(enabled));
+        file.replace_contents(
+            data, null, false, Gio.FileCreateFlags.REPLACE_DESTINATION, null);
+    }
+
+    _presentAbout(window) {
+        const dialog = new Adw.AboutDialog({
+            ...ABOUT,
+            license_type: Gtk.License.GPL_3_0,
+        });
+        dialog.add_link('Source Code', 'https://github.com/ctsdownloads/easyspeak');
+        dialog.add_link(
+            'Discussions', 'https://github.com/ctsdownloads/easyspeak/discussions');
+        dialog.present(window);
+    }
+}

--- a/tests/js/extension-helpers.test.js
+++ b/tests/js/extension-helpers.test.js
@@ -8,6 +8,8 @@ import {
     scrollDirectionDelta,
     gridGeometry,
     indicatorVisibleForState,
+    autostartDesktopEntry,
+    autostartEnabledFromText,
 } from '../../src/extension-helpers.js';
 
 test('clampToWorkArea returns the rectangle unchanged without a work area', () => {
@@ -80,4 +82,27 @@ test('indicatorVisibleForState shows the tray icon only when muted', () => {
     for (const state of ['listening', 'active', 'thinking', '', undefined]) {
         assert.equal(indicatorVisibleForState(state), false);
     }
+});
+
+test('autostartDesktopEntry renders an enabled entry', () => {
+    const text = autostartDesktopEntry(true);
+    assert.match(text, /^\[Desktop Entry\]/);
+    assert.match(text, /^Exec=easyspeak$/m);
+    assert.match(text, /^X-GNOME-Autostart-enabled=true$/m);
+});
+
+test('autostartDesktopEntry renders a disabled entry', () => {
+    assert.match(autostartDesktopEntry(false), /^X-GNOME-Autostart-enabled=false$/m);
+});
+
+test('autostartEnabledFromText reads an explicit false as disabled', () => {
+    assert.equal(autostartEnabledFromText('X-GNOME-Autostart-enabled=false\n'), false);
+});
+
+test('autostartEnabledFromText reads true (or any non-false) as enabled', () => {
+    assert.equal(autostartEnabledFromText('X-GNOME-Autostart-enabled=true\n'), true);
+});
+
+test('autostartEnabledFromText treats a missing key as enabled', () => {
+    assert.equal(autostartEnabledFromText('[Desktop Entry]\nExec=easyspeak\n'), true);
 });

--- a/tests/unit/core/test_cli.py
+++ b/tests/unit/core/test_cli.py
@@ -19,7 +19,7 @@ def test_entrypoint():
     assert shutil.which("easyspeak")
 
 
-@patch("easyspeak.core.cli.EasySpeak")
+@patch("easyspeak.core.main.EasySpeak")
 def test_run(mock_easyspeak):
     """cli.run parses args, configures logging, and runs the app."""
     cli.run([])
@@ -63,22 +63,80 @@ def _run_then_log(argv, capsys, level, message):
     return capsys.readouterr().err
 
 
-@patch("easyspeak.core.cli.EasySpeak")
+@patch("easyspeak.core.main.EasySpeak")
 def test_run_default_prints_info_without_prefix(mock_easyspeak, capsys):
     """No flag: INFO is shown as the bare message; DEBUG is suppressed."""
     assert _run_then_log([], capsys, logging.INFO, "hello") == "hello\n"
     assert _run_then_log([], capsys, logging.DEBUG, "noise") == ""
 
 
-@patch("easyspeak.core.cli.EasySpeak")
+@patch("easyspeak.core.main.EasySpeak")
 def test_run_verbose_enables_debug_with_level_prefix(mock_easyspeak, capsys):
     """-v: DEBUG is shown and every line is prefixed with its level name."""
     assert _run_then_log(["-v"], capsys, logging.INFO, "hello") == "INFO hello\n"
     assert _run_then_log(["-v"], capsys, logging.DEBUG, "x") == "DEBUG x\n"
 
 
-@patch("easyspeak.core.cli.EasySpeak")
+@patch("easyspeak.core.main.EasySpeak")
 def test_run_quiet_silences_info_but_keeps_warnings(mock_easyspeak, capsys):
     """-q: INFO is silent; warnings/errors still print (without a prefix)."""
     assert _run_then_log(["-q"], capsys, logging.INFO, "hidden") == ""
     assert _run_then_log(["-q"], capsys, logging.WARNING, "oops") == "oops\n"
+
+
+@patch("easyspeak.core.desktop_integration.configure")
+def test_run_configure_dispatches_items_and_skips_app(mock_configure):
+    """--configure runs setup with the parsed items and does not start the app."""
+    cli.run(["--configure", "autostart"])
+
+    mock_configure.assert_called_once_with({"autostart"})
+
+
+@patch("easyspeak.core.desktop_integration.configure")
+def test_run_configure_with_no_items_applies_default(mock_configure):
+    """--configure with no items is resolved to the default pair by parse_args."""
+    cli.run(["--configure"])
+
+    mock_configure.assert_called_once_with({"extension", "service"})
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], None),  # no --configure: run the app
+        (["--configure"], {"extension", "service"}),  # empty → default pair
+        (["--configure", "autostart"], {"autostart"}),  # explicit items kept
+    ],
+)
+def test_parse_args_configure_default(argv, expected):
+    """parse_args fills the default pair only for a bare --configure."""
+    assert cli.parse_args(argv).configure == expected
+
+
+@patch("easyspeak.core.desktop_integration.show")
+def test_run_show_prints_items_and_skips_app(mock_show):
+    """--show prints the requested items and does not start the app."""
+    cli.run(["--show", "service"])
+
+    mock_show.assert_called_once_with({"service"})
+
+
+@patch("easyspeak.core.desktop_integration.show")
+def test_run_show_with_no_items_defaults_to_all(mock_show):
+    """--show with no items prints every item."""
+    cli.run(["--show"])
+
+    mock_show.assert_called_once_with({"extension", "service", "autostart", "desktop"})
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], None),  # no --show
+        (["--show"], {"extension", "service", "autostart", "desktop"}),  # empty → all
+        (["--show", "desktop"], {"desktop"}),  # explicit item kept
+    ],
+)
+def test_parse_args_show_default(argv, expected):
+    """parse_args expands a bare --show to all items."""
+    assert cli.parse_args(argv).show == expected

--- a/tests/unit/core/test_desktop_integration.py
+++ b/tests/unit/core/test_desktop_integration.py
@@ -1,0 +1,108 @@
+"""Tests for the --configure desktop-integration setup."""
+
+from unittest.mock import patch
+
+import pytest
+from easyspeak.core import desktop_integration as di
+
+
+def test_paths_are_user_local(tmp_path):
+    with patch.object(di.Path, "home", return_value=tmp_path):
+        assert di.autostart_path() == (
+            tmp_path / ".config" / "autostart" / "easyspeak.desktop"
+        )
+        assert di.desktop_path() == (
+            tmp_path / ".local" / "share" / "applications" / "easyspeak.desktop"
+        )
+
+
+def test_install_autostart_file_writes_bundled_template(tmp_path, readlog):
+    with patch.object(di.Path, "home", return_value=tmp_path):
+        assert di.install_autostart_file() is True
+        dest = di.autostart_path()
+
+    body = dest.read_text()
+    assert "[Desktop Entry]" in body
+    assert "X-GNOME-Autostart-enabled=true" in body
+    assert str(dest) in readlog().err
+
+
+def test_install_desktop_file_writes_bundled_template(tmp_path):
+    with patch.object(di.Path, "home", return_value=tmp_path):
+        assert di.install_desktop_file() is True
+        assert "Exec=easyspeak" in di.desktop_path().read_text()
+
+
+def test_install_data_file_write_failure_returns_false(tmp_path, readlog):
+    with (
+        patch.object(di.Path, "home", return_value=tmp_path),
+        patch.object(di.Path, "write_text", side_effect=OSError("read-only")),
+    ):
+        assert di.install_autostart_file() is False
+    assert "could not write" in readlog().err
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        set(),  # empty does nothing; the CLI supplies any default
+        {"extension"},
+        {"service"},
+        {"autostart"},
+        {"desktop"},
+        {"service", "desktop"},
+        {"extension", "service", "autostart", "desktop"},
+    ],
+)
+def test_configure_runs_exactly_the_requested_activities(items):
+    expected = items
+    done = set()
+    with (
+        patch.object(di, "activate_extension", lambda: done.add("extension")),
+        patch.object(di, "install_refresh_unit", lambda: done.add("service")),
+        patch.object(di, "install_autostart_file", lambda: done.add("autostart")),
+        patch.object(di, "install_desktop_file", lambda: done.add("desktop")),
+    ):
+        di.configure(items)
+
+    assert done == expected
+
+
+@pytest.mark.parametrize(
+    ("item", "needle"),
+    [
+        ("service", "[Unit]"),
+        ("autostart", "X-GNOME-Autostart-enabled"),
+        ("desktop", "Exec=easyspeak"),
+        ("extension", '"uuid"'),  # the metadata.json manifest
+    ],
+)
+def test_item_text_returns_the_items_artifact(item, needle):
+    assert needle in di.item_text(item)
+
+
+def test_show_single_item_is_unlabelled(capsys):
+    di.show(["service"])
+
+    out = capsys.readouterr().out
+    assert out.startswith("[Unit]")
+    assert "# service" not in out
+
+
+def test_show_multiple_items_are_labelled(capsys):
+    di.show(["autostart", "desktop"])
+
+    out = capsys.readouterr().out
+    assert "# autostart\n" in out
+    assert "# desktop\n" in out
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [("no-newline", "no-newline\n"), ("has-newline\n", "has-newline\n")],
+)
+def test_show_normalises_the_trailing_newline(capsys, text, expected):
+    with patch.object(di, "item_text", return_value=text):
+        di.show(["service"])
+
+    assert capsys.readouterr().out == expected

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -221,8 +221,8 @@ def test_refresh_installed_extension_delegates():
 # --- unit rendering ----------------------------------------------------------
 
 
-def test_unit_text_contains_ordering_and_execstart():
-    text = gnome_extension._unit_text()
+def testunit_text_contains_ordering_and_execstart():
+    text = gnome_extension.unit_text()
     assert f"WantedBy={gnome_extension.PRE_SHELL_TARGET}" in text
     assert f"Before={gnome_extension.PRE_SHELL_TARGET}" in text
     assert "org.gnome.Shell@user.service" in text
@@ -358,7 +358,7 @@ def test_install_refresh_unit_heals_unit_left_on_vanished_interpreter(tmp_path):
         patch.object(gnome_extension.sys, "executable", gone),
         patch.object(gnome_extension.sys, "_base_executable", gone),
     ):
-        unit.write_text(gnome_extension._unit_text())
+        unit.write_text(gnome_extension.unit_text())
 
     ephemeral = "/home/u/.cache/easyspeak/uv/builds-v0/.tmpnew/bin/python"
     base = "/nix/store/abc-python3-3.12.13/bin/python3.12"
@@ -377,7 +377,7 @@ def test_install_refresh_unit_heals_unit_left_on_vanished_interpreter(tmp_path):
     ):
         first = gnome_extension.install_refresh_unit()
         healed = unit.read_text()
-        expected = gnome_extension._unit_text()
+        expected = gnome_extension.unit_text()
         # Second run sees its own output and changes nothing.
         second = gnome_extension.install_refresh_unit()
 
@@ -402,7 +402,7 @@ def test_install_refresh_unit_new_install(tmp_path):
 
     unit = tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
     assert unit.is_file()
-    assert unit.read_text() == gnome_extension._unit_text()
+    assert unit.read_text() == gnome_extension.unit_text()
     assert status == f"installed systemd user unit {UNIT_NAME}"
     cmds = [call.args[0] for call in mock_run.call_args_list]
     assert ["systemctl", "--user", "daemon-reload"] in cmds
@@ -428,7 +428,7 @@ def test_install_refresh_unit_systemctl_unexecable_returns_none(tmp_path):
 def test_install_refresh_unit_noop_when_current_and_enabled(tmp_path):
     unit = tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
     unit.parent.mkdir(parents=True)
-    unit.write_text(gnome_extension._unit_text())
+    unit.write_text(gnome_extension.unit_text())
 
     with (
         patch.object(
@@ -452,7 +452,7 @@ def test_install_refresh_unit_noop_when_current_and_enabled(tmp_path):
 def test_install_refresh_unit_current_but_disabled_enables(tmp_path):
     unit = tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
     unit.parent.mkdir(parents=True)
-    unit.write_text(gnome_extension._unit_text())
+    unit.write_text(gnome_extension.unit_text())
 
     with (
         patch.object(
@@ -494,7 +494,7 @@ def test_install_refresh_unit_rewrites_when_changed(tmp_path):
     ):
         status = gnome_extension.install_refresh_unit()
 
-    assert unit.read_text() == gnome_extension._unit_text()
+    assert unit.read_text() == gnome_extension.unit_text()
     assert status == f"installed systemd user unit {UNIT_NAME}"
 
 
@@ -503,7 +503,7 @@ def test_install_refresh_unit_read_error_treated_as_changed(tmp_path):
     unit.parent.mkdir(parents=True)
     unit.write_text("whatever")
 
-    # Fail only on the existing unit's read, not on _unit_text reading its
+    # Fail only on the existing unit's read, not on unit_text reading its
     # template — autospec passes the instance so we can tell them apart.
     real_read_text = gnome_extension.Path.read_text
 
@@ -993,3 +993,52 @@ class TestEnsureExtension:
 
         captured = readlog()
         assert "log out and back in" in captured.err
+
+
+# --- packaged-unit coexistence + activate_extension -------------------------
+
+
+def test_install_refresh_unit_stands_down_for_packaged_unit(tmp_path):
+    """A packaged system unit present: drop the stale user unit and stand down."""
+    unit = tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
+    unit.parent.mkdir(parents=True)
+    unit.write_text("stale user unit")
+
+    with (
+        patch.object(
+            gnome_extension.shutil, "which", return_value="/usr/bin/systemctl"
+        ),
+        patch.object(gnome_extension.Path, "home", return_value=tmp_path),
+        patch.object(gnome_extension, "_system_unit_exists", return_value=True),
+        patch.object(
+            gnome_extension.subprocess, "run", return_value=Mock(returncode=0)
+        ) as mock_run,
+    ):
+        status = gnome_extension.install_refresh_unit()
+
+    assert status is None
+    assert not unit.exists()  # the shadowing user unit was removed
+    cmds = [c.args[0] for c in mock_run.call_args_list]
+    assert ["systemctl", "--user", "disable", UNIT_NAME] in cmds
+
+
+def test_install_refresh_unit_packaged_unit_no_stale_user_copy(tmp_path):
+    """Packaged unit present, no user copy: stand down without touching systemctl."""
+    with (
+        patch.object(
+            gnome_extension.shutil, "which", return_value="/usr/bin/systemctl"
+        ),
+        patch.object(gnome_extension.Path, "home", return_value=tmp_path),
+        patch.object(gnome_extension, "_system_unit_exists", return_value=True),
+        patch.object(gnome_extension.subprocess, "run") as mock_run,
+    ):
+        status = gnome_extension.install_refresh_unit()
+
+    assert status is None
+    mock_run.assert_not_called()
+
+
+def test_activate_extension_skips_without_gnome_cli():
+    """activate_extension is a no-op when the gnome-extensions CLI is absent."""
+    with patch.object(gnome_extension.shutil, "which", return_value=None):
+        assert gnome_extension.activate_extension() is None


### PR DESCRIPTION
This branch rounds out the GNOME extension's desktop integration with a Settings dialog, login-autostart support, and packaging for both system and pip/dev installs.

The extension now ships a `prefs.js` so the GNOME Extensions app's "Settings" button opens an in-process libadwaita preferences window: a switch to start EasySpeak on login (which writes/overrides `~/.config/autostart/easyspeak.desktop`) and an About dialog. A matching "Settings…" item is added to the tray popup (wired through `Extension.openPreferences()`), the stale "Deactivated" status line is dropped, and the reactivate item is relabelled "Reactivate EasySpeak". The pure autostart-entry text handling lives in `extension-helpers.js` so it stays unit-tested.

A new `easyspeak --configure [items]` / `--show [items]` CLI (backed by `core.desktop_integration`) sets up the per-user equivalents for non-packaged installs: the extension and refresh service are always configured, while the launcher and autostart entries are opt-in. `EasySpeak` is now imported lazily so these one-shot subcommands run without pulling in the audio stack.

On the packaging side, the Debian/RPM package gains a default `/etc/xdg/autostart` entry and installs the pre-shell extension-refresh systemd user unit (enabled for every user via a `gnome-session-pre.target.wants` symlink) so the extension is current at first login without launching EasySpeak; the per-user refresh generator stands down when a packaged system unit is present. The gate checks, lint targets, and tests are extended to cover `prefs.js`, the autostart file, and the new CLI/desktop-integration code paths.

Finally, `metadata.json` gains a `url` field so the GNOME Extensions app shows a Website link to the project page.