### PR TITLE
Rename `--show` CLI option to `--preview`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,14 +20,14 @@ wake word each time.
 
 ## Command-line options
 
-| Flag                     | Default             | Effect                                           |
-| ------------------------ | ------------------- | ------------------------------------------------ |
-| `-v`, `--verbose`        |                     | Show debug output                                |
-| `-q`, `--quiet`          |                     | Show only warnings and errors                    |
-| `--configure [ITEM ...]` | `extension service` | Set up the listed integrations and exit          |
-| `--show [ITEM ...]`      | all                 | Print the listed items' files to stdout and exit |
+| Flag                     | Default             | Effect                                                   |
+| ------------------------ | ------------------- | -------------------------------------------------------- |
+| `-v`, `--verbose`        |                     | Show debug output                                        |
+| `-q`, `--quiet`          |                     | Show only warnings and errors                            |
+| `--configure [ITEM ...]` | `extension service` | Set up the listed integrations and exit                  |
+| `--preview ITEM`         |                     | Print the file content that would be configured and exit |
 
-For `--configure`/`--show`, each `ITEM` is one of `extension`, `service`,
+For `--configure`/`--preview`, each `ITEM` is one of `extension`, `service`,
 `autostart`, or `desktop`. Verbosity can also be set with the
 `EASYSPEAK_LOG_LEVEL` environment variable (e.g. `DEBUG`, `INFO`, `WARNING`),
 but the command-line flags take precedence.

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -37,11 +37,11 @@ echo ">> installing app + runtime extras into the venv"
 uv pip install --python "$PREFIX/venv/bin/python" "$WHEEL" piper-tts
 
 echo ">> rendering the GNOME-extension refresh unit for the bundled interpreter"
-# `--show service` prints the unit the bundled interpreter would install, so the
+# `--preview service` prints the unit the bundled interpreter would install, so the
 # packaged file is byte-identical to the runtime-generated one — baked with the
 # bundle's stable interpreter and module paths (PREFIX is the final install path,
 # so they're valid on the target). nfpm ships this to /usr/lib/systemd/user.
-"$PREFIX/venv/bin/easyspeak" --show service \
+"$PREFIX/venv/bin/easyspeak" --preview service \
   > "$REPO_ROOT/dist/easyspeak-extension-refresh.service"
 
 # Where language packages drop their models; config.py discovers them here.

--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -3,7 +3,7 @@
 Verbosity comes from the mutually exclusive `-v`/`--verbose` and `-q`/`--quiet`
 flags, or — with neither — the `EASYSPEAK_LOG_LEVEL` environment variable, which
 the flags override (see [`resolve_level`][core.log.resolve_level]). The one-shot
-`--configure` and `--show` subcommands set up or print the desktop-integration
+`--configure` and `--preview` subcommands set up or print the desktop-integration
 files and exit. All `EASYSPEAK_*` variables are listed in [`core.config`][core.config].
 """
 
@@ -37,17 +37,14 @@ def parse_args(argv=None):
         ),
     )
     parser.add_argument(
-        "--show",
-        nargs="*",
+        "--preview",
         choices=config_items,
-        help="print the listed items' files to stdout and exit (default: all)",
+        help="print the file content that would be configured and exit",
     )
     args = parser.parse_args(argv)
 
     if args.configure is not None:
         args.configure = set(args.configure) or config_defaults
-    if args.show is not None:
-        args.show = set(args.show) or config_items
 
     return args
 
@@ -60,10 +57,10 @@ def run(argv=None):
     """
     args = parse_args(argv)
 
-    if args.show is not None:
-        from .desktop_integration import show
+    if args.preview is not None:
+        from .desktop_integration import preview
 
-        show(args.show)
+        preview(args.preview)
         return
 
     log.configure(log.resolve_level(verbose=args.verbose, quiet=args.quiet))

--- a/src/core/desktop_integration.py
+++ b/src/core/desktop_integration.py
@@ -90,7 +90,7 @@ def configure(items: set[str]):
 def item_text(item):
     """Return the text a configure item creates or uses, for inspection.
 
-    Backs `--show`, and lets packaging capture e.g. the refresh-service unit as
+    Backs `--preview`, and lets packaging capture e.g. the refresh-service unit as
     rendered for the running interpreter — without installing anything.
     """
     if item == "service":
