### PR TITLE
Use the newly acquired easyspeak.dev domain everywhere

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ Contributions welcome — please open an issue first to discuss bigger plans.
 See the docs for the [full contributing guide][docs]. It explains development
 setup, packaging, and the release process.
 
-[docs]: https://ctsdownloads.github.io/easyspeak/contributing/
+[docs]: https://easyspeak.dev/contributing/

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
 Say "Hey Jarvis" and control your desktop with your voice.
 
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg)](https://github.com/ctsdownloads/easyspeak/blob/main/LICENSE)
-[![Platform](https://img.shields.io/badge/platform-Linux-lightgrey.svg)](https://ctsdownloads.github.io/easyspeak/installation/)
-[![Desktop](https://img.shields.io/badge/desktop-GNOME%20%7C%20Wayland-green.svg)](https://ctsdownloads.github.io/easyspeak/how-it-works/)
+[![Platform](https://img.shields.io/badge/platform-Linux-lightgrey.svg)](https://easyspeak.dev/installation/)
+[![Desktop](https://img.shields.io/badge/desktop-GNOME%20%7C%20Wayland-green.svg)](https://easyspeak.dev/how-it-works/)
 [![Status](https://img.shields.io/badge/status-Alpha-orange.svg)](https://github.com/ctsdownloads/easyspeak/releases)
 [![Pipeline](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml)
 [![Safety](https://github.com/ctsdownloads/easyspeak/actions/workflows/safety.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/safety.yml)
 [![Release](https://github.com/ctsdownloads/easyspeak/actions/workflows/release.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/release.yml)
 [![Benchmarks](https://img.shields.io/badge/%F0%9F%90%B0%20Bencher-performance-FD7E14.svg)](https://bencher.dev/perf/easyspeak)
-[![Docs](https://github.com/ctsdownloads/easyspeak/actions/workflows/docs.yml/badge.svg)](https://ctsdownloads.github.io/easyspeak/)
+[![Docs](https://github.com/ctsdownloads/easyspeak/actions/workflows/docs.yml/badge.svg)](https://easyspeak.dev/)
 
 > ⚠️ **Early development.** This project works but is not polished. Expect bugs, incomplete docs, and changes without notice.
 
@@ -47,28 +47,29 @@ cd ~/easyspeak
 uv run easyspeak
 ```
 
-You also need [Piper TTS](https://ctsdownloads.github.io/easyspeak/installation/#3-piper-tts) installed for voice feedback. See the **[Installation guide](https://ctsdownloads.github.io/easyspeak/installation/)** for the venv-based path, head tracking, and full details.
+You also need [Piper TTS](https://easyspeak.dev/installation/#3-piper-tts) installed for voice feedback.
+See the **[Installation guide](https://easyspeak.dev/installation/)** for the venv-based path, head tracking, and full details.
 
 Prefer prebuilt packages? Grab the `easyspeak` app `.deb`/`.rpm` **plus a language
 pack** (e.g. `easyspeak-lang-en`) from the
 [Releases page](https://github.com/ctsdownloads/easyspeak/releases) and install them
 together — a self-contained, offline install (Python runtime, `piper`, GNOME
 extension, and speech models). See the
-**[Packaging guide](https://ctsdownloads.github.io/easyspeak/packaging/)**.
+**[Packaging guide](https://easyspeak.dev/packaging/)**.
 
 Then say "Hey Jarvis" followed by a command. Say "help" to list all commands.
 
 ## Documentation
 
-- **[Installation](https://ctsdownloads.github.io/easyspeak/installation/)** — system packages, Python, Piper TTS
-- **[Usage](https://ctsdownloads.github.io/easyspeak/usage/)** — running the daemon, CLI flags, configuration
-- **[Commands](https://ctsdownloads.github.io/easyspeak/commands/)** — the full command reference
-- **[Writing plugins](https://ctsdownloads.github.io/easyspeak/plugins/)** — extend EasySpeak with a Python file
-- **[Troubleshooting](https://ctsdownloads.github.io/easyspeak/troubleshooting/)** — common problems and fixes
-- **[How it works](https://ctsdownloads.github.io/easyspeak/how-it-works/)** — the architecture
-- **[API reference](https://ctsdownloads.github.io/easyspeak/reference/core/)** — generated from the source docstrings
-- **[Contributing](https://ctsdownloads.github.io/easyspeak/contributing/)** — how to set up a dev environment and submit changes
-- **[License](https://ctsdownloads.github.io/easyspeak/license/)** — GPL-3.0
+- **[Installation](https://easyspeak.dev/installation/)** — system packages, Python, Piper TTS
+- **[Usage](https://easyspeak.dev/usage/)** — running the daemon, CLI flags, configuration
+- **[Commands](https://easyspeak.dev/commands/)** — the full command reference
+- **[Writing plugins](https://easyspeak.dev/plugins/)** — extend EasySpeak with a Python file
+- **[Troubleshooting](https://easyspeak.dev/troubleshooting/)** — common problems and fixes
+- **[How it works](https://easyspeak.dev/how-it-works/)** — the architecture
+- **[API reference](https://easyspeak.dev/reference/core/)** — generated from the source docstrings
+- **[Contributing](https://easyspeak.dev/contributing/)** — how to set up a dev environment and submit changes
+- **[License](https://easyspeak.dev/license/)** — GPL-3.0
 
 ## Acknowledgments
 

--- a/justfile
+++ b/justfile
@@ -118,10 +118,11 @@ check-links *args: docs
     mkdir -p build/linkcheck
     uvx --from markdown markdown_py README.md > build/linkcheck/readme.html
     uvx --from markdown markdown_py CONTRIBUTING.md > build/linkcheck/contributing.html
-    # Ignore material's Pages-only 404-page links and bencher.dev (403s every bot);
-    # the non-default user-agent dodges freedesktop's WAF (418 to "Mozilla").
+    # Skip the 404 page (material renders its links absolute from site_url, so they
+    # 404 on the filesystem) and bencher.dev (403s every bot); the non-default
+    # user-agent dodges freedesktop's WAF (418 to "Mozilla").
     uvx linkchecker --check-extern --no-warnings \
-        --ignore-url '^file:///easyspeak/' \
+        --ignore-url '/404\.html' \
         --ignore-url 'bencher\.dev' \
         --user-agent LinkChecker {{ args }} \
         site/index.html build/linkcheck/readme.html build/linkcheck/contributing.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: Voice control for Linux desktops. Fully local, no cloud, Wayla
 # path, while the latest docs are published to the site root for clean,
 # version-less URLs. Point site_url (canonical links, sitemap) at that root, so
 # the archived snapshots' canonical URLs reference the latest version.
-site_url: https://ctsdownloads.github.io/easyspeak/
+site_url: https://easyspeak.dev/
 repo_url: https://github.com/ctsdownloads/easyspeak
 repo_name: ctsdownloads/easyspeak
 copyright: Copyright &copy; EasySpeak contributors — GPL-3.0

--- a/src/core/about.py
+++ b/src/core/about.py
@@ -21,7 +21,7 @@ COMMENTS = "Voice control for Linux desktops. Fully local, no cloud, Wayland-nat
 COPYRIGHT = "© Matt Hartley and the EasySpeak contributors"
 
 REPO_URL = "https://github.com/ctsdownloads/easyspeak"
-DOCS_URL = "https://ctsdownloads.github.io/easyspeak/"
+DOCS_URL = "https://easyspeak.dev/"
 ISSUES_URL = "https://github.com/ctsdownloads/easyspeak/issues"
 DISCUSSIONS_URL = "https://github.com/ctsdownloads/easyspeak/discussions"
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "EasySpeak",
   "description": "Voice control for Linux — panel indicator and on-screen surfaces.",
-  "url": "https://ctsdownloads.github.io/easyspeak/",
+  "url": "https://easyspeak.dev/",
   "uuid": "easyspeak@local",
   "shell-version": ["47", "48", "49", "50"],
   "settings-schema": "org.gnome.shell.extensions.easyspeak",

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -26,7 +26,7 @@ const ABOUT = {
     developer_name: 'Matt Hartley',
     comments:
         'Voice control for Linux desktops. Fully local, no cloud, Wayland-native.',
-    website: 'https://ctsdownloads.github.io/easyspeak/',
+    website: 'https://easyspeak.dev/',
     issue_url: 'https://github.com/ctsdownloads/easyspeak/issues',
     copyright: '© Matt Hartley and the EasySpeak contributors',
 };


### PR DESCRIPTION
Thanks, Matt, for buying the [easyspeak.dev](https://easyspeak.dev/) domain! :moneybag: 

We can now update all related references in the EasySpeak application and the documentation website. :rocket: 