### PR TITLE
Transparent version pinning (`pins.toml`)

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -18,6 +18,7 @@ jobs:
         task:
         - audit
         - requirements
+        - update-pins
       fail-fast: false
     steps:
     - uses: actions/checkout@v6
@@ -30,3 +31,5 @@ jobs:
         sudo apt update
         sudo apt install -y portaudio19-dev
     - run: just ${{ matrix.task }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}  # lifts the unauthenticated API rate limit

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -37,9 +37,6 @@ only when `pins.toml` does.
 - uv itself: latest in CI (`astral-sh/setup-uv`) and in the build container
   (install script); pinned only for the dev shell via `flake.lock`.
 - GitHub Actions: pinned by major version tag, floating within it.
-- The distro bundle's Python dependency resolution:
-  `packaging/stage-bundle.sh` installs the built wheel with `uv pip install`,
-  resolving at build time rather than from `uv.lock`.
 - The Whisper model at *runtime*: with `EASYSPEAK_OFFLINE=relaxed` and no
   local model, faster-whisper fetches the latest snapshot from Hugging Face
   (`src/core/config.py`); installing the language package avoids this

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,46 @@
+# Dependencies
+
+Every version EasySpeak pins lives in one of four data files; nothing is
+pinned inside scripts or code. When a version changes, exactly one of these
+files changes — the consuming scripts stay untouched.
+
+| Lock file        | Maintained          | Pins                                                  |
+|------------------|---------------------|-------------------------------------------------------|
+| `pins.toml`      | by hand             | Speech models, bundled CPython, build container, nfpm |
+| `pyproject.toml` | by hand             | Supported Python range, dependency lower bounds       |
+| `uv.lock`        | `just requirements` | Exact Python library versions, wheel hashes           |
+| `flake.lock`     | `nix flake update`  | nixpkgs revision for dev shell and `nix run`          |
+
+## pins.toml
+
+The hand-maintained lock file for everything that is *downloaded* by the
+packaging scripts and the Nix flake rather than resolved by a package manager.
+Each entry pins an immutable revision (a Hugging Face commit or tag, a release
+version, an image tag), plus SHA-256 checksums where the artifact is a single
+file. Its consumers:
+
+- `flake.nix` — fetches the Piper voice via `builtins.fromTOML`,
+  checksum-verified by `fetchurl`.
+- `packaging/stage-lang.sh` — downloads the speech models for each
+  `easyspeak-lang-*` package; Piper files are checksum-verified with
+  `sha256sum`.
+- `packaging/stage-bundle.sh` — materialises the pinned standalone CPython.
+- `packaging/build-in-docker.sh` — pulls the pinned build-container image and
+  nfpm release.
+
+The `easyspeak-lang-*` packages carry the app's release version, so a newer
+package version does not imply newer model content — the model content changes
+only when `pins.toml` does.
+
+## Deliberately floating
+
+- uv itself: latest in CI (`astral-sh/setup-uv`) and in the build container
+  (install script); pinned only for the dev shell via `flake.lock`.
+- GitHub Actions: pinned by major version tag, floating within it.
+- The distro bundle's Python dependency resolution:
+  `packaging/stage-bundle.sh` installs the built wheel with `uv pip install`,
+  resolving at build time rather than from `uv.lock`.
+- The Whisper model at *runtime*: with `EASYSPEAK_OFFLINE=relaxed` and no
+  local model, faster-whisper fetches the latest snapshot from Hugging Face
+  (`src/core/config.py`); installing the language package avoids this
+  entirely.

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -6,7 +6,7 @@ files changes — the consuming scripts stay untouched.
 
 | Lock file        | Maintained          | Pins                                                  |
 |------------------|---------------------|-------------------------------------------------------|
-| `pins.toml`      | by hand             | Speech models, bundled CPython, build container, nfpm |
+| `pins.toml`      | `just update-pins`  | Speech models, bundled CPython, build container, nfpm |
 | `pyproject.toml` | by hand             | Supported Python range, dependency lower bounds       |
 | `uv.lock`        | `just requirements` | Exact Python library versions, wheel hashes           |
 | `flake.lock`     | `nix flake update`  | nixpkgs revision for dev shell and `nix run`          |
@@ -31,6 +31,11 @@ file. Its consumers:
 The `easyspeak-lang-*` packages carry the app's release version, so a newer
 package version does not imply newer model content — the model content changes
 only when `pins.toml` does.