@@ -103,11 +103,7 @@ def item_text(item):
     return (extension_source_dir() / "metadata.json").read_text()
 
 
-def show(items):
-    """Print each item's text to stdout, header-separated only when several."""
-    labelled = len(items) > 1
-    for item in items:
-        if labelled:
-            sys.stdout.write(f"# {item}\n")
-        text = item_text(item)
-        sys.stdout.write(text if text.endswith("\n") else text + "\n")
+def preview(item):
+    """Print the item's file content to stdout, with a trailing newline."""
+    text = item_text(item)
+    sys.stdout.write(text if text.endswith("\n") else text + "\n")

--- a/src/core/desktop_integration.py
+++ b/src/core/desktop_integration.py
@@ -11,13 +11,17 @@ opt-in, since not everyone wants EasySpeak in their menu or starting at login.
 
 import logging
 import sys
-from importlib import resources
+from functools import partial
 from pathlib import Path
+
+from easyspeak.data import data_text
 
 from .gnome_extension import (
     activate_extension,
+    extension_dest_dir,
     extension_source_dir,
     install_refresh_unit,
+    unit_path,
     unit_text,
 )
 
@@ -41,16 +45,11 @@ def desktop_path():
     return Path.home() / ".local" / "share" / "applications" / INSTALLED_DESKTOP_NAME
 
 
-def _data_text(name):
-    """Read a bundled data file (package data) as text."""
-    return (resources.files("easyspeak.data") / name).read_text()
-
-
 def _install_data_file(template, dest):
     """Copy a bundled desktop file into `dest`, best-effort."""
     try:
         dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(_data_text(template))
+        dest.write_text(data_text(template))
     except OSError as e:
         logger.warning("could not write %s (%s)", dest, e)
         return False
@@ -87,23 +86,23 @@ def configure(items: set[str]):
         install_autostart_file()
 
 
-def item_text(item):
-    """Return the text a configure item creates or uses, for inspection.
-
-    Backs `--preview`, and lets packaging capture e.g. the refresh-service unit as
-    rendered for the running interpreter — without installing anything.
-    """
-    if item == "service":
-        return unit_text()
-    if item == "autostart":
-        return _data_text(AUTOSTART_TEMPLATE)
-    if item == "desktop":
-        return _data_text(DESKTOP_TEMPLATE)
-    # extension: its metadata.json manifest is the one representative file.
+def _manifest_text():
+    """The GNOME extension's `metadata.json`, its one representative file."""
     return (extension_source_dir() / "metadata.json").read_text()
 
 
 def preview(item):
-    """Print the item's file content to stdout, with a trailing newline."""
-    text = item_text(item)
-    sys.stdout.write(text if text.endswith("\n") else text + "\n")
+    """Write an item's content to stdout and its target install path to stderr.
+
+    Backs `--preview`. The `TARGET:` line goes to stderr so packaging can capture
+    just the content off stdout; the content is written verbatim, since adding a
+    trailing newline is packaging's concern, not this function's.
+    """
+    render, path = {
+        "extension": (_manifest_text, extension_dest_dir),
+        "service": (unit_text, unit_path),
+        "desktop": (partial(data_text, DESKTOP_TEMPLATE), desktop_path),
+        "autostart": (partial(data_text, AUTOSTART_TEMPLATE), autostart_path),
+    }[item]
+    sys.stderr.write(f"TARGET: {path()}\n")
+    sys.stdout.write(render())

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -22,6 +22,8 @@ import sys
 from importlib import resources
 from pathlib import Path
 
+from easyspeak.data import data_text
+
 logger = logging.getLogger(__name__)
 
 EXTENSION_UUID = "gnome@easyspeak.dev"
@@ -151,7 +153,8 @@ def refresh_installed_extension():
     return refresh_extension_files(extension_source_dir(), extension_dest_dir())
 
 
-def _unit_path():
+def unit_path():
+    """User-local path of the extension-refresh unit."""
     return Path.home() / ".config" / "systemd" / "user" / REFRESH_UNIT_NAME
 
 
