### PR TITLE
Add a tray icon and menu screenshot, reduce file sizes

### DIFF
--- a/docs/media/browser-link-hints.png
+++ b/docs/media/browser-link-hints.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ae43022edeacdfc879bd48ea667c4c7d5c489036d10a340ec2e6c91c1b116455
-size 143557
+oid sha256:f6d643d3788b618e48c918e9deb6f5a3320fbb46ea6d7847e164d2a3ea710b60
+size 47147

--- a/docs/media/daemon-startup.png
+++ b/docs/media/daemon-startup.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51d0e489f087cbad25c73f28ccbd1bf089b3abbff5637c14a7e7b0ca8a0d4f8c
-size 212591
+oid sha256:43ab8b41de812b6f6cfd1c736971f99f1f858d2e1db32107f45c7c14cd7789aa
+size 65274

--- a/docs/media/mouse-grid-browser.png
+++ b/docs/media/mouse-grid-browser.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ce8137a7aa04c309f3dffc61e6f40c1946dcf3e94d31076209c8aea17968c261
-size 157838
+oid sha256:e15ed39bf451fa6df2e7c00c51196bedaedd9ab463c028a80957b39ef4369039
+size 62589

--- a/docs/media/mouse-grid-files.png
+++ b/docs/media/mouse-grid-files.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15ed6251e017b615d5760ad8adf88dc3f23db285bf5fafd1f561203872e61441
-size 122063
+oid sha256:8cdacb4bfa312616b6a9d2b3b7c757fa87e2d0e8392a1992da02309799f8fe7b
+size 48654

--- a/docs/media/tray-menu.png
+++ b/docs/media/tray-menu.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81aff386d9361ce9d08bd01542776abfba1a173ed487dd3d012c9312c838d46
+size 3567

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -17,6 +17,17 @@ the daemon settles into **Listening for wake word…**.
 The `ALSA lib … unable to open slave` lines are harmless audio-device probing
 noise (surpressed in newer versions).
 
+## Tray menu
+
+![The EasySpeak tray menu open in the GNOME top bar, the panel icon showing a muted microphone; the menu lists "Reactivate EasySpeak" (hovered), "Settings…", "Help", "About EasySpeak", and "Quit EasySpeak"](media/tray-menu.png){ width="170" }
+
+Say, "stop listening", to make EasySpeak stop responding to your voice. The
+panel icon switches to a muted microphone to show it's asleep, and EasySpeak
+ignores everything until you wake it again from the tray. Click the icon and
+choose **Reactivate EasySpeak** to start listening once more. The same menu
+opens **Settings…**, **Help**, and the **About EasySpeak** dialog, or shuts the
+daemon down with **Quit EasySpeak**.
+
 ## Mouse grid
 
 ![A 3x3 numbered grid overlaying the GNOME Files window, with a red crosshair centred on cell 5](media/mouse-grid-files.png){ width="100%" }


### PR DESCRIPTION
Adds a screenshot of the recently extended tray icon menu to the documentation's Screenshots section.

Shrinks the file size of all screenshot image files, performed using TinyPNG.