### PR TITLE
Add missing modules to the API documentation

### DIFF
--- a/docs/reference/core.md
+++ b/docs/reference/core.md
@@ -26,9 +26,17 @@ instance and use its small public API (`speak`, `host_run`, `transcribe`,
 
 ::: core.speech
 
+## core.wakeword
+
+::: core.wakeword
+
 ## core.tray
 
 ::: core.tray
+
+## core.about
+
+::: core.about
 
 ## core.hotkey
 
@@ -41,3 +49,7 @@ instance and use its small public API (`speak`, `host_run`, `transcribe`,
 ## core.gnome_extension
 
 ::: core.gnome_extension
+
+## core.desktop_integration
+
+::: core.desktop_integration

--- a/uv.lock
+++ b/uv.lock
@@ -847,11 +847,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.4"
+version = "3.29.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The list of modules is hand-maintained in the API docs, not automatic. Some modules were missed out in the past, we add them now.