### PR TITLE
Serve main docs at the root, redirect `/latest` to it

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,18 +69,17 @@ jobs:
     - name: Publish "latest" docs from main
       if: github.ref == 'refs/heads/main'
       run: just docs-publish deploy --push latest
-    - name: Publish tagged release docs to site root
-      if: startsWith(github.ref, 'refs/tags/')
-      env:
-        REF_NAME: ${{ github.ref_name }}
+    - name: Mirror main to the root and redirect /latest to it
+      if: github.ref == 'refs/heads/main'
       run: |
         git fetch origin gh-pages
         git worktree add gh-pages-root origin/gh-pages
         python packaging/sync-docs-root.py site gh-pages-root
+        python packaging/make-latest-redirects.py site gh-pages-root/latest
         git -C gh-pages-root add -A
         if git -C gh-pages-root diff --cached --quiet; then
           echo "Site root already up to date."
         else
-          git -C gh-pages-root commit -m "Publish $REF_NAME docs to site root"
+          git -C gh-pages-root commit -m "Mirror main docs to root; redirect /latest"
           git -C gh-pages-root push origin HEAD:gh-pages
         fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: EasySpeak
 site_description: Voice control for Linux desktops. Fully local, no cloud, Wayland-native.
 # Docs are versioned with mike (see the `extra.version` block and the Docs
-# workflow): each release/dev build is archived under its own `/<version>/`
-# path, while the latest docs are published to the site root for clean,
-# version-less URLs. Point site_url (canonical links, sitemap) at that root, so
-# the archived snapshots' canonical URLs reference the latest version.
+# workflow): each release is archived under its own `/<version>/` path, while
+# the in-development `main` docs are served at the site root for clean,
+# version-less URLs. `/latest/` permanently redirects to that root. Point
+# site_url (canonical links, sitemap) at the root.
 site_url: https://easyspeak.dev/
 repo_url: https://github.com/ctsdownloads/easyspeak
 repo_name: ctsdownloads/easyspeak

--- a/packaging/make-latest-redirects.py
+++ b/packaging/make-latest-redirects.py
@@ -1,0 +1,50 @@
+"""Replace the gh-pages ``/latest/`` tree with redirect stubs to the site root.
+
+The site root serves the current ``main`` docs at clean, version-less URLs (see
+sync-docs-root.py). ``/latest/`` is kept only as a stable, addressable alias for
+that same content: every page under it redirects to its root counterpart, with a
+``rel=canonical`` pointing at the root so search engines treat the root as the
+single canonical copy. GitHub Pages can't issue a real HTTP 301, so each stub is
+a meta-refresh + canonical (the same technique mike's redirect aliases use) and
+carries any URL fragment (e.g. ``#core.config``) across the hop.
+
+Usage:
+    python make-latest-redirects.py <built-site-dir> <latest-dir> [base-url]
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+STUB = """<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting…</title>
+    <link rel="canonical" href="{base}{target}">
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0; url={target}">
+    <script>location.replace("{target}" + location.hash + location.search)</script>
+  </head>
+  <body>Redirecting to <a href="{target}">{target}</a>…</body>
+</html>
+"""
+
+
+def main(site: str, latest_dir: str, base: str = "https://easyspeak.dev") -> None:
+    """Mirror every built page's path under `latest_dir` as a redirect to root."""
+    site_dir, latest, base = Path(site), Path(latest_dir), base.rstrip("/")
+    if latest.exists():
+        shutil.rmtree(latest)
+    for index in site_dir.rglob("index.html"):
+        rel = index.parent.relative_to(site_dir).as_posix()
+        target = "/" if rel == "." else f"/{rel}/"
+        out = latest / "index.html" if rel == "." else latest / rel / "index.html"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(STUB.format(base=base, target=target), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    if not 3 <= len(sys.argv) <= 4:
+        raise SystemExit(__doc__)
+    main(*sys.argv[1:])

--- a/packaging/sync-docs-root.py
+++ b/packaging/sync-docs-root.py
@@ -1,7 +1,7 @@
-"""Publish the latest MkDocs build to the gh-pages site root.
+"""Mirror the in-development ``main`` MkDocs build to the gh-pages site root.
 
-mike archives every release/dev build under its own ``/<version>/`` path and
-maintains ``versions.json`` plus ``.nojekyll`` at the root. To serve the latest
+mike archives every release under its own ``/<version>/`` path and maintains
+``versions.json`` plus ``.nojekyll`` at the root. To serve the current ``main``
 docs at clean, version-less URLs (``/easyspeak/installation/`` rather than
 ``/easyspeak/latest/installation/``), this copies a freshly built site into the
 gh-pages root, replacing the previous canonical files but leaving mike's version


### PR DESCRIPTION
Make the version-less site root mirror `main` instead of the latest version release, and turn `/latest/` into a permanent redirect to it — so the default site shows the in-development docs and the version selector's `latest` entry lands on clean root URLs.

- `docs.yml`: on a `main` push, mirror the build to the root and regenerate `/latest/` as redirect stubs; the tag-only root sync is gone (releases are still archived at `/<version>/`).
- `make-latest-redirects.py` (new): per-page meta-refresh + `rel=canonical` stubs, fragment-preserving.
- `sync-docs-root.py` / `mkdocs.yml`: docstring and comment updated to match.

GitHub Pages can't issue a real HTTP 301, so the stubs use a meta-refresh plus `rel=canonical` (the same technique mike's redirect aliases use); the canonical tells search engines the root is the one true copy.