### PR TITLE
Disable the setup-uv cache to stop cache-save races

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
-        ignore-nothing-to-cache: true
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - name: Install PortAudio headers
       run: |
@@ -52,6 +52,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - name: Install PortAudio headers
       run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
-        ignore-nothing-to-cache: true
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - run: |
         sudo apt update
@@ -66,7 +66,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: ${{ matrix.python-version }}
-        ignore-nothing-to-cache: true
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - run: |
         sudo apt update
@@ -81,7 +81,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
-        ignore-nothing-to-cache: true
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - run: |
         sudo apt update
@@ -95,6 +95,6 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
-        ignore-nothing-to-cache: true
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - run: just check-python-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - run: |
         sudo apt update

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -24,6 +24,7 @@ jobs:
     - uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.14'
+        enable-cache: false
     - uses: taiki-e/install-action@just
     - run: |
         sudo apt update


### PR DESCRIPTION
Stop the `setup-uv` "Unable to reserve cache … another job may be creating this cache" warnings across the Docs/Pipeline/Safety workflows.

- The cache key includes the runner + Python + lock hash but **not** the job, so every parallel `3.14` job shares one key and they race to save it.
- Rather than give each job a unique `cache-suffix` (noisy YAML, one cache per job), just **disable** the cache: `enable-cache: false` on each `setup-uv`, dropping the now-pointless `ignore-nothing-to-cache` flags.

Trade-off: each job re-downloads its uv deps, but uv is fast — ~15–25s on the heavy jobs (unit/acceptance/packaging), seconds on the light ones — worth it for simpler, warning-free workflows. Easy to re-enable per job with a `cache-suffix` later if CI time becomes a concern.