### PR TITLE
Gate implicit Whisper downloads behind `EASYSPEAK_OFFLINE`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,6 +88,12 @@ cd ~/easyspeak
 pip install -e .
 ```
 
+A Python-only installation has no bundled speech-recognition model, and EasySpeak
+stays offline by default ([`EASYSPEAK_OFFLINE=strict`](usage.md#configuration)),
+so on first run it reports the model as missing. Set `EASYSPEAK_OFFLINE=relaxed`
+to have it fetch `base.en` (about 140 MB) from Hugging Face for you, or install a
+language pack.
+
 ### 3. Piper TTS
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,6 +45,7 @@ the module that reads each (linked to its API reference).
 | Variable                         | Default                                | Effect                                     |
 | -------------------------------- | -------------------------------------- | ------------------------------------------ |
 | `EASYSPEAK_HOTKEY`               | `ctrl+shift`                           | Keys held to dictate without the wake word |
+| `EASYSPEAK_OFFLINE`              | `strict`                               | Stay offline; `relaxed` downloads models   |
 | `EASYSPEAK_PIPER_BIN`            | `piper`                                | Piper TTS binary                           |
 | `EASYSPEAK_PIPER_MODEL`          | bundled Amy voice                      | Piper voice `.onnx` for speech output      |
 | `EASYSPEAK_SOUNDS_DIR`           | `/usr/share/sounds/freedesktop/stereo` | Directory of the wake chime and error bell |

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,8 @@
         commonEnv = with pkgs; ''
           export UV_PYTHON='${python}/bin/python'
           export EASYSPEAK_PIPER_MODEL="''${EASYSPEAK_PIPER_MODEL:-${piperModelPath}}"
+          # No Whisper model is bundled here, so allow fetching it on demand.
+          export EASYSPEAK_OFFLINE="''${EASYSPEAK_OFFLINE:-relaxed}"
           export EASYSPEAK_SOUNDS_DIR="''${EASYSPEAK_SOUNDS_DIR:-${soundsNixDir}}"
           export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX="''${SETUPTOOLS_SCM_PRETEND_VERSION_FOR_EASYSPEAK_LINUX:-${pretendVersion}}"
           export CPPFLAGS="-I${portaudio}/include ''${CPPFLAGS:-}"

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,7 @@
             just
             eslint # JS linter for the GNOME Shell extension (see `just lint-js`)
             nodejs # `node --test` for the extension's JS helpers (see `just test-js`)
-            desktop-file-utils # desktop-file-validate for the launcher (see `just gate`)
+            desktop-file-utils # desktop-file-validate for the launcher (see `just check-desktop-integration`)
             glib.dev # glib-compile-schemas for the extension's GSettings schema (see `just compile-schemas`)
             dpkg # dpkg-deb to read .deb contents (see tests/packaging/test_deb.sh)
             rpm # rpm to read .rpm contents (see tests/packaging/test_rpm.sh)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -6,6 +6,7 @@ builds the faster-whisper model from them. Most are plain constants; these
 honor an `EASYSPEAK_*` environment variable:
 
 - `EASYSPEAK_HOTKEY`
+- `EASYSPEAK_OFFLINE`
 - `EASYSPEAK_PIPER_BIN`
 - `EASYSPEAK_PIPER_MODEL`
 - `EASYSPEAK_SOUNDS_DIR`
@@ -20,11 +21,18 @@ A plugin that needs host-environment setup does it in its own `setup()` hook —
 see [Writing Plugins](../plugins.md).
 """
 
+import logging
 import os
 import sys
 from pathlib import Path
 
 from faster_whisper import WhisperModel
+
+logger = logging.getLogger(__name__)
+
+# --- Network policy ---
+OFFLINE_MODE = os.environ.get("EASYSPEAK_OFFLINE", "strict").strip().lower()
+NETWORK_ALLOWED = OFFLINE_MODE == "relaxed"
 
 # --- Wake word ---
 WAKE_WORD = "hey_jarvis"  # OpenWakeWord model name
@@ -101,5 +109,28 @@ def load_whisper_model(
     compute_type: str = WHISPER_COMPUTE_TYPE,
     cpu_threads: int = WHISPER_CPU_THREADS,
 ) -> WhisperModel:
-    """Build a faster-whisper model from the configured (or given) settings."""
-    return WhisperModel(model_name, compute_type=compute_type, cpu_threads=cpu_threads)
+    """Build a faster-whisper model from the configured (or given) settings.
+
+    A model already on disk — bundled in a language pack or cached from an earlier
+    run — loads without any network access. When it is missing, EasySpeak stays
+    offline by default and raises an actionable message; setting
+    `EASYSPEAK_OFFLINE=relaxed` (see `NETWORK_ALLOWED`) lets it fetch a bare name
+    like `base.en` from Hugging Face instead.
+    """
+    kwargs = {"compute_type": compute_type, "cpu_threads": cpu_threads}
+    try:
+        return WhisperModel(model_name, local_files_only=True, **kwargs)
+    except FileNotFoundError:
+        if not NETWORK_ALLOWED:
+            msg = (
+                f"speech model {model_name!r} is not installed; set "
+                "EASYSPEAK_OFFLINE=relaxed to download it, or install a language pack"
+            )
+            raise RuntimeError(msg) from None
+        logger.warning(
+            "Speech model %r is not installed; downloading it from Hugging Face. "
+            "Install a language pack to avoid this, or set EASYSPEAK_OFFLINE=strict "
+            "to keep EasySpeak offline.",
+            model_name,
+        )
+        return WhisperModel(model_name, local_files_only=False, **kwargs)

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -495,7 +495,11 @@ class EasySpeak:
             WHISPER_COMPUTE_TYPE,
             WHISPER_CPU_THREADS or "auto",
         )
-        self.whisper = load_whisper_model()
+        try:
+            self.whisper = load_whisper_model()
+        except RuntimeError as exc:
+            logger.error("Cannot start EasySpeak: %s", exc)  # noqa: TRY400
+            raise SystemExit(1) from exc
 
         # The GNOME Shell extension powers both the panel indicator and the
         # mouse grid, so core (not a plugin) owns installing/refreshing/enabling

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -23,6 +23,7 @@ def _restore_config(monkeypatch):
         "EASYSPEAK_PIPER_MODEL",
         "EASYSPEAK_PIPER_BIN",
         "EASYSPEAK_HOTKEY",
+        "EASYSPEAK_OFFLINE",
     ]:
         monkeypatch.delenv(var, raising=False)
     importlib.reload(config)
@@ -57,11 +58,13 @@ def test_whisper_cpu_threads_negative_clamped(monkeypatch):
 
 
 def test_load_whisper_model_invokes_whisper():
-    """load_whisper_model passes its args through to WhisperModel()."""
+    """A locally-present model loads once, offline (local_files_only=True)."""
     with patch("easyspeak.core.config.WhisperModel") as mock_model:
         result = config.load_whisper_model("tiny.en", "float32", 4)
 
-    mock_model.assert_called_once_with("tiny.en", compute_type="float32", cpu_threads=4)
+    mock_model.assert_called_once_with(
+        "tiny.en", local_files_only=True, compute_type="float32", cpu_threads=4
+    )
     assert result is mock_model.return_value
 
 
@@ -72,9 +75,65 @@ def test_load_whisper_model_uses_module_defaults():
 
     mock_model.assert_called_once_with(
         config.WHISPER_MODEL,
+        local_files_only=True,
         compute_type=config.WHISPER_COMPUTE_TYPE,
         cpu_threads=config.WHISPER_CPU_THREADS,
     )
+
+
+def test_load_whisper_model_downloads_when_missing_and_relaxed(monkeypatch, caplog):
+    """Relaxed mode: an absent local model is re-fetched with downloads allowed."""
+    monkeypatch.setattr(config, "NETWORK_ALLOWED", True)
+    downloaded = object()
+    with (
+        patch(
+            "easyspeak.core.config.WhisperModel",
+            side_effect=[FileNotFoundError, downloaded],
+        ) as mock_model,
+        caplog.at_level("WARNING"),
+    ):
+        result = config.load_whisper_model("base.en", "int8", 0)
+
+    assert result is downloaded
+    assert mock_model.call_args_list[0].kwargs["local_files_only"] is True
+    assert mock_model.call_args_list[1].kwargs["local_files_only"] is False
+    assert "downloading" in caplog.text.lower()
+
+
+def test_load_whisper_model_strict_raises_when_missing(monkeypatch):
+    """Strict mode: an absent local model raises rather than downloading."""
+    monkeypatch.setattr(config, "NETWORK_ALLOWED", False)
+    with (
+        patch(
+            "easyspeak.core.config.WhisperModel", side_effect=FileNotFoundError
+        ) as mock_model,
+        pytest.raises(RuntimeError, match="EASYSPEAK_OFFLINE=relaxed"),
+    ):
+        config.load_whisper_model("base.en")
+
+    mock_model.assert_called_once()
+
+
+def test_offline_default_blocks_network(monkeypatch):
+    """Unset EASYSPEAK_OFFLINE: defaults to strict, so no network access."""
+    monkeypatch.delenv("EASYSPEAK_OFFLINE", raising=False)
+    importlib.reload(config)
+    assert config.NETWORK_ALLOWED is False
+
+
+@pytest.mark.parametrize("value", ["relaxed", "RELAXED", "  relaxed  "])
+def test_offline_relaxed_allows_network(monkeypatch, value):
+    """EASYSPEAK_OFFLINE=relaxed (any case, trimmed) permits network access."""
+    monkeypatch.setenv("EASYSPEAK_OFFLINE", value)
+    importlib.reload(config)
+    assert config.NETWORK_ALLOWED is True
+
+
+def test_offline_unknown_value_stays_strict(monkeypatch):
+    """Any value other than relaxed is treated as strict (no network)."""
+    monkeypatch.setenv("EASYSPEAK_OFFLINE", "yes")
+    importlib.reload(config)
+    assert config.NETWORK_ALLOWED is False
 
 
 def test_piper_model_env_override(monkeypatch):

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -813,6 +813,20 @@ class TestEasySpeakRun:
 
     @patch("easyspeak.core.main.WakeWordModel")
     @patch("easyspeak.core.main.load_whisper_model")
+    def test_run_aborts_when_speech_model_missing(
+        self, mock_whisper_model, mock_wakeword_model, caplog
+    ):
+        """A missing speech model aborts startup cleanly, not mid-run."""
+        mock_whisper_model.side_effect = RuntimeError("install a language pack")
+
+        with caplog.at_level("ERROR"), pytest.raises(SystemExit) as excinfo:
+            EasySpeak().run()
+
+        assert excinfo.value.code == 1
+        assert "language pack" in caplog.text
+
+    @patch("easyspeak.core.main.WakeWordModel")
+    @patch("easyspeak.core.main.load_whisper_model")
     @patch.object(EasySpeak, "load_plugins")
     def test_run_no_plugins(
         self, mock_load_plugins, mock_whisper_model, mock_wakeword_model, readlog


### PR DESCRIPTION
`EASYSPEAK_OFFLINE` is EasySpeak's single switch for whether it may reach the network, and it defaults to `strict` — nothing is fetched at runtime unless you opt in, matching EasySpeak's fully-local ethos.

The recognition-model load probes locally first (`local_files_only=True`), so a bundled or previously-cached model loads with no network access at all. When the model is missing under `strict` (the default), startup aborts cleanly: `core.main` logs an actionable message — <q>set `EASYSPEAK_OFFLINE=relaxed` to download it, or install a language pack</q> — and exits non-zero, mirroring the existing no-microphone handling. Setting `EASYSPEAK_OFFLINE=relaxed` opts into the on-demand `base.en` download from Hugging Face, announced with a warning.