+
+`just update-pins` bumps every entry to its current upstream version and
+recomputes checksums; the build container advances only when its LTS leaves
+standard support, since its glibc is the packages' compatibility floor.
+Review the diff before committing.
 
 ## Deliberately floating
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-exclude CHANGELOG.md CONTRIBUTING.md flake.* .gitignore .gitattributes justfile MANIFEST.in *.mjs package.json uv.lock *.yaml *.yml
+exclude CHANGELOG.md CONTRIBUTING.md DEPENDENCIES.md flake.* .gitignore .gitattributes justfile MANIFEST.in *.mjs package.json pins.toml uv.lock *.yaml *.yml
 prune docs
 prune .github
 prune packaging

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,5 @@
+<!--
+This page includes the repository-root DEPENDENCIES.md verbatim via
+pymdownx.snippets, so the root file stays the single source of truth.
+-->
+--8<-- "DEPENDENCIES.md"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782467914,
-        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,26 +76,28 @@
         # EASYSPEAK_SOUNDS_DIR (commonEnv) redirects to the Nix store one.
         soundsNixDir = "${pkgs.sound-theme-freedesktop}/share/sounds/freedesktop/stereo";
 
-        # Piper voice (Amy, US English), fetched at build time. Piper wants the
-        # .onnx and .onnx.json side by side, so linkFarm them and point
-        # EASYSPEAK_PIPER_MODEL at the .onnx.
-        piperVoice = pkgs.linkFarm "piper-voice-en-US-amy-medium" [
+        # Piper voice, fetched at build time from the revision pinned in
+        # pins.toml. Piper wants the .onnx and .onnx.json side by side, so
+        # linkFarm them and point EASYSPEAK_PIPER_MODEL at the .onnx.
+        piperPin = (builtins.fromTOML (builtins.readFile ./pins.toml)).lang.en.piper;
+        piperBaseUrl = "https://huggingface.co/${piperPin.repo}/resolve/${piperPin.revision}/${piperPin.path}";
+        piperVoice = pkgs.linkFarm "piper-voice-${piperPin.voice}" [
           {
-            name = "en_US-amy-medium.onnx";
+            name = "${piperPin.voice}.onnx";
             path = pkgs.fetchurl {
-              url = "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx";
-              sha256 = "063c43bbs0nb09f86l4avnf9mxah38b1h9ffl3kgpixqaxxy99mk";
+              url = "${piperBaseUrl}/${piperPin.voice}.onnx";
+              sha256 = piperPin.onnx_sha256;
             };
           }
           {
-            name = "en_US-amy-medium.onnx.json";
+            name = "${piperPin.voice}.onnx.json";
             path = pkgs.fetchurl {
-              url = "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/en/en_US/amy/medium/en_US-amy-medium.onnx.json";
-              sha256 = "0xvxjxk59byydx9gj6rdvvydp5zm8mzsrf9vyy6x6299sjs3x8lm";
+              url = "${piperBaseUrl}/${piperPin.voice}.onnx.json";
+              sha256 = piperPin.json_sha256;
             };
           }
         ];
-        piperModelPath = "${piperVoice}/en_US-amy-medium.onnx";
+        piperModelPath = "${piperVoice}/${piperPin.voice}.onnx";
 
         # Env shared by the `nix run` wrapper and the dev shell, so `uv run
         # easyspeak` behaves identically in both; `:-`/`:+` defaulting lets a

--- a/justfile
+++ b/justfile
@@ -60,6 +60,12 @@ requirements:
     uvx uv lock --upgrade
     git diff --color --exit-code uv.lock
 
+# Bump the hand-maintained pins in pins.toml to their current upstream versions
+[group('safety')]
+update-pins:
+    uv run --no-project --with packaging python packaging/update_pins.py
+    git diff --color pins.toml
+
 # Run test suite and show coverage (unit tests, integration, acceptance)
 [group('tests')]
 test: test-js pytest coverage integration acceptance

--- a/justfile
+++ b/justfile
@@ -118,11 +118,14 @@ check-links *args: docs
     uvx --from markdown markdown_py CONTRIBUTING.md > build/linkcheck/contributing.html
     # No flag drops linkchecker's copyright banner; omit the 'intro' output part instead.
     printf '[text]\nparts=url,parenturl,realurl,result,warning,info,stats,outro\n' > build/.linkcheckrc
-    # Skips: 404 page (absolute site_url links 404 on disk), bencher.dev (bot 403s),
-    # GitHub /compare (404s until the just-pushed tag propagates) and /pull links
-    # (permanent, never outdate); custom UA dodges freedesktop's WAF (418 to "Mozilla").
+    # Skips: 404 page (absolute site_url links 404 on disk), the site's own /latest/
+    # pages (the local build IS /latest/, checked on disk; canonicals of new pages
+    # 404 online until the next deploy), bencher.dev (bot 403s), GitHub /compare
+    # (404s until the just-pushed tag propagates) and /pull links (permanent, never
+    # outdate); custom UA dodges freedesktop's WAF (418 to "Mozilla").
     uvx linkchecker --config build/.linkcheckrc --check-extern --no-warnings \
         --ignore-url '/404\.html' \
+        --ignore-url 'easyspeak\.dev/latest/' \
         --ignore-url 'bencher\.dev' \
         --ignore-url 'github\.com/.*/compare/' \
         --ignore-url 'github\.com/.*/pull/' \

--- a/justfile
+++ b/justfile
@@ -16,6 +16,18 @@ all: codestyle safety test check-docs check-desktop-integration compile-schemas 
 clean *args:
     uvx pyclean . {{ args }} --debris all --erase .benchmarks 'build/**/*' build result results.json 'site/**/*' site --yes
 
+# Check project dependencies are up-to-date (uv.lock)
+[group('lifecycle')]
+requirements:
+    uvx uv lock --upgrade
+    git diff --color --exit-code uv.lock
+
+# Bump the hand-maintained pins in pins.toml to their current upstream versions
+[group('lifecycle')]
+update-pins:
+    uv run --no-project --with packaging python packaging/update_pins.py
+    git diff --color --exit-code pins.toml
+
 # Run all code style checks (format, lint, js, yaml)
 [group('codestyle')]
 codestyle: format lint lint-js lint-yaml
@@ -45,26 +57,14 @@ lint-yaml *args:
 types *args:
     uv run --extra=mypy mypy src {{ args }}
 
-# Run all safety checks (types, requirements, audit)
+# Run all safety checks (update-pins, requirements, audit, types)
 [group('safety')]
-safety: types requirements audit
+safety: update-pins requirements audit types
 
 # Check project dependencies for known vulnerabilities
 [group('safety')]
 audit *args:
     uv run --with=pip-audit pip-audit --progress-spinner=off --skip-editable {{ args }}
-
-# Check project dependencies are up-to-date (uv.lock)
-[group('safety')]
-requirements:
-    uvx uv lock --upgrade
-    git diff --color --exit-code uv.lock
-
-# Bump the hand-maintained pins in pins.toml to their current upstream versions
-[group('safety')]
-update-pins:
-    uv run --no-project --with packaging python packaging/update_pins.py
-    git diff --color pins.toml
 
 # Run test suite and show coverage (unit tests, integration, acceptance)
 [group('tests')]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
 - Home: index.md
 - Installation: installation.md
 - Packaging: packaging.md
+- Dependencies: dependencies.md
 - Usage: usage.md
 - Screenshots: screenshots.md
 - Commands: commands.md

--- a/packaging/build-in-docker.sh
+++ b/packaging/build-in-docker.sh
@@ -8,7 +8,9 @@ set -euo pipefail
 
 VERSION="${1:-0.0.0}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-IMAGE="${IMAGE:-ubuntu:24.04}"
+# Grep, not a TOML parser: this host side runs with nothing but docker + git
+# (the CI packages job has no uv), and the key is unique in pins.toml.
+IMAGE="${IMAGE:-$(grep -Po '^ubuntu_image = "\K[^"]+' "$REPO_ROOT/pins.toml")}"
 
 command -v docker >/dev/null || { echo "error: docker is required" >&2; exit 1; }
 mkdir -p "$REPO_ROOT/dist"
@@ -25,8 +27,8 @@ docker run --rm \
     curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1
     export PATH="$HOME/.local/bin:$PATH"
 
-    # Install nfpm (static Go binary) from the latest GitHub release.
-    NFPM_VER=$(curl -fsSL https://api.github.com/repos/goreleaser/nfpm/releases/latest | grep -oP "\"tag_name\":\s*\"v\K[^\"]+")
+    # Install nfpm (static Go binary) at the version pinned in pins.toml.
+    NFPM_VER=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open(\"/src/pins.toml\", \"rb\"))[\"toolchain\"][\"nfpm\"])")
     curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VER}/nfpm_${NFPM_VER}_linux_x86_64.tar.gz" \
       | tar -xz -C /usr/local/bin nfpm
 

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -10,10 +10,19 @@
 set -euo pipefail
 
 PREFIX="${PREFIX:-/opt/easyspeak}"
-PY_VERSION="${PY_VERSION:-3.14}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 command -v uv >/dev/null || { echo "error: uv is required (https://astral.sh/uv)" >&2; exit 1; }
+
+# The bundled CPython version is pinned in pins.toml at the repo root.
+PY_VERSION="${PY_VERSION:-$(uv run --no-project python - "$REPO_ROOT/pins.toml" <<'PY'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as f:
+    print(tomllib.load(f)["python"]["bundle"])
+PY
+)}"
 
 echo ">> building wheel"
 ( cd "$REPO_ROOT" && uv build --wheel --out-dir "$REPO_ROOT/dist" )

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -24,11 +24,6 @@ with open(sys.argv[1], "rb") as f:
 PY
 )}"
 
