### PR TITLE
Group the distro package checks; rename "native" → "distro"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Build .deb and .rpm
-      # Reuses the same containerised build as `just package-native`, so local
+      # Reuses the same containerised build as `just package-distro`, so local
       # and CI builds are byte-for-byte the same path. Strips a leading "v".
       run: |
         tag='${{ github.event.release.tag_name }}'

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,6 +1,6 @@
 # Packaging
 
-EasySpeak ships **native `.deb` and `.rpm` packages**, split into two:
+EasySpeak ships **distro `.deb` and `.rpm` packages**, split into two:
 
 - **`easyspeak`** (amd64) — the application: a self-contained Python runtime
   (standalone CPython + all wheels, including the `piper` engine and the
@@ -17,7 +17,7 @@ without re-downloading the runtime. See [Language](#language).
 
 > EasySpeak integrates deeply with the host (raw input devices, the AT-SPI bus,
 > session D-Bus, a GNOME Shell extension, and spawning host binaries). That is why
-> the supported formats are **unconfined native packages** — sandboxed formats
+> the supported formats are **unconfined distro packages** — sandboxed formats
 > (Flatpak/Snap) fight every one of those integration points.
 
 ## Install
@@ -86,8 +86,8 @@ whether produced locally or in CI — handy on NixOS, where the bundle's standal
 CPython and manylinux wheels can't run on the host:
 
 ```bash
-just package-native            # -> ./dist/ : app + language .deb and .rpm
-just package-native 1.2.3      # set an explicit version
+just package-distro            # -> ./dist/ : app + language .deb and .rpm
+just package-distro 1.2.3      # set an explicit version
 ```
 
 This produces the `easyspeak` app packages and every `easyspeak-lang-*` data

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@
 
 # Run codestyle and safety checks, tests, packaging, docs, and cleanup
 [group('lifecycle')]
-all: codestyle safety test check-docs check-desktop-integration compile-schemas check-python-packages check-native-packages clean
+all: codestyle safety test check-docs check-desktop-integration compile-schemas check-python-packages check-distro-packages clean
 
 # Remove build artifacts and reports (use -v for verbose, -n for dry-run)
 [group('lifecycle')]
@@ -151,17 +151,17 @@ docs-publish *args:
 
 # Build the Debian package and verify its contents
 [group('release')]
-check-deb-package: (package-native)
+check-deb-package: (package-distro)
     bash tests/packaging/test_deb.sh
 
 # Build the RedHat package and verify its contents
 [group('release')]
-check-rpm-package: (package-native)
+check-rpm-package: (package-distro)
     bash tests/packaging/test_rpm.sh
 
-# Build the native packages once (just dedupes package-native), check deb and rpm
+# Build the distro packages once (just dedupes package-distro), check deb and rpm
 [group('release')]
-check-native-packages: check-deb-package check-rpm-package
+check-distro-packages: check-deb-package check-rpm-package
 
 # Build the wheel and sdist, then verify their contents
 [group('release')]
@@ -215,5 +215,5 @@ stage-lang code:
 
 # Build .deb and .rpm locally in a clean ubuntu container -> ./dist
 [group('packaging')]
-package-native version='0.0.0':
+package-distro version='0.0.0':
     bash packaging/build-in-docker.sh {{ version }}

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@
 
 # Run codestyle and safety checks, tests, packaging, docs, and cleanup
 [group('lifecycle')]
-all: codestyle safety test check-docs check-desktop-integration compile-schemas check-python-packages check-deb-package check-rpm-package clean
+all: codestyle safety test check-docs check-desktop-integration compile-schemas check-python-packages check-native-packages clean
 
 # Remove build artifacts and reports (use -v for verbose, -n for dry-run)
 [group('lifecycle')]
@@ -55,7 +55,7 @@ audit *args:
 # Check project dependencies are up-to-date (uv.lock)
 [group('safety')]
 requirements:
-    uv lock --upgrade
+    uvx uv lock --upgrade
     git diff --color --exit-code uv.lock
 
 # Run test suite and show coverage (unit tests, integration, acceptance)
@@ -158,6 +158,10 @@ check-deb-package: (package-native)
 [group('release')]
 check-rpm-package: (package-native)
     bash tests/packaging/test_rpm.sh
+
+# Build the native packages once (just dedupes package-native), check deb and rpm
+[group('release')]
+check-native-packages: check-deb-package check-rpm-package
 
 # Build the wheel and sdist, then verify their contents
 [group('release')]

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -4,7 +4,7 @@
 # `easyspeak-lang-*` packages (see packaging/stage-lang.sh).
 #
 # Runs in a clean glibc build environment (CI ubuntu-latest, or a container — see
-# `just package-native`), NOT on the host directly. It materialises a standalone
+# `just package-distro`), NOT on the host directly. It materialises a standalone
 # CPython + venv at PREFIX; PREFIX must equal the final install path so the venv's
 # absolute paths (shebangs, interpreter symlinks) stay valid on the target machine.
 set -euo pipefail


### PR DESCRIPTION
Build-tooling housekeeping, split out of #101.

**Group the checks behind one build** — adds a `check-distro-packages` recipe depending on `check-deb-package` and `check-rpm-package`; `just` dedupes the shared build so the container stages once and then verifies both the deb and the rpm. `all` uses it.

**Rename `native` → `distro`** — `package-native` → `package-distro`, `check-native-packages` → `check-distro-packages`, with the docs prose and CI/script comments following. "Native" was ambiguous (native arch? native-to-a-language?); these are specifically the distribution formats the system package manager installs, as opposed to the language-level Python wheel/sdist. `CHANGELOG.md` keeps the old wording as a historical record.