### PR TITLE
Tidy the docs deploy scripts and names

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -65,21 +65,10 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
     - name: Archive tagged release snapshot
       if: startsWith(github.ref, 'refs/tags/')
-      run: just docs-publish deploy --push "${GITHUB_REF_NAME}"
+      run: just docs-mike deploy --push "${GITHUB_REF_NAME}"
     - name: Publish "latest" docs from main
       if: github.ref == 'refs/heads/main'
-      run: just docs-publish deploy --push latest
+      run: just docs-mike deploy --push latest
     - name: Mirror main to the root and redirect /latest to it
       if: github.ref == 'refs/heads/main'
-      run: |
-        git fetch origin gh-pages
-        git worktree add gh-pages-root origin/gh-pages
-        python packaging/sync-docs-root.py site gh-pages-root
-        python packaging/make-latest-redirects.py site gh-pages-root/latest
-        git -C gh-pages-root add -A
-        if git -C gh-pages-root diff --cached --quiet; then
-          echo "Site root already up to date."
-        else
-          git -C gh-pages-root commit -m "Mirror main docs to root; redirect /latest"
-          git -C gh-pages-root push origin HEAD:gh-pages
-        fi
+      run: bash packaging/docs-mirror-root.sh

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Say "Hey Jarvis" and control your desktop with your voice.
 [![Pipeline](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/pipeline.yml)
 [![Safety](https://github.com/ctsdownloads/easyspeak/actions/workflows/safety.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/safety.yml)
 [![Release](https://github.com/ctsdownloads/easyspeak/actions/workflows/release.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/release.yml)
+[![Docs](https://github.com/ctsdownloads/easyspeak/actions/workflows/docs.yml/badge.svg)](https://github.com/ctsdownloads/easyspeak/actions/workflows/docs.yml)
 [![Benchmarks](https://img.shields.io/badge/%F0%9F%90%B0%20Bencher-performance-FD7E14.svg)](https://bencher.dev/perf/easyspeak)
-[![Docs](https://github.com/ctsdownloads/easyspeak/actions/workflows/docs.yml/badge.svg)](https://easyspeak.dev/)
 
 > ⚠️ **Early development.** This project works but is not polished. Expect bugs, incomplete docs, and changes without notice.
 

--- a/justfile
+++ b/justfile
@@ -142,14 +142,14 @@ lint-docstrings:
 lint-md *args:
     git ls-files '*.md' | xargs uvx --from pymarkdownlnt pymarkdown {{ args }} scan
 
-# Build the docs (use `serve` to serve at http://127.0.0.1:8000 with live-reload)
+# Build the docs (use `serve` to serve them locally with live-reload)
 [group('docs')]
 docs *args=('build --strict'):
     uv run --extra=docs mkdocs {{ args }}
 
-# Publish versioned docs via mike (CI; e.g. `just docs-publish deploy --push dev`)
+# Run a mike command for the versioned docs (e.g. `just docs-mike list`, `just docs-mike delete 0.4.0rc1`)
 [group('docs')]
-docs-publish *args:
+docs-mike *args:
     uv run --extra=docs mike {{ args }}
 
 # Build the Debian package and verify its contents

--- a/packaging/docs-mirror-root.sh
+++ b/packaging/docs-mirror-root.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Mirror the freshly built "latest" docs onto the version-less gh-pages root
+# and rebuild the /latest redirects. Run after `just docs` (builds ./site)
+# and the mike deploy that publishes "latest".
+set -euo pipefail
+
+trap 'git worktree remove --force gh-pages-root 2>/dev/null || true' EXIT
+git worktree remove --force gh-pages-root 2>/dev/null || true
+git fetch origin gh-pages
+git worktree add gh-pages-root origin/gh-pages
+python packaging/docs-sync-root.py site gh-pages-root
+python packaging/docs-redirect-latest.py site gh-pages-root/latest
+git -C gh-pages-root add -A
+if git -C gh-pages-root diff --cached --quiet; then
+    echo "Site root already up to date."
+else
+    git -C gh-pages-root commit -m "Mirror main docs to root; redirect /latest"
+    git -C gh-pages-root push origin HEAD:gh-pages
+fi

--- a/packaging/docs-redirect-latest.py
+++ b/packaging/docs-redirect-latest.py
@@ -1,7 +1,7 @@
 """Replace the gh-pages ``/latest/`` tree with redirect stubs to the site root.
 
 The site root serves the current ``main`` docs at clean, version-less URLs (see
-sync-docs-root.py). ``/latest/`` is kept only as a stable, addressable alias for
+docs-sync-root.py). ``/latest/`` is kept only as a stable, addressable alias for
 that same content: every page under it redirects to its root counterpart, with a
 ``rel=canonical`` pointing at the root so search engines treat the root as the
 single canonical copy. GitHub Pages can't issue a real HTTP 301, so each stub is
@@ -9,7 +9,7 @@ a meta-refresh + canonical (the same technique mike's redirect aliases use) and
 carries any URL fragment (e.g. ``#core.config``) across the hop.
 
 Usage:
-    python make-latest-redirects.py <built-site-dir> <latest-dir> [base-url]
+    python docs-redirect-latest.py <built-site-dir> <latest-dir> [base-url]
 """
 
 import shutil

--- a/packaging/docs-sync-root.py
+++ b/packaging/docs-sync-root.py
@@ -8,7 +8,7 @@ gh-pages root, replacing the previous canonical files but leaving mike's version
 directories and metadata untouched.
 
 Usage:
-    python sync-docs-root.py <built-site-dir> <gh-pages-checkout>
+    python docs-sync-root.py <built-site-dir> <gh-pages-checkout>
 """
 
 import json


### PR DESCRIPTION
Tidy the docs deploy plumbing — no behaviour change.

- `packaging/docs-mirror-root.sh` (new): the gh-pages root-mirror block, moved out of the workflow so the step is a one-line call. Named for the single step it performs (mirror main to the root, redirect `/latest`) — not a whole deployment. It orchestrates the two helper scripts, which is more than a justfile recipe should carry.
- `justfile`: rename the mike passthrough `docs-publish` → `docs-mike` (clearer it is the raw tool, not the deploy).
- `packaging/`: rename `sync-docs-root.py` → `docs-sync-root.py` and `make-latest-redirects.py` → `docs-redirect-latest.py` for a consistent `docs-` prefix.

The build and mike publish stay explicit `just docs` / `just docs-mike deploy` steps in the workflow, so it is obvious `just` is required up front.