-echo ">> building wheel"
-( cd "$REPO_ROOT" && uv build --wheel --out-dir "$REPO_ROOT/dist" )
-WHEEL=$(ls -t "$REPO_ROOT"/dist/easyspeak_linux-*.whl | head -1)
-echo "   $WHEEL"
-
 echo ">> materialising standalone CPython $PY_VERSION at $PREFIX/python"
 uv python install "$PY_VERSION"
 SRC_PY=$(dirname "$(dirname "$(uv python find "$PY_VERSION")")")
@@ -41,9 +36,15 @@ cp -rL "$SRC_PY"/. "$PREFIX/python/"
 echo ">> creating venv from the bundled interpreter"
 "$PREFIX/python/bin/python3" -m venv "$PREFIX/venv"
 
-echo ">> installing app + runtime extras into the venv"
-# piper-tts: provides the `piper` binary inside the venv (no system piper packaged).
-uv pip install --python "$PREFIX/venv/bin/python" "$WHEEL" piper-tts
+echo ">> installing the app and its locked dependencies into the venv"
+# --frozen installs exactly what uv.lock records — the same resolution CI
+# tests — plus the bundle extra (piper-tts, providing the `piper` binary; no
+# system piper is packaged). --no-editable builds the project into a wheel and
+# installs it; --python keeps uv on the bundled interpreter so it reuses the
+# venv above instead of recreating it from a cached toolchain.
+( cd "$REPO_ROOT" && UV_PROJECT_ENVIRONMENT="$PREFIX/venv" \
+    uv sync --frozen --no-dev --no-editable --extra bundle \
+    --python "$PREFIX/python/bin/python3" )
 
 echo ">> rendering the GNOME-extension refresh unit for the bundled interpreter"
 # `--preview service` prints the unit the bundled interpreter would install, so the

