### PR TITLE
Merge the two HOTKEY env vars and validate the combo

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,20 +42,20 @@ the module that reads each (linked to its API reference).
 
 ### [`core.config`][core.config]
 
-| Variable                         | Default                                | Effect                                               |
-| -------------------------------- | -------------------------------------- | ---------------------------------------------------- |
-| `EASYSPEAK_HOTKEY`               | `1`                                    | Set `0` to disable hold-to-dictate silent activation |
-| `EASYSPEAK_HOTKEY_COMBO`         | `ctrl+shift`                           | Keys held to dictate without the wake word           |
-| `EASYSPEAK_PIPER_BIN`            | `piper`                                | Piper TTS binary                                     |
-| `EASYSPEAK_PIPER_MODEL`          | bundled Amy voice                      | Piper voice `.onnx` for speech output                |
-| `EASYSPEAK_SOUNDS_DIR`           | `/usr/share/sounds/freedesktop/stereo` | Directory of the wake chime and error bell           |
-| `EASYSPEAK_WHISPER_COMPUTE_TYPE` | `int8`                                 | CTranslate2 compute type                             |
-| `EASYSPEAK_WHISPER_CPU_THREADS`  | `0`                                    | CPU threads for transcription (`0` = auto)           |
-| `EASYSPEAK_WHISPER_MODEL`        | `base.en`                              | faster-whisper model for transcription               |
+| Variable                         | Default                                | Effect                                     |
+| -------------------------------- | -------------------------------------- | ------------------------------------------ |
+| `EASYSPEAK_HOTKEY`               | `ctrl+shift`                           | Keys held to dictate without the wake word |
+| `EASYSPEAK_PIPER_BIN`            | `piper`                                | Piper TTS binary                           |
+| `EASYSPEAK_PIPER_MODEL`          | bundled Amy voice                      | Piper voice `.onnx` for speech output      |
+| `EASYSPEAK_SOUNDS_DIR`           | `/usr/share/sounds/freedesktop/stereo` | Directory of the wake chime and error bell |
+| `EASYSPEAK_WHISPER_COMPUTE_TYPE` | `int8`                                 | CTranslate2 compute type                   |
+| `EASYSPEAK_WHISPER_CPU_THREADS`  | `0`                                    | CPU threads for transcription (`0` = auto) |
+| `EASYSPEAK_WHISPER_MODEL`        | `base.en`                              | faster-whisper model for transcription     |
 
-`EASYSPEAK_HOTKEY_COMBO` takes the `ctrl`/`shift`/`alt`/`super` aliases or raw
-evdev key names joined with `+`, and needs read access to `/dev/input` (be in
-the `input` group).
+`EASYSPEAK_HOTKEY` takes the `ctrl`/`shift`/`alt`/`super` aliases or raw evdev
+key names joined with `+` (e.g. `ctrl+space`); set it to empty, `off`, or `none`
+to turn it off, and an unrecognized key disables it too. See
+[Packaging](packaging.md) for the device access it needs.
 
 ### [`core.log`][core.log]
 

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -6,7 +6,6 @@ builds the faster-whisper model from them. Most are plain constants; these
 honor an `EASYSPEAK_*` environment variable:
 
 - `EASYSPEAK_HOTKEY`
-- `EASYSPEAK_HOTKEY_COMBO`
 - `EASYSPEAK_PIPER_BIN`
 - `EASYSPEAK_PIPER_MODEL`
 - `EASYSPEAK_SOUNDS_DIR`
@@ -40,13 +39,10 @@ MISUNDERSTAND_GRACE = 4.0  # Seconds to ignore repeat misses after feedback
 FOLLOWUP_IDLE_ROUNDS = 2  # Quiet listens tolerated before a command session ends
 
 # --- Keyboard (silent) activation ---
-HOTKEY_COMBO = os.environ.get("EASYSPEAK_HOTKEY_COMBO", "ctrl+shift")
-HOTKEY_ENABLED = os.environ.get("EASYSPEAK_HOTKEY", "1").lower() not in (
-    "0",
-    "false",
-    "no",
-    "off",
-)
+# Hold EASYSPEAK_HOTKEY to dictate; an empty value or `off`/`none` disables it
+# (an empty combo leaves the listener inert). core.hotkey validates the keys.
+_hotkey = os.environ.get("EASYSPEAK_HOTKEY", "ctrl+shift").strip()
+HOTKEY_COMBO = "" if _hotkey.lower() in ("", "off", "none") else _hotkey
 
 
 # --- Models ---

--- a/src/core/hotkey.py
+++ b/src/core/hotkey.py
@@ -64,6 +64,28 @@ def parse_combo(spec: str) -> tuple[frozenset[str], ...]:
     return tuple(groups)
 
 
+def unknown_keys(spec: str) -> list[str]:
+    """Return combo tokens that are neither a modifier alias nor a real evdev key.
+
+    Validates against `evdev.ecodes`, so a typo (`ctrl+spcae`) is caught instead of
+    silently becoming a dead key. Returns `[]` when python-evdev can't be imported,
+    since the listener is inert without it anyway. Only evdev key names are checked;
+    the portal-based activation in issue #92 would use a different trigger grammar.
+    """
+    try:
+        from evdev import ecodes
+    except ImportError:
+        return []
+    unknown = []
+    for part in spec.split("+"):
+        name = part.strip().lower()
+        if not name or name in _MODIFIER_ALIASES:
+            continue
+        if f"KEY_{name.upper()}" not in ecodes.ecodes:
+            unknown.append(part.strip())
+    return unknown
+
+
 class HotkeyListener:
     """Track whether a key combo is held, off a background evdev reader.
 
@@ -78,12 +100,19 @@ class HotkeyListener:
     def __init__(self, combo="ctrl+shift", enabled=True):
         """Set up the listener for `combo` (e.g. `"ctrl+shift"`).
 
