### PR TITLE
docs: Show the tray menu and Quick Settings side by side

### DIFF
--- a/docs/media/extension-settings.png
+++ b/docs/media/extension-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfea3082aa3c298a5dcbc9139c1a2d529ad0ae8f55fca3e2dfad81b9c83829fa
+size 8363

--- a/docs/media/quick-settings.png
+++ b/docs/media/quick-settings.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9da69a7aea8a93f73c30d56aa8085dccdca6aed6d62e6086d2901ac1fb6be6
+size 12627

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -9,28 +9,49 @@ browser entirely by voice.
 ![EasySpeak starting in a terminal: OpenWakeWord and Whisper load, each plugin reports "Loaded", and the daemon begins listening for the wake word](media/daemon-startup.png){ width="100%" }
 
 An earlier version of EasySpeak running from a terminal. On start it loads the
-wake-word model (OpenWakeWord) and the speech recogniser (Whisper), then brings
+wake-word model (OpenWakeWord) and the speech recognizer (Whisper), then brings
 up each plugin in turn — head tracking, mouse grid, apps, browser, dictation,
 files, media, and system. The banner confirms the wake word ("Hey Jarvis") and
 the daemon settles into **Listening for wake word…**.
 
 The `ALSA lib … unable to open slave` lines are harmless audio-device probing
-noise (surpressed in newer versions).
+noise (suppressed in newer versions).
 
-## Tray menu
+## Tray menu and Quick Settings
 
-![The EasySpeak tray menu open in the GNOME top bar, the panel icon showing a muted microphone; the menu lists "Reactivate EasySpeak" (hovered), "Settings…", "Help", "About EasySpeak", and "Quit EasySpeak"](media/tray-menu.png){ width="170" }
+EasySpeak lives in the GNOME top bar, ready whenever you want to mute it, wake
+it, or reach its settings. It shows up either as a panel tray icon or as a
+[Quick Settings](https://help.gnome.org/gnome-help/quick-settings.html) toggle —
+a single switch in its extension settings decides which.
+
+<div markdown style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start; justify-content: center;">
+
+![The EasySpeak tray menu open in the GNOME top bar, the panel icon showing a muted microphone; the menu lists "Reactivate EasySpeak" (hovered), "Settings…", "Help", "About EasySpeak", and "Quit EasySpeak"](media/tray-menu.png){ width="124" }
+
+![The GNOME Quick Settings menu with an active-microphone EasySpeak toggle expanded into its sub-menu: an "EasySpeak" heading, a "Help" entry, and "EasySpeak Settings" (hovered)](media/quick-settings.png){ width="206" }
+
+![EasySpeak's extension settings — a "Configure EasySpeak" panel with two toggles, "Start EasySpeak on login" and "Show EasySpeak in Quick Settings Menu", both on, above an "About EasySpeak" row](media/extension-settings.png){ width="344" }
+
+</div>
 
 Say, "stop listening", to make EasySpeak stop responding to your voice. The
-panel icon switches to a muted microphone to show it's asleep, and EasySpeak
-ignores everything until you wake it again from the tray. Click the icon and
-choose **Reactivate EasySpeak** to start listening once more. The same menu
-opens **Settings…**, **Help**, and the **About EasySpeak** dialog, or shuts the
-daemon down with **Quit EasySpeak**.
+panel icon (left) switches to a muted microphone to show it's asleep, and
+EasySpeak ignores everything until you wake it again. Click the icon and choose
+**Reactivate EasySpeak** to start listening once more; the same menu opens
+**Settings…**, **Help**, and the **About EasySpeak** dialog, or shuts the daemon
+down with **Quit EasySpeak**.
+
+Prefer to keep the top bar tidy? Turn on **Show EasySpeak in Quick Settings
+Menu** in the extension settings (right) and EasySpeak moves into GNOME's Quick
+Settings as a toggle (center) instead of the panel icon. Expanding the toggle
+reveals the same **Help** and **EasySpeak Settings** actions, so either entry
+point reaches the very same extension settings — the panel GNOME's Extensions
+app exposes for EasySpeak, which also makes it **start on login** and opens
+**About EasySpeak**.
 
 ## Mouse grid
 
-![A 3x3 numbered grid overlaying the GNOME Files window, with a red crosshair centred on cell 5](media/mouse-grid-files.png){ width="100%" }
+![A 3x3 numbered grid overlaying the GNOME Files window, with a red crosshair centered on cell 5](media/mouse-grid-files.png){ width="100%" }
 
 The **mouse grid** (["grid" command](commands.md#mouse-grid)) overlays a
 numbered 3×3 grid on the whole screen. Saying a digit zooms the grid into

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ warn_unused_ignores = true
 plugins.md013.enabled = false  # line-length
 plugins.md024.enabled = false  # no-duplicate-heading
 plugins.md032.enabled = false  # blanks-around-lists
+plugins.md033.allowed_elements = "!--,div"  # inline-html (allow the Material grid wrapper)
 plugins.md036.enabled = false  # no-emphasis-as-heading
 plugins.md040.enabled = false  # fenced-code-language
 plugins.md041.enabled = false  # first-line-heading


### PR DESCRIPTION
Adds screenshots for the extension Settings and the [Quick Settings menu](https://help.gnome.org/gnome-help/quick-settings.html) added with 8dde944.

Combines the panel tray menu, the GNOME Quick Settings toggle, and the extension settings into a single row in the Screenshots chapter, with prose explaining how they play together: EasySpeak appears either as a tray icon or a Quick Settings toggle, a switch in the extension settings decides which, and both routes reach the same Help, Settings, and About actions. Links "Quick Settings" to the GNOME help site, and refers to the "Configure EasySpeak" dialog as the extension settings, since that is how the GNOME Extensions app integrates them.

Lays the three captures out in a flex row scaled to a common ~0.55x zoom so they appear the same size and fit on one line on a regular screen, wrapping on narrow ones. Allows the inline `div` wrapper through pymarkdown's inline-HTML rule, and corrects the chapter's stray British spellings (and a "surpressed" typo) to US English.