--- a/packaging/stage-bundle.sh
+++ b/packaging/stage-bundle.sh
@@ -33,15 +33,9 @@ mkdir -p "$PREFIX/python"
 # (plain cp -r keeps symlinks pointing back into uv's cache, breaking relocation.)
 cp -rL "$SRC_PY"/. "$PREFIX/python/"
 
-echo ">> creating venv from the bundled interpreter"
-"$PREFIX/python/bin/python3" -m venv "$PREFIX/venv"
-
 echo ">> installing the app and its locked dependencies into the venv"
-# --frozen installs exactly what uv.lock records — the same resolution CI
-# tests — plus the bundle extra (piper-tts, providing the `piper` binary; no
-# system piper is packaged). --no-editable builds the project into a wheel and
-# installs it; --python keeps uv on the bundled interpreter so it reuses the
-# venv above instead of recreating it from a cached toolchain.
+# uv creates the venv from the bundled interpreter, keeping its paths under
+# $PREFIX; the bundle extra adds piper-tts (no system piper is packaged).
 ( cd "$REPO_ROOT" && UV_PROJECT_ENVIRONMENT="$PREFIX/venv" \
     uv sync --frozen --no-dev --no-editable --extra bundle \
     --python "$PREFIX/python/bin/python3" )

--- a/packaging/stage-lang.sh
+++ b/packaging/stage-lang.sh
@@ -12,39 +12,50 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 command -v uv >/dev/null   || { echo "error: uv is required" >&2; exit 1; }
 command -v curl >/dev/null || { echo "error: curl is required" >&2; exit 1; }
 
-# Per-language model selection. faster-whisper models live in Systran HF repos;
-# Piper voices live under rhasspy/piper-voices at <path>/<voice>.onnx(.json).
-case "$CODE" in
-  en)
-    WHISPER_NAME="base.en"
-    WHISPER_REPO="Systran/faster-whisper-base.en"
-    PIPER_VOICE="en_US-amy-medium"
-    PIPER_PATH="en/en_US/amy/medium"
-    ;;
-  *)
-    echo "error: no model mapping for language '$CODE'" >&2
-    exit 1
-    ;;
-esac
+# Per-language model selection, read from the pins.toml lock file at the repo
+# root (repos, revisions, and checksums live there, not here).
+MODEL_VARS="$(uv run --no-project python - "$REPO_ROOT/pins.toml" "$CODE" <<'PY'
+import sys
+import tomllib
+
+pins_file, code = sys.argv[1], sys.argv[2]
+with open(pins_file, "rb") as f:
+    lang = tomllib.load(f)["lang"].get(code)
+if lang is None:
+    sys.exit(f"error: no model pins for language '{code}' in pins.toml")
+whisper, piper = lang["whisper"], lang["piper"]
+print(f'WHISPER_NAME="{whisper["model"]}"')
+print(f'WHISPER_REPO="{whisper["repo"]}"')
+print(f'WHISPER_REV="{whisper["revision"]}"')
+print(f'PIPER_VOICE="{piper["voice"]}"')
+print(f'PIPER_BASE="https://huggingface.co/{piper["repo"]}/resolve/{piper["revision"]}/{piper["path"]}"')
+print(f'PIPER_ONNX_SHA256="{piper["onnx_sha256"]}"')
+print(f'PIPER_JSON_SHA256="{piper["json_sha256"]}"')
+PY
+)"
+eval "$MODEL_VARS"
 
 STAGE="$REPO_ROOT/dist/stage-lang-$CODE"
 MODELS="$STAGE/opt/easyspeak/models"
 rm -rf "$STAGE"
 mkdir -p "$MODELS/whisper" "$MODELS/piper"
 