-        An unparseable or empty combo, or `enabled=False`, leaves the listener disabled
-        so [`start`][core.hotkey.HotkeyListener.start] is a no-op.
+        An empty, unparseable, or unknown-key combo, or `enabled=False`, leaves the
+        listener disabled so [`start`][core.hotkey.HotkeyListener.start] is a no-op.
         """
         self._spec = combo
         self._groups = parse_combo(combo)
-        self._enabled = enabled and bool(self._groups)
+        unknown = unknown_keys(combo)
+        if unknown:
+            logger.warning(
+                "Ignoring hotkey combo %r: unknown key(s) %s.",
+                combo,
+                ", ".join(unknown),
+            )
+        self._enabled = enabled and bool(self._groups) and not unknown
         self._pressed = set()  # combo keys currently held
         self._held = False  # whole combo satisfied
         self._activation = False  # rising edge, consumed by take_activation()

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -22,7 +22,6 @@ from .config import (
     COMMAND_PROMPT,
     FOLLOWUP_IDLE_ROUNDS,
     HOTKEY_COMBO,
-    HOTKEY_ENABLED,
     MISUNDERSTAND_GRACE,
     SILENCE_DURATION,
     SILENCE_THRESHOLD,
@@ -79,7 +78,7 @@ class EasySpeak:
         self.tray = Tray(speak=self.speak)
         # Hold-to-dictate keyboard activation; the dictation plugin registers
         # the session to run while the combo is held (see register_push_to_talk).
-        self.hotkey = HotkeyListener(HOTKEY_COMBO, HOTKEY_ENABLED)
+        self.hotkey = HotkeyListener(HOTKEY_COMBO)
         self._push_to_talk = None
 
     # --- Utilities for plugins ---

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -22,6 +22,7 @@ def _restore_config(monkeypatch):
         "EASYSPEAK_WHISPER_COMPUTE_TYPE",
         "EASYSPEAK_PIPER_MODEL",
         "EASYSPEAK_PIPER_BIN",
+        "EASYSPEAK_HOTKEY",
     ]:
         monkeypatch.delenv(var, raising=False)
     importlib.reload(config)
@@ -137,3 +138,25 @@ def test_piper_bin_env_override(monkeypatch):
     monkeypatch.setenv("EASYSPEAK_PIPER_BIN", "/opt/voices/piper")
     importlib.reload(config)
     assert config.PIPER_BIN == "/opt/voices/piper"
+
+
+def test_hotkey_default(monkeypatch):
+    """EASYSPEAK_HOTKEY defaults to the ctrl+shift combo."""
+    monkeypatch.delenv("EASYSPEAK_HOTKEY", raising=False)
+    importlib.reload(config)
+    assert config.HOTKEY_COMBO == "ctrl+shift"
+
+
+def test_hotkey_custom_combo(monkeypatch):
+    """EASYSPEAK_HOTKEY sets the combo directly."""
+    monkeypatch.setenv("EASYSPEAK_HOTKEY", "ctrl+space")
+    importlib.reload(config)
+    assert config.HOTKEY_COMBO == "ctrl+space"
+
+
+@pytest.mark.parametrize("value", ["", "off", "none", "OFF", "  none  "])
+def test_hotkey_disable_values(monkeypatch, value):
+    """An empty value or off/none (any case, trimmed) disables the hotkey."""
+    monkeypatch.setenv("EASYSPEAK_HOTKEY", value)
+    importlib.reload(config)
+    assert config.HOTKEY_COMBO == ""

--- a/tests/unit/core/test_hotkey.py
+++ b/tests/unit/core/test_hotkey.py
@@ -164,6 +164,17 @@ class TestStart:
 
         grab.assert_not_called()
 
+    def test_unknown_key_disables_and_warns(self, caplog):
+        """An unrecognized key name disables the listener, with a warning."""
+        with caplog.at_level(logging.WARNING):
+            h = HotkeyListener("ctrl+banana")
+
+        with patch.object(h, "_grab_devices") as grab:
+            h.start()
+
+        grab.assert_not_called()
+        assert "banana" in caplog.text
+
     def test_no_devices_starts_no_thread(self):
         h = HotkeyListener("ctrl+shift")
 


### PR DESCRIPTION
Collapse the two hotkey environment variables into one and catch mis-typed combos instead of silently arming a dead key.

- `EASYSPEAK_HOTKEY` now holds the combo itself (default `ctrl+shift`); set it empty or to `off`/`none` to disable. `EASYSPEAK_HOTKEY_COMBO` and the `HOTKEY_ENABLED` constant are gone.
- `core.hotkey.unknown_keys()` validates each token against `evdev.ecodes`; an unknown key (e.g. `ctrl+spcae`) logs a warning and disables the listener rather than silently never firing.
- Docs: Usage > Configuration collapses the two rows into one and documents the syntax + disable values; the permission caveat stays in Packaging.
- Tests: disable-keyword parsing in `test_config`, unknown-key disabling in `test_hotkey`.

Scoped to the evdev path — the portal trigger grammar from #92 would validate differently (noted in a code comment).