### PR TITLE
Make desktop sounds configurable, document env vars

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,10 +78,8 @@
           portaudio
         ];
 
-        # FHS-style sounds directory baked into the source (wake chime in
-        # core.main, error chime in core.tray); doesn't exist on NixOS, so we
-        # sed-replace it with the Nix store one during the sync step.
-        soundsFhsDir = "/usr/share/sounds/freedesktop/stereo";
+        # The chime/error-bell default to the FHS sounds dir, absent on NixOS;
+        # EASYSPEAK_SOUNDS_DIR (commonEnv) redirects to the Nix store one.
         soundsNixDir = "${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo";
 
         # Piper voice model (Amy, US English) — fetched at build time so the
@@ -106,6 +104,26 @@
         ];
         piperModelPath = "${piperVoice}/en_US-amy-medium.onnx";
 
+        # Env shared by the `nix run` wrapper and the dev shell, so `uv run
+        # easyspeak` behaves identically in both; `:-`/`:+` defaulting lets a
+        # value the user already exported win. SETUPTOOLS_SCM matters only when
+        # .git is missing (e.g. a tarball checkout); the pyaudio build flags
+        # compile it against the Nix-store portaudio (CPPFLAGS/LDFLAGS feed
+        # distutils, C_INCLUDE_PATH/LIBRARY_PATH feed gcc).
+        commonEnv = ''
+          export UV_PYTHON='${python}/bin/python'
+          export EASYSPEAK_PIPER_MODEL="''${EASYSPEAK_PIPER_MODEL:-${piperModelPath}}"
+          export EASYSPEAK_SOUNDS_DIR="''${EASYSPEAK_SOUNDS_DIR:-${soundsNixDir}}"
+          export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX="''${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX:-${pretendVersion}}"
+          export CPPFLAGS="-I${pkgs.portaudio}/include ''${CPPFLAGS:-}"
+          export LDFLAGS="-L${pkgs.portaudio}/lib -Wl,-rpath,${pkgs.portaudio}/lib ''${LDFLAGS:-}"
+          export C_INCLUDE_PATH="${pkgs.portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+          export LIBRARY_PATH="${pkgs.portaudio}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+          export LD_LIBRARY_PATH='${pkgs.lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
+          export EASYSPEAK_ATSPI_PYTHON='${atspiPython}/bin/python3'
+          export GI_TYPELIB_PATH='${giTypelibPath}'":''${GI_TYPELIB_PATH:-}"
+        '';
+
         easyspeak = pkgs.writeShellApplication {
           name = "easyspeak";
           runtimeInputs = [
@@ -129,30 +147,12 @@
             if [ ! -f "$stamp" ] || [ "$(cat "$stamp" 2>/dev/null || true)" != "${./.}" ]; then
               rm -rf "$src_dir"
               cp -r --no-preserve=mode,ownership "${./.}" "$src_dir"
-              sed -i 's|${soundsFhsDir}|${soundsNixDir}|g' \
-                "$src_dir/src/core/main.py" "$src_dir/src/core/tray.py"
               echo "${./.}" > "$stamp"
             fi
 
-            export UV_PYTHON='${python}/bin/python'
             export UV_CACHE_DIR="''${XDG_CACHE_HOME:-$HOME/.cache}/easyspeak/uv"
             export UV_PROJECT_ENVIRONMENT="$state_dir/venv"
-            export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX='${pretendVersion}'
-            export EASYSPEAK_PIPER_MODEL='${piperModelPath}'
-            # pyaudio's setup.py hard-codes /usr/include and won't find
-            # headers from the Nix store. CPPFLAGS/LDFLAGS are picked up by
-            # distutils; C_INCLUDE_PATH/LIBRARY_PATH are read by gcc itself,
-            # bypassing any Nix cc-wrapper variable-name quirks.
-            export CPPFLAGS="-I${pkgs.portaudio}/include ''${CPPFLAGS:-}"
-            export LDFLAGS="-L${pkgs.portaudio}/lib -Wl,-rpath,${pkgs.portaudio}/lib ''${LDFLAGS:-}"
-            export C_INCLUDE_PATH="${pkgs.portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
-            export LIBRARY_PATH="${pkgs.portaudio}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
-            export LD_LIBRARY_PATH='${pkgs.lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
-            # Dictation's AT-SPI helper runs in this PyGObject-equipped
-            # interpreter, with the typelibs it imports on GI_TYPELIB_PATH.
-            export EASYSPEAK_ATSPI_PYTHON='${atspiPython}/bin/python3'
-            export GI_TYPELIB_PATH='${giTypelibPath}'":''${GI_TYPELIB_PATH:-}"
-
+            ${commonEnv}
             cd "$src_dir"
             exec uv run easyspeak "$@"
           '';
@@ -194,18 +194,7 @@
             # tagged with the wrong ABI. Strip both to keep uv pure.
             unset PYTHONPATH PYTHONHOME
 
-            export LD_LIBRARY_PATH='${pkgs.lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
-            export EASYSPEAK_ATSPI_PYTHON='${atspiPython}/bin/python3'
-            export GI_TYPELIB_PATH='${giTypelibPath}'":''${GI_TYPELIB_PATH:-}"
-            export CPPFLAGS="-I${pkgs.portaudio}/include ''${CPPFLAGS:-}"
-            export LDFLAGS="-L${pkgs.portaudio}/lib -Wl,-rpath,${pkgs.portaudio}/lib ''${LDFLAGS:-}"
-            export C_INCLUDE_PATH="${pkgs.portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
-            export LIBRARY_PATH="${pkgs.portaudio}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
-            export UV_PYTHON='${python}/bin/python'
-            export EASYSPEAK_PIPER_MODEL="''${EASYSPEAK_PIPER_MODEL:-${piperModelPath}}"
-            # Only used when .git is missing (e.g. tarball checkout); a real
-            # git tree lets setuptools_scm derive the proper version.
-            export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX="''${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX:-${pretendVersion}}"
+            ${commonEnv}
             echo "EasySpeak dev shell — Python $(python --version 2>&1 | awk '{print $2}'), uv $(uv --version | awk '{print $2}')"
             echo "Run:  uv run [--extra head-tracking] easyspeak"
             echo "      just --list"

--- a/flake.nix
+++ b/flake.nix
@@ -19,24 +19,20 @@
 
         python = pkgs.python314;
 
-        # The dictation plugin shells out to an AT-SPI helper that needs
-        # PyGObject + the AT-SPI typelib — which uv can't put in the app's
-        # venv (PyGObject isn't a wheel). So ship a dedicated interpreter that
-        # has it and point EASYSPEAK_ATSPI_PYTHON at it.
+        # Dedicated interpreter for dictation's AT-SPI helper: it needs PyGObject
+        # + the AT-SPI typelib, which uv can't put in a wheel venv (EASYSPEAK_ATSPI_PYTHON).
         atspiPython = python.withPackages (ps: [ ps.pygobject3 ]);
 
-        # Typelibs the helper's `gi` imports resolve at runtime: GLib/GObject/
-        # Gio from glib, GIRepository from gobject-introspection, Atspi from
-        # at-spi2-core.
-        giTypelibPath = pkgs.lib.makeSearchPath "lib/girepository-1.0" [
-          pkgs.glib
-          pkgs.gobject-introspection
-          pkgs.at-spi2-core
+        # Typelibs the helper's `gi` imports resolve at runtime (GLib/GObject/Gio,
+        # GIRepository, Atspi).
+        giTypelibPath = with pkgs; lib.makeSearchPath "lib/girepository-1.0" [
+          glib
+          gobject-introspection
+          at-spi2-core
         ];
 
-        # .git is stripped from the flake source, so setuptools_scm can't
-        # infer a version. Derive a PEP 440 "local version" from whatever
-        # the flake knows (clean rev > dirty rev > nothing).
+        # .git is stripped from the flake source, so derive a PEP 440 "local
+        # version" for setuptools_scm (clean rev > dirty rev > nothing).
         pretendVersion =
           if self ? rev then
             "0.0.0+g${builtins.substring 0 8 self.rev}"
@@ -45,11 +41,9 @@
           else
             "0.0.0+nix";
 
-        # Shared libraries that Python wheels dlopen at runtime.
-        # NOTE: nix-ld (programs.nix-ld) does NOT cover these — it only injects
-        # NIX_LD_LIBRARY_PATH for foreign executables that run through its loader
-        # stub. These wheels are dlopen'd by a Nix-store Python, which uses the
-        # normal glibc loader and only searches LD_LIBRARY_PATH/rpath.
+        # Shared libraries that Python wheels dlopen at runtime. nix-ld does NOT
+        # cover these: the wheels are dlopen'd by a Nix-store Python, whose glibc
+        # loader only searches LD_LIBRARY_PATH/rpath, not NIX_LD_LIBRARY_PATH.
         runtimeLibs = with pkgs; [
           portaudio # libportaudio.so for pyaudio
           stdenv.cc.cc.lib # libstdc++ for onnxruntime / faster-whisper
@@ -82,10 +76,9 @@
         # EASYSPEAK_SOUNDS_DIR (commonEnv) redirects to the Nix store one.
         soundsNixDir = "${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo";
 
-        # Piper voice model (Amy, US English) — fetched at build time so the
-        # README's manual wget step isn't needed on NixOS. Piper expects the
-        # .onnx and .onnx.json to live in the same directory, so we linkFarm
-        # them together and point EASYSPEAK_PIPER_MODEL at the .onnx.
+        # Piper voice (Amy, US English), fetched at build time. Piper wants the
+        # .onnx and .onnx.json side by side, so linkFarm them and point
+        # EASYSPEAK_PIPER_MODEL at the .onnx.
         piperVoice = pkgs.linkFarm "piper-voice-en-US-amy-medium" [
           {
             name = "en_US-amy-medium.onnx";
@@ -110,35 +103,35 @@
         # .git is missing (e.g. a tarball checkout); the pyaudio build flags
         # compile it against the Nix-store portaudio (CPPFLAGS/LDFLAGS feed
         # distutils, C_INCLUDE_PATH/LIBRARY_PATH feed gcc).
-        commonEnv = ''
+        commonEnv = with pkgs; ''
           export UV_PYTHON='${python}/bin/python'
           export EASYSPEAK_PIPER_MODEL="''${EASYSPEAK_PIPER_MODEL:-${piperModelPath}}"
           export EASYSPEAK_SOUNDS_DIR="''${EASYSPEAK_SOUNDS_DIR:-${soundsNixDir}}"
           export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX="''${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX:-${pretendVersion}}"
-          export CPPFLAGS="-I${pkgs.portaudio}/include ''${CPPFLAGS:-}"
-          export LDFLAGS="-L${pkgs.portaudio}/lib -Wl,-rpath,${pkgs.portaudio}/lib ''${LDFLAGS:-}"
-          export C_INCLUDE_PATH="${pkgs.portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
-          export LIBRARY_PATH="${pkgs.portaudio}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
-          export LD_LIBRARY_PATH='${pkgs.lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
+          export CPPFLAGS="-I${portaudio}/include ''${CPPFLAGS:-}"
+          export LDFLAGS="-L${portaudio}/lib -Wl,-rpath,${portaudio}/lib ''${LDFLAGS:-}"
+          export C_INCLUDE_PATH="${portaudio}/include''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+          export LIBRARY_PATH="${portaudio}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+          export LD_LIBRARY_PATH='${lib.makeLibraryPath runtimeLibs}'":''${LD_LIBRARY_PATH:-}"
           export EASYSPEAK_ATSPI_PYTHON='${atspiPython}/bin/python3'
           export GI_TYPELIB_PATH='${giTypelibPath}'":''${GI_TYPELIB_PATH:-}"
         '';
 
         easyspeak = pkgs.writeShellApplication {
           name = "easyspeak";
-          runtimeInputs = [
+          runtimeInputs = with pkgs; [
             python
-            pkgs.uv
-            pkgs.coreutils
-            pkgs.gnused
+            uv
+            coreutils
+            gnused
           ]
           ++ runtimeTools
           ++ buildTools;
           text = ''
             set -euo pipefail
 
-            # uv needs a writable project directory; the flake source in
-            # /nix/store is read-only, so mirror it under XDG_STATE_HOME.
+            # uv needs a writable project dir, but /nix/store is read-only, so
+            # mirror the source under XDG_STATE_HOME.
             state_dir="''${XDG_STATE_HOME:-$HOME/.local/state}/easyspeak"
             src_dir="$state_dir/src"
             stamp="$src_dir/.nix-store-path"
@@ -172,26 +165,24 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = [
+          packages = with pkgs; [
             python
-            pkgs.uv
-            pkgs.just
-            pkgs.eslint # JS linter for the GNOME Shell extension (see `just lint-js`)
-            pkgs.nodejs # `node --test` for the extension's JS helpers (see `just test-js`)
-            pkgs.desktop-file-utils # desktop-file-validate for the launcher (see `just gate`)
-            pkgs.glib.dev # glib-compile-schemas for the extension's GSettings schema (see `just compile-schemas`)
-            pkgs.dpkg # dpkg-deb to read .deb contents (see tests/packaging/test_deb.sh)
-            pkgs.rpm # rpm to read .rpm contents (see tests/packaging/test_rpm.sh)
-            pkgs.unzip # read .whl contents (see tests/packaging/test_python_wheel.sh)
+            uv
+            just
+            eslint # JS linter for the GNOME Shell extension (see `just lint-js`)
+            nodejs # `node --test` for the extension's JS helpers (see `just test-js`)
+            desktop-file-utils # desktop-file-validate for the launcher (see `just gate`)
+            glib.dev # glib-compile-schemas for the extension's GSettings schema (see `just compile-schemas`)
+            dpkg # dpkg-deb to read .deb contents (see tests/packaging/test_deb.sh)
+            rpm # rpm to read .rpm contents (see tests/packaging/test_rpm.sh)
+            unzip # read .whl contents (see tests/packaging/test_python_wheel.sh)
           ]
           ++ runtimeTools
           ++ buildTools;
           shellHook = ''
-            # mkShell's setup-hooks pile every Python app's (qutebrowser,
-            # piper-tts, onnxruntime, ...) site-packages onto PYTHONPATH. uv
-            # inherits that into PEP 517 build subprocesses, which then mix a
-            # different Python's setuptools into our build and produce wheels
-            # tagged with the wrong ABI. Strip both to keep uv pure.
+            # mkShell's setup-hooks pile other apps' site-packages onto
+            # PYTHONPATH; uv would inherit them into PEP 517 builds and produce
+            # wheels with the wrong ABI. Strip both to keep uv pure.
             unset PYTHONPATH PYTHONHOME
 
             ${commonEnv}

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -1,4 +1,11 @@
-"""Command-line entry point: parse arguments, set up logging, run the app."""
+"""Command-line entry point: parse arguments, set up logging, run the app.
+
+Verbosity comes from the mutually exclusive `-v`/`--verbose` and `-q`/`--quiet`
+flags, or — with neither — the `EASYSPEAK_LOG_LEVEL` environment variable, which
+the flags override (see [`resolve_level`][core.log.resolve_level]). The one-shot
+`--configure` and `--show` subcommands set up or print the desktop-integration
+files and exit. All `EASYSPEAK_*` variables are listed in [`core.config`][core.config].
+"""
 
 import argparse
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,8 +1,25 @@
 """Tuning constants and model factory for EasySpeak.
 
-Override the EASYSPEAK_* environment variables to customise behaviour without editing
-source. Plugin-specific host-environment setup lives in each plugin's own setup() hook,
-not here.
+Override the `EASYSPEAK_*` environment variables to customise behaviour without
+editing source. Plugin-specific host-environment setup lives in each plugin's own
+`setup()` hook, not here.
+
+Every variable EasySpeak reads and what it affects — the defaults are the constant
+values rendered below, except `EASYSPEAK_LOG_LEVEL` (handled in `core.log`) and
+`EASYSPEAK_ATSPI_PYTHON` (in `core.tray`/`plugins.dictation`):
+
+| Variable                         | Effect                                           |
+| -------------------------------- | ------------------------------------------------ |
+| `EASYSPEAK_LOG_LEVEL`            | Logging level when no `-v`/`-q` flag is given.   |
+| `EASYSPEAK_HOTKEY`               | Disable hold-to-dictate silent activation.       |
+| `EASYSPEAK_HOTKEY_COMBO`         | Keys held to dictate without the wake word.      |
+| `EASYSPEAK_PIPER_MODEL`          | Piper voice `.onnx` used for speech output.      |
+| `EASYSPEAK_PIPER_BIN`            | Piper TTS binary.                                |
+| `EASYSPEAK_WHISPER_MODEL`        | faster-whisper model used for transcription.     |
+| `EASYSPEAK_WHISPER_COMPUTE_TYPE` | CTranslate2 compute type.                        |
+| `EASYSPEAK_WHISPER_CPU_THREADS`  | CPU threads for transcription.                   |
+| `EASYSPEAK_SOUNDS_DIR`           | Directory of the wake chime and error bell.      |
+| `EASYSPEAK_ATSPI_PYTHON`         | Interpreter running the dictation AT-SPI helper. |
 """
 
 import os

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -82,6 +82,18 @@ COMMAND_PROMPT = (
 )
 
 
+# --- Desktop sounds ---
+# The wake chime and error bell come from the freedesktop sound theme. The
+# directory is the FHS location by default; on NixOS that path doesn't exist, so
+# the flake points EASYSPEAK_SOUNDS_DIR at the sound-theme-freedesktop store path
+# (for both `nix run` and the dev shell) so the files are actually found.
+SOUNDS_DIR = os.environ.get(
+    "EASYSPEAK_SOUNDS_DIR", "/usr/share/sounds/freedesktop/stereo"
+)
+WAKE_SOUND = os.path.join(SOUNDS_DIR, "message.oga")
+ERROR_SOUND = os.path.join(SOUNDS_DIR, "dialog-error.oga")
+
+
 def load_whisper_model(
     model_name: str = WHISPER_MODEL,
     compute_type: str = WHISPER_COMPUTE_TYPE,

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -27,6 +27,7 @@ from .config import (
     SILENCE_DURATION,
     SILENCE_THRESHOLD,
     WAKE_COOLDOWN,
+    WAKE_SOUND,
     WAKE_THRESHOLD,
     WHISPER_COMPUTE_TYPE,
     WHISPER_CPU_THREADS,
@@ -407,10 +408,7 @@ class EasySpeak:
         Flushing drops the chime audio that bled into the mic so it isn't mistaken for
         the user speaking.
         """
-        subprocess.run(
-            ["paplay", "/usr/share/sounds/freedesktop/stereo/message.oga"],
-            capture_output=True,
-        )
+        subprocess.run(["paplay", WAKE_SOUND], capture_output=True)
         self.flush_stream()
 
     def _drain_feedback(self):

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -28,6 +28,7 @@ import time
 from pathlib import Path
 
 from .about import DOCS_URL
+from .config import ERROR_SOUND
 
 logger = logging.getLogger(__name__)
 
@@ -52,12 +53,6 @@ ABOUT_HELPER = str(Path(__file__).with_name("about.py"))
 
 # Shared with the extension's ScreenshotManager, which creates ~/.cache/easyspeak.
 CONTROL_FILE = Path.home() / ".cache" / "easyspeak" / "control"
-
-# Desktop "something failed" sound, played alongside the spoken apology when a
-# menu helper can't open. FHS path (from sound-theme-freedesktop); the flake
-# sed-replaces this directory with the Nix store one at sync time, mirroring the
-# wake chime in core.main.
-ERROR_SOUND = "/usr/share/sounds/freedesktop/stereo/dialog-error.oga"
 
 # How long to idle between control-file probes while the assistant is asleep.
 SLEEP_POLL_INTERVAL = 0.2


### PR DESCRIPTION
Fixes the wake chime that stayed silent under `uv run easyspeak` in the Nix dev shell, consolidates the duplicated environment setup in the flake, and documents every `EASYSPEAK_*` variable in the generated API docs — split into three focused commits:

- **Fix wake chime when running from the dev shell** — adds `EASYSPEAK_SOUNDS_DIR` (read in `core.config`, defaulting to the FHS path), routes `core.main`/`core.tray` through it, and exports it from a single shared `commonEnv` binding used by both `nix run` and the dev shell.
- **Shorten flake comments and use `with pkgs`** — trims the verbose comment blocks to one or two lines and brings the remaining `pkgs.`-prefixed lists under `with pkgs;`.
- **Document the EASYSPEAK_* variables in docstrings** — lists every variable in the `core.config` docstring as a table the mkdocstrings reference renders, and notes `EASYSPEAK_LOG_LEVEL` in `core.cli`.

The chime worked under `nix run` only because its wrapper `sed`-rewrote the hard-coded FHS sound path (`/usr/share/sounds/freedesktop/stereo`, absent on NixOS) to the Nix store; the dev shell never did, so `paplay` was handed files that do not exist. Moving the directory behind `EASYSPEAK_SOUNDS_DIR` and exporting it from the shared `commonEnv` drops the `sed` step entirely and makes both entry points behave identically. Defaults are deliberately left out of the docstrings — they render straight from the constants — so the prose cannot drift out of date.