### PR TITLE
Stop leaking dev-shell libraries into spawned desktop apps

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -129,7 +129,7 @@ Requires a webcam and additional dependencies — see [Installation](installatio
 
 Default apps live in [`plugins/apps.py`](https://github.com/ctsdownloads/easyspeak/blob/HEAD/src/plugins/apps.py)
 (edit to match your system): firefox, steam, spotify, calculator, settings,
-files, terminal, browser, music player, and more. Some accept spoken aliases —
+terminal, browser, music player, and more. Some accept spoken aliases —
 e.g. "open music app" works the same as "open music player".
 
 "Open terminal" and "close terminal" are special: they open and close your
@@ -137,8 +137,12 @@ system's default terminal, whichever one that is, rather than a fixed app.
 
 ## Files
 
+Folders open in whatever file manager your desktop is configured for (via
+`xdg-open`).
+
 | Command | Action |
 |---------|--------|
+| open files / file manager | Open your default file manager (at `$HOME`) |
 | open documents | Open Documents folder |
 | open downloads | Open Downloads folder |
 | open pictures | Open Pictures folder |

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -84,13 +84,30 @@ class EasySpeak:
 
     # --- Utilities for plugins ---
 
-    def host_run(self, cmd, background=False):
-        """Run a shell command."""
+    def host_run(self, cmd, background=False, clean_env=False):
+        """Run a shell command.
+
+        With clean_env, EasySpeak's injected LD_LIBRARY_PATH and GI_TYPELIB_PATH
+        are stripped from the child's environment. The dev flake prepends its own
+        libraries (glib among them) to those paths for EasySpeak's own
+        dependencies; left in place they leak into spawned desktop apps, which
+        then load EasySpeak's flake-pinned libraries instead of their own rpath
+        ones. A glib/GIO build mismatch there wedges GTK apps such as the file
+        manager. Pass clean_env=True when launching external GUI programs so they
+        run in the plain host environment.
+        """
+        env = None
+        if clean_env:
+            env = {
+                k: v
+                for k, v in os.environ.items()
+                if k not in ("LD_LIBRARY_PATH", "GI_TYPELIB_PATH")
+            }
         if background:
             return subprocess.Popen(
-                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env
             )
-        return subprocess.run(cmd, capture_output=True, text=True)
+        return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
     def speak(self, text):
         """Speak a phrase.

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -8,7 +8,7 @@ DESCRIPTION = "Launch and close applications"
 COMMANDS = [
     "open/launch [app] - open an application",
     "close [app] - close an application",
-    "Apps: browser, steam, spotify, files, calculator, settings, terminal",
+    "Apps: browser, steam, spotify, calculator, settings, terminal",
 ]
 
 # Flatpak apps
@@ -34,7 +34,6 @@ LOCAL_APPS = {
     "editor": "gnome-text-editor",
     "epiphany": "epiphany",
     "extensions": "gnome-extensions-app",
-    "files": "nautilus",
     "gimp": "gimp",
     "inkscape": "inkscape",
     "logs": "gnome-logs",

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -164,10 +164,10 @@ def launch_app(name, core):
     """Launch the named app (flatpak or local binary); False if not found."""
     app_type, app_id = find_app(name, core)
     if app_type == "flatpak":
-        core.host_run(["flatpak", "run", app_id], background=True)
+        core.host_run(["flatpak", "run", app_id], background=True, clean_env=True)
         return True
     if app_type == "local":
-        core.host_run([app_id], background=True)
+        core.host_run([app_id], background=True, clean_env=True)
         return True
     return False
 

--- a/src/plugins/files.py
+++ b/src/plugins/files.py
@@ -45,7 +45,7 @@ def open_folder(path, core):
     for fm, args in file_managers:
         result = core.host_run(["which", fm])
         if result.returncode == 0:
-            core.host_run([fm, *args], background=True)
+            core.host_run([fm, *args], background=True, clean_env=True)
             return True
     return False
 

--- a/src/plugins/files.py
+++ b/src/plugins/files.py
@@ -6,9 +6,13 @@ NAME = "files"
 DESCRIPTION = "Folder navigation"
 
 COMMANDS = [
-    "open [folder] - open folder in file manager",
+    "open [folder] - open a folder in your default file manager",
+    "open files / file manager - open your default file manager",
     "Folders: documents, downloads, pictures, music, videos, projects, home, desktop",
 ]
+
+OPEN_VERBS = ("open", "go to", "show", "browse")
+FILE_MANAGER_PHRASES = ("file manager", "file browser", "files")
 
 FOLDERS = {
     "documents": "~/Documents",
@@ -31,35 +35,40 @@ def setup(c):
 
 
 def open_folder(path, core):
-    """Open a folder in the first available file manager; False if none found."""
+    """Open a folder in the user's default file manager; False if unavailable.
+
+    Delegates to xdg-open so whichever file manager the desktop is configured
+    for is honoured, rather than hardcoding one. Launched with a clean
+    environment (see core.host_run) so it doesn't inherit EasySpeak's library
+    paths.
+    """
     expanded = os.path.expanduser(path)
-
-    file_managers = [
-        ("nautilus", [expanded]),
-        ("dolphin", [expanded]),
-        ("thunar", [expanded]),
-        ("nemo", [expanded]),
-        ("xdg-open", [expanded]),
-    ]
-
-    for fm, args in file_managers:
-        result = core.host_run(["which", fm])
-        if result.returncode == 0:
-            core.host_run([fm, *args], background=True, clean_env=True)
-            return True
-    return False
+    if core.host_run(["which", "xdg-open"]).returncode != 0:
+        return False
+    core.host_run(["xdg-open", expanded], background=True, clean_env=True)
+    return True
 
 
 def handle(cmd, core):
-    """Open a known folder when the command names one; return None otherwise."""
+    """Open a named folder, or the file manager itself; None if neither matched."""
+    if not any(verb in cmd for verb in OPEN_VERBS):
+        return None
+
     for folder, path in FOLDERS.items():
-        if folder in cmd and (
-            "open" in cmd or "go to" in cmd or "show" in cmd or "browse" in cmd
-        ):
-            if open_folder(path, core):
-                core.speak(f"Opening {folder}.")
-            else:
-                core.speak("No file manager found.")
+        if folder in cmd:
+            _open(path, folder, core)
             return True
 
+    if any(phrase in cmd for phrase in FILE_MANAGER_PHRASES):
+        _open("~", "files", core)
+        return True
+
     return None  # Not handled
+
+
+def _open(path, label, core):
+    """Open path in the file manager and announce it, or report none is found."""
+    if open_folder(path, core):
+        core.speak(f"Opening {label}.")
+    else:
+        core.speak("No file manager found.")

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -38,9 +38,30 @@ class TestEasySpeakUtilities:
         result = easy.host_run(["echo", "test"], background=False)
 
         mock_run.assert_called_once_with(
-            ["echo", "test"], capture_output=True, text=True
+            ["echo", "test"], capture_output=True, text=True, env=None
         )
         assert result == mock_result
+
+    @patch.dict(
+        "os.environ",
+        {
+            "LD_LIBRARY_PATH": "/flake/lib",
+            "GI_TYPELIB_PATH": "/flake/gi",
+            "PATH": "/bin",
+        },
+        clear=True,
+    )
+    @patch("subprocess.Popen")
+    def test_host_run_clean_env_strips_injected_paths(self, mock_popen):
+        """clean_env drops EasySpeak's library paths so child apps use their own."""
+        easy = EasySpeak()
+
+        easy.host_run(["nautilus"], background=True, clean_env=True)
+
+        env = mock_popen.call_args[1]["env"]
+        assert "LD_LIBRARY_PATH" not in env
+        assert "GI_TYPELIB_PATH" not in env
+        assert env["PATH"] == "/bin"
 
     @patch("subprocess.Popen")
     def test_host_run_background(self, mock_popen):

--- a/tests/unit/plugins/test_apps.py
+++ b/tests/unit/plugins/test_apps.py
@@ -108,7 +108,10 @@ def test_launch_app_flatpak(mock_find_app, mock_core):
     assert mock_core.host_run.call_args.args == (
         ["flatpak", "run", "org.mozilla.firefox"],
     )
-    assert mock_core.host_run.call_args.kwargs == {"background": True}
+    assert mock_core.host_run.call_args.kwargs == {
+        "background": True,
+        "clean_env": True,
+    }
 
 
 @patch("easyspeak.plugins.apps.find_app", return_value=("local", "nautilus"))
@@ -121,7 +124,10 @@ def test_launch_app_local(mock_find_app, mock_core):
     assert result is True
     assert mock_find_app.call_args.args == (app_name, mock_core)
     assert mock_core.host_run.call_args.args == (["nautilus"],)
-    assert mock_core.host_run.call_args.kwargs == {"background": True}
+    assert mock_core.host_run.call_args.kwargs == {
+        "background": True,
+        "clean_env": True,
+    }
 
 
 @patch("easyspeak.plugins.apps.find_app", return_value=(None, None))
@@ -417,7 +423,10 @@ def test_launch_registered_terminal(mock_core):
 
     assert result is True
     assert mock_core.host_run.call_args.args == (["ghostty"],)
-    assert mock_core.host_run.call_args.kwargs == {"background": True}
+    assert mock_core.host_run.call_args.kwargs == {
+        "background": True,
+        "clean_env": True,
+    }
 
 
 def test_close_registered_terminal(mock_core):

--- a/tests/unit/plugins/test_apps.py
+++ b/tests/unit/plugins/test_apps.py
@@ -60,7 +60,7 @@ def test_find_app_flatpak_not_installed(mock_core_failure, app_name):
 @pytest.mark.parametrize(
     ["app_name", "binary_name"],
     [
-        ["files", "nautilus"],
+        ["nautilus", "nautilus"],
         ["browser", "qutebrowser"],
     ],
 )
@@ -117,7 +117,7 @@ def test_launch_app_flatpak(mock_find_app, mock_core):
 @patch("easyspeak.plugins.apps.find_app", return_value=("local", "nautilus"))
 def test_launch_app_local(mock_find_app, mock_core):
     """When local app is launched, then it runs directly."""
-    app_name = "files"
+    app_name = "nautilus"
 
     result = apps.launch_app(app_name, mock_core)
 
@@ -446,7 +446,6 @@ def test_close_registered_terminal(mock_core):
         ["open firefox", "firefox"],
         ["launch steam", "steam"],
         ["open spotify", "spotify"],
-        ["launch files", "files"],
         ["open calculator", "calculator"],
         ["open music player", "music player"],
         ["open music app", "music app"],
@@ -485,7 +484,6 @@ def test_handle_open_not_installed_app(mock_launch_app, mock_core, command, app_
         ["close firefox", "firefox"],
         ["close steam", "steam"],
         ["close spotify", "spotify"],
-        ["close files", "files"],
     ],
 )
 def test_handle_close_app(mock_close_app, mock_core, command, app_name):

--- a/tests/unit/plugins/test_files.py
+++ b/tests/unit/plugins/test_files.py
@@ -24,38 +24,20 @@ def test_open_folder_expands_path(mock_expanduser, mock_core):
     assert mock_expanduser.call_args.args == ("~/Documents",)
 
 
-@pytest.mark.parametrize(
-    ["file_manager", "expected_args"],
-    [
-        ("nautilus", ["/home/user/Documents"]),
-        ("dolphin", ["/home/user/Documents"]),
-        ("thunar", ["/home/user/Documents"]),
-        ("nemo", ["/home/user/Documents"]),
-        ("xdg-open", ["/home/user/Documents"]),
-    ],
-)
 @patch(
     "easyspeak.plugins.files.os.path.expanduser", return_value="/home/user/Documents"
 )
-def test_open_folder_tries_file_managers(
-    mock_expanduser, file_manager, expected_args, mock_core_which_finds_file_manager
-):
-    """When a file manager is available then open_folder uses it to open the folder."""
-    core = mock_core_which_finds_file_manager(file_manager)
+def test_open_folder_uses_xdg_open(mock_expanduser, mock_core_which_finds_file_manager):
+    """When xdg-open is available then open_folder launches it with a clean env."""
+    core = mock_core_which_finds_file_manager("xdg-open")
 
     result = files.open_folder("~/Documents", core)
 
     assert result is True
-    found_call = False
-    for call in core.host_run.call_args_list:
-        cmd_args = call.args[0]
-        if cmd_args[0] == file_manager:
-            found_call = True
-            assert cmd_args == [file_manager, *expected_args]
-            assert call.kwargs["background"] is True
-            assert call.kwargs["clean_env"] is True
-            break
-    assert found_call
+    launch = core.host_run.call_args_list[-1]
+    assert launch.args[0] == ["xdg-open", "/home/user/Documents"]
+    assert launch.kwargs["background"] is True
+    assert launch.kwargs["clean_env"] is True
 
 
 @patch(
@@ -95,6 +77,24 @@ def test_handle_open_command_with_folders(
     assert mock_open_folder.call_args.args == (files.FOLDERS[folder_name], mock_core)
     assert mock_core.speak.call_count == 1
     assert mock_core.speak.call_args.args == (expected_message,)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "open files",
+        "open file manager",
+        "show file browser",
+    ],
+)
+@patch("easyspeak.plugins.files.open_folder", return_value=True)
+def test_handle_opens_default_file_manager(mock_open_folder, command, mock_core):
+    """When asked for the file manager then handle opens it at home and speaks."""
+    result = files.handle(command, mock_core)
+
+    assert result is True
+    assert mock_open_folder.call_args.args == ("~", mock_core)
+    assert mock_core.speak.call_args.args == ("Opening files.",)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/plugins/test_files.py
+++ b/tests/unit/plugins/test_files.py
@@ -53,6 +53,7 @@ def test_open_folder_tries_file_managers(
             found_call = True
             assert cmd_args == [file_manager, *expected_args]
             assert call.kwargs["background"] is True
+            assert call.kwargs["clean_env"] is True
             break
     assert found_call
 


### PR DESCRIPTION
EasySpeak runs from a dev flake that prepends its own libraries, glib among them, onto `LD_LIBRARY_PATH` and `GI_TYPELIB_PATH` so its own dependencies resolve. Those variables were inherited by every program EasySpeak launched, so a spawned desktop app loaded EasySpeak's flake-pinned libraries instead of its own rpath ones. Once the pinned glib build diverged from the host's after a system upgrade, opening the file manager through the assistant ("open downloads", "open files") wedged for 25 seconds on a Tracker registration timeout and never showed a window.

We fix that by giving `host_run` a `clean_env` option that strips those two variables, and the application and folder launches pass it so desktop apps run in the plain host environment. Folder opening and "open files" also move to `xdg-open`, honouring the configured default file manager rather than hardcoding nautilus.

The `flake.lock` bump to the host's current nixpkgs revision realigns the pinned glib as an immediate mitigation; the clean-env change is what keeps a future drift from breaking launched apps again.

Generalizes the file-manager commands to honor the desktop's configured default file manager instead of hardcoding GNOME Files. Folder opening (`open documents`, `open downloads`, `open videos`, …) now delegates to `xdg-open` rather than probing a fixed preference list (nautilus, dolphin, thunar, nemo), and the `open files` / `file manager` phrases open the default file manager at `$HOME`. The hardcoded `files` → nautilus mapping is dropped from the apps plugin, while `open nautilus` still launches nautilus explicitly by name, and the command reference in `docs/commands.md` is updated to match.