@@ -200,8 +203,8 @@ def unit_text():
     — on Wayland the shell only loads extensions at login. And both ExecStart
     arguments are quoted, since systemd splits ExecStart on whitespace.
     """
-    template = (resources.files("easyspeak.data") / REFRESH_UNIT_TEMPLATE).read_text()
-    return template.format(
+    return data_text(
+        REFRESH_UNIT_TEMPLATE,
         target=PRE_SHELL_TARGET,
         python=_stable_interpreter(),
         script=Path(__file__).resolve(),
@@ -260,30 +263,30 @@ def install_refresh_unit():
     if shutil.which("systemctl") is None:
         return None
 
-    unit_path = _unit_path()
+    path = unit_path()
 
     if _system_unit_exists():
         # The package owns the unit; don't shadow it with a user copy. Clear out a
         # stale one a prior pip/dev install left — `~/.config/systemd/user` takes
         # precedence over the packaged path and would point at a vanished
         # interpreter, so it must go for the packaged unit to take effect.
-        if unit_path.is_file():
+        if path.is_file():
             _run_systemctl("disable", REFRESH_UNIT_NAME)
             with contextlib.suppress(OSError):
-                unit_path.unlink()
+                path.unlink()
         return None
 
     desired = unit_text()
     try:
-        current = unit_path.read_text() if unit_path.is_file() else None
+        current = path.read_text() if path.is_file() else None
     except OSError:
         current = None
 
     changed = current != desired
     if changed:
         try:
-            unit_path.parent.mkdir(parents=True, exist_ok=True)
-            unit_path.write_text(desired)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(desired)
         except OSError:
             return None
         _run_systemctl("daemon-reload")

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,1 +1,9 @@
 """EasySpeak bundled data files, loaded at runtime via importlib.resources."""
+
+from importlib import resources
+
+
+def data_text(name, **fields):
+    """Read a bundled data file as text, substituting any `{fields}` it uses."""
+    text = (resources.files(__name__) / name).read_text()
+    return text.format(**fields) if fields else text

--- a/tests/integration/test_gnome_extension_unit.py
+++ b/tests/integration/test_gnome_extension_unit.py
@@ -38,7 +38,7 @@ def _remove_test_unit(unit_path):
 def test_install_refresh_unit_enables_via_real_systemctl(user_systemd, monkeypatch):
     """install_refresh_unit writes a unit a real user systemd manager enables."""
     monkeypatch.setattr(gnome_extension, "REFRESH_UNIT_NAME", TEST_UNIT)
-    unit_path = gnome_extension._unit_path()
+    unit_path = gnome_extension.unit_path()
 
     _remove_test_unit(unit_path)  # clear any leftover from a prior failed run
     try:

--- a/tests/unit/core/test_cli.py
+++ b/tests/unit/core/test_cli.py
@@ -113,30 +113,21 @@ def test_parse_args_configure_default(argv, expected):
     assert cli.parse_args(argv).configure == expected
 
 
-@patch("easyspeak.core.desktop_integration.show")
-def test_run_show_prints_items_and_skips_app(mock_show):
-    """--show prints the requested items and does not start the app."""
-    cli.run(["--show", "service"])
+@patch("easyspeak.core.desktop_integration.preview")
+def test_run_preview_prints_item_and_skips_app(mock_preview):
+    """--preview prints the requested item and does not start the app."""
+    cli.run(["--preview", "service"])
 
-    mock_show.assert_called_once_with({"service"})
-
-
-@patch("easyspeak.core.desktop_integration.show")
-def test_run_show_with_no_items_defaults_to_all(mock_show):
-    """--show with no items prints every item."""
-    cli.run(["--show"])
-
-    mock_show.assert_called_once_with({"extension", "service", "autostart", "desktop"})
+    mock_preview.assert_called_once_with("service")
 
 
 @pytest.mark.parametrize(
     ("argv", "expected"),
     [
-        ([], None),  # no --show
-        (["--show"], {"extension", "service", "autostart", "desktop"}),  # empty → all
-        (["--show", "desktop"], {"desktop"}),  # explicit item kept
+        ([], None),  # no --preview: run the app
+        (["--preview", "desktop"], "desktop"),  # the single item to print
     ],
 )
-def test_parse_args_show_default(argv, expected):
-    """parse_args expands a bare --show to all items."""
-    assert cli.parse_args(argv).show == expected
+def test_parse_args_preview(argv, expected):
+    """parse_args records the one --preview item, or None when absent."""
+    assert cli.parse_args(argv).preview == expected

--- a/tests/unit/core/test_desktop_integration.py
+++ b/tests/unit/core/test_desktop_integration.py
@@ -77,22 +77,31 @@ def test_configure_runs_exactly_the_requested_activities(items):
         ("extension", '"uuid"'),  # the metadata.json manifest
     ],
 )
-def test_item_text_returns_the_items_artifact(item, needle):
-    assert needle in di.item_text(item)
+def test_preview_renders_each_items_artifact(item, needle, capsys):
+    di.preview(item)
+
+    assert needle in capsys.readouterr().out
 
 
-def test_preview_prints_the_item_content(capsys):
-    di.preview("service")
+@pytest.mark.parametrize("text", ["no-newline", "has-newline\n"])
+def test_preview_writes_content_verbatim(capsys, text):
+    """The content goes to stdout unchanged — no trailing-newline fixup."""
+    with patch.object(di, "data_text", return_value=text):
+        di.preview("desktop")
 
-    assert capsys.readouterr().out.startswith("[Unit]")
+    assert capsys.readouterr().out == text
 
 
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [("no-newline", "no-newline\n"), ("has-newline\n", "has-newline\n")],
-)
-def test_preview_normalises_the_trailing_newline(capsys, text, expected):
-    with patch.object(di, "item_text", return_value=text):
-        di.preview("service")
+def test_preview_prints_target_path_to_stderr(capsys):
+    """The `TARGET:` line goes to stderr, keeping stdout to just the content."""
+    with (
+        patch.object(di, "data_text", return_value="body"),
+        patch.object(
+            di, "desktop_path", return_value=di.Path("/dest/easyspeak.desktop")
+        ),
+    ):
+        di.preview("desktop")
 
-    assert capsys.readouterr().out == expected
+    captured = capsys.readouterr()
+    assert captured.out == "body"
+    assert captured.err == "TARGET: /dest/easyspeak.desktop\n"

--- a/tests/unit/core/test_desktop_integration.py
+++ b/tests/unit/core/test_desktop_integration.py
@@ -81,28 +81,18 @@ def test_item_text_returns_the_items_artifact(item, needle):
     assert needle in di.item_text(item)
 
 
-def test_show_single_item_is_unlabelled(capsys):
-    di.show(["service"])
+def test_preview_prints_the_item_content(capsys):
+    di.preview("service")
 
-    out = capsys.readouterr().out
-    assert out.startswith("[Unit]")
-    assert "# service" not in out
-
-
-def test_show_multiple_items_are_labelled(capsys):
-    di.show(["autostart", "desktop"])
-
-    out = capsys.readouterr().out
-    assert "# autostart\n" in out
-    assert "# desktop\n" in out
+    assert capsys.readouterr().out.startswith("[Unit]")
 
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [("no-newline", "no-newline\n"), ("has-newline\n", "has-newline\n")],
 )
-def test_show_normalises_the_trailing_newline(capsys, text, expected):
+def test_preview_normalises_the_trailing_newline(capsys, text, expected):
     with patch.object(di, "item_text", return_value=text):
-        di.show(["service"])
+        di.preview("service")
 
     assert capsys.readouterr().out == expected

--- a/tests/unit/core/test_gnome_extension.py
+++ b/tests/unit/core/test_gnome_extension.py
@@ -287,7 +287,7 @@ def testunit_text_contains_ordering_and_execstart():
 
 def test_unit_path(tmp_path):
     with patch.object(gnome_extension.Path, "home", return_value=tmp_path):
-        assert gnome_extension._unit_path() == (
+        assert gnome_extension.unit_path() == (
             tmp_path / ".config" / "systemd" / "user" / UNIT_NAME
         )
 


### PR DESCRIPTION
Renames the one-shot `--show` desktop-integration option to `--preview`, which reads naturally alongside `--configure`. It prints the file content that would be configured/installed to stdout.

The option now takes exactly one `ITEM` instead of a list — concatenating several files' contents to stdout served no real purpose. The packaging bundle step and the usage docs are updated to match.