-echo ">> [$CODE] downloading Whisper model ($WHISPER_NAME) from $WHISPER_REPO"
-uv run --no-project --with huggingface_hub python - "$WHISPER_REPO" "$MODELS/whisper/$WHISPER_NAME" <<'PY'
+echo ">> [$CODE] downloading Whisper model ($WHISPER_NAME) from $WHISPER_REPO @ $WHISPER_REV"
+uv run --no-project --with huggingface_hub python - "$WHISPER_REPO" "$WHISPER_REV" "$MODELS/whisper/$WHISPER_NAME" <<'PY'
 import sys
 from huggingface_hub import snapshot_download
-repo, dest = sys.argv[1], sys.argv[2]
+repo, rev, dest = sys.argv[1], sys.argv[2], sys.argv[3]
 # Only the files faster-whisper needs; skip README/.gitattributes.
-snapshot_download(repo, local_dir=dest, allow_patterns=["*.bin", "*.json", "*.txt"])
+snapshot_download(repo, revision=rev, local_dir=dest, allow_patterns=["*.bin", "*.json", "*.txt"])
 PY
 rm -rf "$MODELS/whisper/$WHISPER_NAME/.cache"
 
 echo ">> [$CODE] downloading Piper voice ($PIPER_VOICE)"
-PIPER_BASE="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/$PIPER_PATH"
 curl -fsSL "$PIPER_BASE/$PIPER_VOICE.onnx"      -o "$MODELS/piper/$PIPER_VOICE.onnx"
 curl -fsSL "$PIPER_BASE/$PIPER_VOICE.onnx.json" -o "$MODELS/piper/$PIPER_VOICE.onnx.json"
+sha256sum --check --quiet - <<EOF
+$PIPER_ONNX_SHA256  $MODELS/piper/$PIPER_VOICE.onnx
+$PIPER_JSON_SHA256  $MODELS/piper/$PIPER_VOICE.onnx.json
+EOF
 
 echo ">> [$CODE] language data staged at $STAGE ($(du -sh "$MODELS" | cut -f1))"

--- a/packaging/update_pins.py
+++ b/packaging/update_pins.py
@@ -19,6 +19,8 @@ committed; review with `git diff pins.toml`.
 import datetime
 import hashlib
 import json
+import os
+import subprocess
 import urllib.request
 
 import tomllib
@@ -28,10 +30,26 @@ from packaging.version import Version
 PINS = "pins.toml"
 
 
-def fetch_json(url):
+def fetch_json(url, token=None):
     """Return the JSON document at `url`."""
-    with urllib.request.urlopen(url) as response:
+    request = urllib.request.Request(url)
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request) as response:
         return json.load(response)
