### PR TITLE
Adopt pathlib for filesystem paths

### DIFF
--- a/packaging/update_pins.py
+++ b/packaging/update_pins.py
@@ -22,12 +22,13 @@ import json
 import os
 import subprocess
 import urllib.request
+from pathlib import Path
 
 import tomllib
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-PINS = "pins.toml"
+PINS = Path("pins.toml")
 
 
 def fetch_json(url, token=None):
@@ -123,12 +124,10 @@ def bump(text, key, old, new, label):
 
 def main():
     """Refresh every pin and rewrite pins.toml when anything moved."""
-    with open(PINS, "rb") as f:
-        pins = tomllib.load(f)
-    with open("pyproject.toml", "rb") as f:
-        requires_python = tomllib.load(f)["project"]["requires-python"]
-    with open(PINS, encoding="utf-8") as f:
-        text = original = f.read()
+    text = original = PINS.read_text(encoding="utf-8")
+    pins = tomllib.loads(text)
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    requires_python = pyproject["project"]["requires-python"]
 
     text = bump(
         text,
@@ -188,8 +187,7 @@ def main():
             print(f"  ok    lang.{code}.piper.revision = {new_tag}")
 
     if text != original:
-        with open(PINS, "w", encoding="utf-8") as f:
-            f.write(text)
+        PINS.write_text(text, encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,17 +137,7 @@ addopts = "--ignore=tests/acceptance --ignore=tests/benchmarks --ignore=tests/in
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
-  # --- Conflicts with the Ruff formatter (per Ruff's own recommendation) ---
-  "COM812",  # missing-trailing-comma
-  "COM819",  # prohibited-trailing-comma
-  "ISC001",  # single-line-implicit-string-concatenation
-  "ISC002",  # multi-line-implicit-string-concatenation
-  "Q000", "Q001", "Q002", "Q003",  # quote style is the formatter's job
-  "W191",    # tab-indentation
-  "E111", "E114", "E117",  # indentation (formatter-owned)
-  "D206", "D300",  # docstring whitespace/quotes (formatter-owned)
-
-  # --- Intentional project policy ---
+  "COM812",  # missing-trailing-comma: formatter-owned; ruff warns if left enabled
   "ANN",     # type annotations not enforced project-wide; mypy covers used types
   "S603",    # subprocess use is how a desktop voice controller works, by design
   "S607",    # binaries (piper, wl-copy, ...) resolved via PATH for portability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,6 @@ ignore = [
   "S603",    # subprocess use is how a desktop voice controller works, by design
   "S607",    # binaries (piper, wl-copy, ...) resolved via PATH for portability
   "PLC0415", # imports inside functions lazily load optional deps (cv2, ...)
-  "PTH",     # os.path/open are kept; they're the seams the unit tests mock
   "PLW0603", # module-level global state is part of the runtime/plugin design
   "PLW0602", # ditto: globals declared for clarity even when only read
   "C901",    # cyclomatic-complexity threshold not enforced

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -72,7 +72,7 @@ PIPER_MODEL = os.environ.get("EASYSPEAK_PIPER_MODEL") or _bundled_model(
     "models",
     "piper",
     "en_US-amy-medium.onnx",
-    default=os.path.expanduser("~/.local/share/piper/en_US-amy-medium.onnx"),
+    default=str(Path("~/.local/share/piper/en_US-amy-medium.onnx").expanduser()),
 )
 PIPER_BIN = os.environ.get("EASYSPEAK_PIPER_BIN") or _bundled_bin(
     "piper", default="piper"
@@ -97,11 +97,11 @@ COMMAND_PROMPT = (
 # --- Desktop sounds ---
 # Default to the FHS sound-theme path; on NixOS the flake overrides
 # EASYSPEAK_SOUNDS_DIR to the Nix store copy, which actually exists.
-SOUNDS_DIR = os.environ.get(
-    "EASYSPEAK_SOUNDS_DIR", "/usr/share/sounds/freedesktop/stereo"
+SOUNDS_DIR = Path(
+    os.environ.get("EASYSPEAK_SOUNDS_DIR", "/usr/share/sounds/freedesktop/stereo")
 )
-WAKE_SOUND = os.path.join(SOUNDS_DIR, "message.oga")
-ERROR_SOUND = os.path.join(SOUNDS_DIR, "dialog-error.oga")
+WAKE_SOUND = SOUNDS_DIR / "message.oga"
+ERROR_SOUND = SOUNDS_DIR / "dialog-error.oga"
 
 
 def load_whisper_model(

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -388,7 +388,7 @@ class EasySpeak:
                 f.name, initial_prompt=use_prompt, beam_size=1, vad_filter=True
             )
             text = " ".join([s.text for s in segments]).strip()
-            os.remove(f.name)
+            Path(f.name).unlink()
             return text
 
     # --- Main loop ---

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -51,7 +51,7 @@ def suppressed_c_stderr():
         yield
         return
     try:
-        with open(os.devnull, "w") as devnull:
+        with open(os.devnull, "w") as devnull:  # noqa: PTH123
             try:
                 os.dup2(devnull.fileno(), stderr_fd)
             except OSError:
@@ -86,7 +86,7 @@ class SpeechPipeline:
     def _piper_sample_rate(self):
         """Read the model's output sample rate (defaults to 22050)."""
         try:
-            with open(f"{PIPER_MODEL}.json") as f:
+            with open(f"{PIPER_MODEL}.json") as f:  # noqa: PTH123
                 return int(json.load(f)["audio"]["sample_rate"])
         except (OSError, ValueError, KeyError, TypeError):
             return 22050

--- a/src/plugins/apps.py
+++ b/src/plugins/apps.py
@@ -1,6 +1,6 @@
 """Apps Plugin - Launch and close applications."""
 
-import os
+from pathlib import Path
 
 NAME = "apps"
 DESCRIPTION = "Launch and close applications"
@@ -117,10 +117,10 @@ def _register_from_argv(argv, core):
     the caller falls back to TERMINAL_FALLBACKS instead of registering a
     "terminal" entry whose launch would raise.
     """
-    args = [a for a in argv if "=" not in a and os.path.basename(a) != "env"]
+    args = [a for a in argv if "=" not in a and Path(a).name != "env"]
     if not args:
         return False
-    command = os.path.basename(args[0])
+    command = Path(args[0]).name
     if command in ("flatpak", "snap"):
         target = next(
             (a for a in args[1:] if a != "run" and not a.startswith("-")), None

--- a/src/plugins/files.py
+++ b/src/plugins/files.py
@@ -1,6 +1,6 @@
 """Files Plugin - Open folders in file manager."""
 
-import os
+from pathlib import Path
 
 NAME = "files"
 DESCRIPTION = "Folder navigation"
@@ -42,7 +42,7 @@ def open_folder(path, core):
     environment (see core.host_run) so it doesn't inherit EasySpeak's library
     paths.
     """
-    expanded = os.path.expanduser(path)
+    expanded = Path(path).expanduser()
     if core.host_run(["which", "xdg-open"]).returncode != 0:
         return False
     core.host_run(["xdg-open", expanded], background=True, clean_env=True)

--- a/tests/unit/core/test_main.py
+++ b/tests/unit/core/test_main.py
@@ -627,9 +627,9 @@ class TestEasySpeakAudio:
         assert result is None
 
     @patch("wave.open")
-    @patch("os.remove")
+    @patch("easyspeak.core.main.Path")
     @patch("tempfile.NamedTemporaryFile")
-    def test_transcribe(self, mock_tempfile, mock_remove, mock_wave):
+    def test_transcribe(self, mock_tempfile, mock_path, mock_wave):
         """Test transcribe method."""
         easy = EasySpeak()
 
@@ -653,12 +653,13 @@ class TestEasySpeakAudio:
         result = easy.transcribe(audio_data)
 
         assert result == "Hello world"
-        mock_remove.assert_called_once_with("/tmp/test.wav")
+        mock_path.assert_called_once_with("/tmp/test.wav")
+        mock_path.return_value.unlink.assert_called_once_with()
 
     @patch("wave.open")
-    @patch("os.remove")
+    @patch("easyspeak.core.main.Path")
     @patch("tempfile.NamedTemporaryFile")
-    def test_transcribe_with_custom_prompt(self, mock_tempfile, mock_remove, mock_wave):
+    def test_transcribe_with_custom_prompt(self, mock_tempfile, mock_path, mock_wave):
         """Test transcribe method with custom prompt."""
         easy = EasySpeak()
 
@@ -689,9 +690,9 @@ class TestEasySpeakAudio:
         assert call_args[1]["initial_prompt"] == custom_prompt
 
     @patch("wave.open")
-    @patch("os.remove")
+    @patch("easyspeak.core.main.Path")
     @patch("tempfile.NamedTemporaryFile")
-    def test_transcribe_multiple_segments(self, mock_tempfile, mock_remove, mock_wave):
+    def test_transcribe_multiple_segments(self, mock_tempfile, mock_path, mock_wave):
         """Test transcribe method with multiple segments."""
         easy = EasySpeak()
 

--- a/tests/unit/plugins/test_files.py
+++ b/tests/unit/plugins/test_files.py
@@ -13,22 +13,19 @@ def test_setup_stores_core_reference(mock_core):
     assert files.core == mock_core
 
 
-@patch(
-    "easyspeak.plugins.files.os.path.expanduser", return_value="/home/user/Documents"
-)
-def test_open_folder_expands_path(mock_expanduser, mock_core):
+@patch("easyspeak.plugins.files.Path")
+def test_open_folder_expands_path(mock_path, mock_core):
     """When open_folder is used with a user path then it expands the path."""
     files.open_folder("~/Documents", mock_core)
 
-    assert mock_expanduser.call_count == 1
-    assert mock_expanduser.call_args.args == ("~/Documents",)
+    mock_path.assert_called_once_with("~/Documents")
+    mock_path.return_value.expanduser.assert_called_once_with()
 
 
-@patch(
-    "easyspeak.plugins.files.os.path.expanduser", return_value="/home/user/Documents"
-)
-def test_open_folder_uses_xdg_open(mock_expanduser, mock_core_which_finds_file_manager):
+@patch("easyspeak.plugins.files.Path")
+def test_open_folder_uses_xdg_open(mock_path, mock_core_which_finds_file_manager):
     """When xdg-open is available then open_folder launches it with a clean env."""
+    mock_path.return_value.expanduser.return_value = "/home/user/Documents"
     core = mock_core_which_finds_file_manager("xdg-open")
 
     result = files.open_folder("~/Documents", core)
@@ -40,11 +37,8 @@ def test_open_folder_uses_xdg_open(mock_expanduser, mock_core_which_finds_file_m
     assert launch.kwargs["clean_env"] is True
 
 
-@patch(
-    "easyspeak.plugins.files.os.path.expanduser", return_value="/home/user/Documents"
-)
 def test_open_folder_returns_false_when_no_file_manager_found(
-    mock_expanduser, mock_core_no_file_manager
+    mock_core_no_file_manager,
 ):
     """When no file manager is available then open_folder returns False."""
     result = files.open_folder("~/Documents", mock_core_no_file_manager)

--- a/uv.lock
+++ b/uv.lock
@@ -2302,6 +2302,7 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
     { url = "https://files.pythonhosted.org/packages/15/8c/bc1bda6aae69a32e9d84fc34153ba104cd25226861eb4aea33b2cea4860d/opencv_python-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6bbc32f59e1b1a7db7b39c81f63d00625f041d333037fd8702f6da52cc39108b", size = 34782755, upload-time = "2026-07-02T05:51:30.556Z" },


### PR DESCRIPTION
Ruff's PTH rules are now enabled and the flagged `os.path`/`open()`/`os.remove` call sites converted to pathlib — in `config`, `main`, the `apps` and `files` plugins, and the pin updater, where `read_text`/`write_text` actually shorten the code.

`speech.py` deliberately keeps its two plain `open()` calls, marked `noqa: PTH123`: `Path.open()` would be pure ceremony there (one call opens `os.devnull` for an fd swap, the other reads an already-built path string), and converting would additionally break the `builtins.open` patches its unit tests rely on. Tests that mocked the removed seams elsewhere (`os.remove`, `os.path.expanduser`) now patch the module-qualified `Path` instead, keeping the same locality. Suite green at 100 % coverage.