+
+
+def github_token():
+    """Return a GitHub token from `GITHUB_TOKEN` or the gh CLI, else None."""
+    if token := os.environ.get("GITHUB_TOKEN"):
+        return token
+    try:
+        gh = subprocess.run(
+            ["gh", "auth", "token"], capture_output=True, text=True, check=True
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return gh.stdout.strip() or None
 
 
 def sha256_of(url):
@@ -73,7 +91,10 @@ def supported_ubuntu_image(current):
 
 def latest_nfpm():
     """Return the newest nfpm release version."""
-    release = fetch_json("https://api.github.com/repos/goreleaser/nfpm/releases/latest")
+    release = fetch_json(
+        "https://api.github.com/repos/goreleaser/nfpm/releases/latest",
+        token=github_token(),
+    )
     return release["tag_name"].removeprefix("v")
 
 

--- a/packaging/update_pins.py
+++ b/packaging/update_pins.py
@@ -1,0 +1,175 @@
+"""Bump the hand-maintained pins in pins.toml to their current upstream versions.
+
+One policy per pin:
+
+- `python.bundle` — newest stable CPython minor that satisfies the project's
+  `requires-python` range.
+- `toolchain.ubuntu_image` — advances only when the pinned LTS leaves standard
+  support: the container's glibc is the packages' compatibility floor, so
+  "newest LTS" would silently drop older target distros.
+- `toolchain.nfpm` — latest GitHub release.
+- `lang.*.whisper.revision` — the model repo's current snapshot commit.
+- `lang.*.piper.revision` — the voice repo's newest tag; the file checksums
+  are re-downloaded and recomputed when the tag moves.
+
+Values are rewritten in place, so comments in pins.toml survive. Nothing is
+committed; review with `git diff pins.toml`.
+"""
+
+import datetime
+import hashlib
+import json
+import urllib.request
+
+import tomllib
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+PINS = "pins.toml"
+
+
+def fetch_json(url):
+    """Return the JSON document at `url`."""
+    with urllib.request.urlopen(url) as response:
+        return json.load(response)
+
+
+def sha256_of(url):
+    """Return the hex SHA-256 of the file at `url`."""
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(url) as response:
+        for chunk in iter(lambda: response.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def latest_python(requires_python):
+    """Return the newest stable CPython cycle allowed by `requires_python`."""
+    cycles = fetch_json("https://endoflife.date/api/python.json")
+    allowed = SpecifierSet(requires_python)
+    return max(
+        (c["cycle"] for c in cycles if Version(c["cycle"]) in allowed),
+        key=Version,
+    )
+
+
+def supported_ubuntu_image(current):
+    """Advance the LTS base image only once the pinned one has gone EOL."""
+    pinned = current.removeprefix("ubuntu:")
+    today = datetime.datetime.now(tz=datetime.timezone.utc).date()
+    supported = [
+        c["cycle"]
+        for c in fetch_json("https://endoflife.date/api/ubuntu.json")
+        if c.get("lts") and datetime.date.fromisoformat(c["eol"]) > today
+    ]
+    if pinned in supported:
+        return current
+    oldest = min(
+        (c for c in supported if Version(c) > Version(pinned)),
+        key=Version,
+    )
+    return f"ubuntu:{oldest}"
+
+
+def latest_nfpm():
+    """Return the newest nfpm release version."""
+    release = fetch_json("https://api.github.com/repos/goreleaser/nfpm/releases/latest")
+    return release["tag_name"].removeprefix("v")
+
+
+def whisper_revision(repo):
+    """Return the current snapshot commit of the Hugging Face `repo`."""
+    return fetch_json(f"https://huggingface.co/api/models/{repo}")["sha"]
+
+
+def latest_piper_tag(repo):
+    """Return the newest release tag of the Hugging Face `repo`."""
+    refs = fetch_json(f"https://huggingface.co/api/models/{repo}/refs")
+    return max(
+        (tag["name"] for tag in refs["tags"]),
+        key=lambda name: Version(name.removeprefix("v")),
+    )
+
+
+def bump(text, key, old, new, label):
+    """Replace `key = "old"` in `text` with `new`, reporting the change."""
+    if old == new:
+        print(f"  ok    {label} = {old}")
+        return text
+    print(f"  bump  {label}: {old} -> {new}")
+    return text.replace(f'{key} = "{old}"', f'{key} = "{new}"', 1)
+
+
+def main():
+    """Refresh every pin and rewrite pins.toml when anything moved."""
+    with open(PINS, "rb") as f:
+        pins = tomllib.load(f)
+    with open("pyproject.toml", "rb") as f:
+        requires_python = tomllib.load(f)["project"]["requires-python"]
+    with open(PINS, encoding="utf-8") as f:
+        text = original = f.read()
+
+    text = bump(
+        text,
+        "bundle",
+        pins["python"]["bundle"],
+        latest_python(requires_python),
+        "python.bundle",
+    )
+    text = bump(
+        text,
+        "ubuntu_image",
+        pins["toolchain"]["ubuntu_image"],
+        supported_ubuntu_image(pins["toolchain"]["ubuntu_image"]),
+        "toolchain.ubuntu_image",
+    )
+    text = bump(
+        text, "nfpm", pins["toolchain"]["nfpm"], latest_nfpm(), "toolchain.nfpm"
+    )
+
+    for code, lang in pins["lang"].items():
+        whisper, piper = lang["whisper"], lang["piper"]
+        text = bump(
+            text,
+            "revision",
+            whisper["revision"],
+            whisper_revision(whisper["repo"]),
+            f"lang.{code}.whisper.revision",
+        )
+        new_tag = latest_piper_tag(piper["repo"])
+        if new_tag != piper["revision"]:
+            base = (
+                f"https://huggingface.co/{piper['repo']}/resolve"
+                f"/{new_tag}/{piper['path']}/{piper['voice']}"
+            )
+            text = bump(
+                text,
+                "revision",
+                piper["revision"],
+                new_tag,
+                f"lang.{code}.piper.revision",
+            )
+            text = bump(
+                text,
+                "onnx_sha256",
+                piper["onnx_sha256"],
+                sha256_of(f"{base}.onnx"),
+                f"lang.{code}.piper.onnx_sha256",
+            )
+            text = bump(
+                text,
+                "json_sha256",
+                piper["json_sha256"],
+                sha256_of(f"{base}.onnx.json"),
+                f"lang.{code}.piper.json_sha256",
+            )
+        else:
+            print(f"  ok    lang.{code}.piper.revision = {new_tag}")
+
+    if text != original:
+        with open(PINS, "w", encoding="utf-8") as f:
+            f.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/pins.toml
+++ b/pins.toml
@@ -1,0 +1,31 @@
+# Pinned versions of everything the packaging scripts and the Nix flake
+# download. Bump versions here; the consumers stay untouched:
+#
+#   flake.nix                     Piper voice for `nix run` / dev shell
+#   packaging/stage-lang.sh       speech models per language pack
+#   packaging/stage-bundle.sh     bundled CPython for the .deb/.rpm
+#   packaging/build-in-docker.sh  build container image and nfpm
+
+[python]
+bundle = "3.14"
+
+[toolchain]
+ubuntu_image = "ubuntu:24.04"
+nfpm = "2.47.0"
+
+# Speech models, one table pair per language pack (easyspeak-lang-<code>).
+# revision is an immutable Hugging Face commit or tag; the sha256 hashes are
+# hex, verified by both Nix fetchurl and sha256sum.
+
+[lang.en.whisper]
+model = "base.en"
+repo = "Systran/faster-whisper-base.en"
+revision = "3d3d5dee26484f91867d81cb899cfcf72b96be6c"
+
+[lang.en.piper]
+voice = "en_US-amy-medium"
+repo = "rhasspy/piper-voices"
+revision = "v1.0.0"
+path = "en/en_US/amy/medium"
+onnx_sha256 = "b3a6e47b57b8c7fbe6a0ce2518161a50f59a9cdd8a50835c02cb02bdd6206c18"
+json_sha256 = "95a23eb4d42909d38df73bb9ac7f45f597dbfcde2d1bf9526fdeaf5466977d77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,11 @@ benchmark = [
   "pytest>=8",
   "pytest-benchmark>=5",
 ]
+# The distro bundle ships the `piper` binary inside its venv — no system piper
+# is packaged (see packaging/stage-bundle.sh). An extra so uv.lock pins it.
+bundle = [
+  "piper-tts>=1.4",
+]
 docs = [
   "mike>=2.1",
   # Cap MkDocs below 2.0: the 2.0 line may drop the plugin API that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,8 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "packaging/**" = [
   "INP001",  # standalone build scripts, run directly — not an importable package
+  "S310",    # https URLs to known registries (endoflife.date, GitHub, Hugging Face)
+  "T201",    # build scripts report progress on the console
 ]
 "src/plugins/00_*.py" = ["N999"]    # numeric prefix sets plugin load order
 "src/plugins/zz_base.py" = ["N999"] # zz_ prefix loads the base plugin last

--- a/tests/packaging/test_python_sdist.sh
+++ b/tests/packaging/test_python_sdist.sh
@@ -8,7 +8,7 @@ has() { grep -q "$1" <<<"$files" || { echo "  MISSING: $1" >&2; exit 1; }; }
 lacks() { ! grep -qE "$1" <<<"$files" || { echo "  FORBIDDEN: $1" >&2; exit 1; }; }
 
 echo "The sdist ships no markdown, docs, tests, or dev tooling config"
-lacks 'C.*\.md|docs|package\.json|tests|\.lock|\.mjs|\.nix|\.ya?ml'
+lacks 'C.*\.md|DEPENDENCIES\.md|pins\.toml|docs|package\.json|tests|\.lock|\.mjs|\.nix|\.ya?ml'
 
 echo "The sdist ships the core module and the plugins"
 has core

--- a/tests/packaging/test_python_wheel.sh
+++ b/tests/packaging/test_python_wheel.sh
@@ -8,7 +8,7 @@ has() { grep -q "$1" <<<"$files" || { echo "  MISSING: $1" >&2; exit 1; }; }
 lacks() { ! grep -qE "$1" <<<"$files" || { echo "  FORBIDDEN: $1" >&2; exit 1; }; }
 
 echo "The wheel ships no markdown, docs, tests, or dev tooling config"
-lacks 'C.*\.md|docs|package\.json|tests|\.lock|\.mjs|\.nix|\.ya?ml'
+lacks 'C.*\.md|DEPENDENCIES\.md|pins\.toml|docs|package\.json|tests|\.lock|\.mjs|\.nix|\.ya?ml'
 
 echo "The wheel ships the core module and the plugins"
 has core

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -292,7 +292,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -370,7 +370,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -600,7 +600,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -635,34 +635,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1009,7 +1009,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -1392,15 +1392,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1476,16 +1476,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -2013,7 +2013,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2052,7 +2052,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2064,7 +2064,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2094,9 +2094,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2108,7 +2108,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2168,12 +2168,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "protobuf", marker = "python_full_version < '3.11'" },
-    { name = "sympy", marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -2216,11 +2216,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -2295,10 +2295,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2367,10 +2367,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2851,7 +2851,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2912,7 +2912,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2991,7 +2991,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -277,7 +277,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -292,7 +292,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -370,7 +370,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -600,7 +600,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -635,34 +635,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.11' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -698,6 +698,9 @@ acceptance = [
 benchmark = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
+]
+bundle = [
+    { name = "piper-tts" },
 ]
 docs = [
     { name = "mike" },
@@ -736,6 +739,7 @@ requires-dist = [
     { name = "onnxruntime", specifier = ">=1.23.2" },
     { name = "onnxruntime", marker = "python_full_version < '3.11'", specifier = "<1.24" },
     { name = "opencv-python", marker = "extra == 'head-tracking'", specifier = ">=4.13.0.90" },
+    { name = "piper-tts", marker = "extra == 'bundle'", specifier = ">=1.4" },
     { name = "pyaudio", specifier = ">=0.2.14" },
     { name = "pyopen-wakeword", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'acceptance'", specifier = ">=8" },
@@ -747,7 +751,7 @@ requires-dist = [
     { name = "sixdrepnet", marker = "extra == 'head-tracking'", specifier = ">=0.1.6" },
     { name = "types-pyaudio", marker = "extra == 'mypy'", specifier = ">=0.2.16.20250801" },
 ]
-provides-extras = ["acceptance", "benchmark", "docs", "head-tracking", "integration", "mypy", "unittest"]
+provides-extras = ["acceptance", "benchmark", "bundle", "docs", "head-tracking", "integration", "mypy", "unittest"]
 
 [[package]]
 name = "evdev-binary"
@@ -773,7 +777,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1005,7 +1009,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -1388,15 +1392,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version < '3.11'" },
+    { name = "fonttools", marker = "python_full_version < '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1472,16 +1476,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.11'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -2009,7 +2013,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2048,7 +2052,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2060,7 +2064,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2090,9 +2094,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2104,7 +2108,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2164,12 +2168,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -2212,11 +2216,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -2291,10 +2295,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2363,10 +2367,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2451,6 +2455,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2521,6 +2534,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
     { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
+]
+
+[[package]]
+name = "piper-tts"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pathvalidate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/53/3c636c4250e8cb489c50c6dda9d64400518e8c6600576850104b3232b562/piper_tts-1.4.2.tar.gz", hash = "sha256:dbe7e5391d7657f8a5f2b7ce7cdbafc5bbc559de2af15e5299ce298323eade51", size = 4364835, upload-time = "2026-04-02T21:17:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/27/5e309f1218296118e8e9ac22eeeddb0bb9a17095bd9eedcd26603eea7bf5/piper_tts-1.4.2-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:d996f9139c44a0bedb6a9ed45805c429a827c56ef9213933859349801fa7f4e1", size = 13822408, upload-time = "2026-04-02T21:16:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e1/84fcb36c7ac413bb22eb3bdda5f21861f02d0f436df0a9090949c9fec032/piper_tts-1.4.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:138e6adf26a8e796f53866770ea30b666b65432a5e94857c2d9a8c473a8a1f90", size = 13830417, upload-time = "2026-04-02T21:17:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1c/260c65320df47fee582d78ad52d49d4195c5439a77b62e73306c2de835ea/piper_tts-1.4.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6736329f1ef58c39272215849dffdacae601201480b08a0c892938fa4d7c8c67", size = 13841991, upload-time = "2026-04-02T21:17:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/58/7b7cbd7e570ac6eb8dbfc22de94d1457863b97876c1cb6a926e959423fb2/piper_tts-1.4.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b17184a664bd9431ce95c138f4bfb3025e1280cf26075a703dbfdcab989b8ee3", size = 13841872, upload-time = "2026-04-02T21:17:06.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5a/fda959ca07554a8ec3e380b168e79fff16f3020f4956c356a613616c1994/piper_tts-1.4.2-cp39-abi3-win_amd64.whl", hash = "sha256:9c4a3a11f5889ea9d0df4414dce2bd9bee5ce7d9cf604c8fd5e307441d4c031f", size = 13831944, upload-time = "2026-04-02T21:17:08.755Z" },
 ]
 
 [[package]]
@@ -2820,7 +2851,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2881,7 +2912,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2960,7 +2991,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
Groundwork for a clean NixOS package: every version the build downloads is now pinned transparently in a single hand-maintained lock file, `pins.toml`, consumed by the Nix flake and the packaging scripts alike — nothing is buried in scripts anymore.

The distro bundle now installs from `uv.lock` instead of resolving fresh, the Whisper snapshot and Piper checksums are pinned and verified, and `just update-pins` refreshes all pins with per-pin policies (the build container advances only when its LTS leaves standard support, since its glibc is the packages' compatibility floor). DEPENDENCIES.md maps where each pin lives.