### PR TITLE
Split language-pack builds from the application build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
       contents: write   # upload assets to the release
     steps:
     - uses: actions/checkout@v6
-    - name: Build .deb and .rpm
-      # Reuses the same containerised build as `just package-distro`, so local
-      # and CI builds are byte-for-byte the same path. Strips a leading "v".
+    - name: Build app packages
       run: |
         tag='${{ github.event.release.tag_name }}'
         bash packaging/build-in-docker.sh "${tag#v}"
+    - name: Build language packs
+      run: bash packaging/build-lang-in-docker.sh
     - name: Attach packages to the release
       env:
         GH_TOKEN: ${{ github.token }}

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -86,13 +86,19 @@ whether produced locally or in CI — handy on NixOS, where the bundle's standal
 CPython and manylinux wheels can't run on the host:
 
 ```bash
-just package-distro            # -> ./dist/ : app + language .deb and .rpm
-just package-distro 1.2.3      # set an explicit version
+just package-app              # -> ./dist/ : the easyspeak app .deb and .rpm
+just package-app 1.2.3        # set an explicit app version
+just package-lang             # -> ./dist/ : every easyspeak-lang-* .deb and .rpm
+just package-lang en          # ... or just the named pack(s)
+just package-distro           # both of the above (every distro package)
 ```
 
-This produces the `easyspeak` app packages and every `easyspeak-lang-*` data
-package. CI builds them automatically: `.github/workflows/release.yml` runs the same
-script on every published GitHub Release and attaches all archives to it.
+The app and the language packs build independently. The app build needs a
+compiler and the standalone CPython bundle; a language pack is only downloaded
+speech models, so it builds in a lighter container with no compiler and carries
+its own version from `pins.toml`, independent of the app release. CI builds all
+of them on every published GitHub Release (`.github/workflows/release.yml`) and
+attaches the archives to it.
 
 ## Other distributions
 

--- a/justfile
+++ b/justfile
@@ -165,20 +165,20 @@ docs-mike *args:
 
 # Build the Debian package and verify its contents
 [group('release')]
-check-deb-package: (package-distro)
+check-deb-package: (package-app)
     bash tests/packaging/test_deb.sh
 
 # Build the RedHat package and verify its contents
 [group('release')]
-check-rpm-package: (package-distro)
+check-rpm-package: (package-app)
     bash tests/packaging/test_rpm.sh
 
-# Build the language packages and verify their contents and independent version
+# Build every language pack and verify each carries its own version and models
 [group('release')]
-check-lang-packages: (package-distro)
-    bash tests/packaging/test_lang.sh en
+check-lang-packages: (package-lang)
+    bash tests/packaging/test_lang.sh
 
-# Build the distro packages once (just dedupes package-distro), check them all
+# Build the app once and each language pack once (just dedupes), check them all
 [group('release')]
 check-distro-packages: check-deb-package check-rpm-package check-lang-packages
 
@@ -232,7 +232,16 @@ stage-bundle:
 stage-lang code:
     bash packaging/stage-lang.sh {{ code }}
 
-# Build .deb and .rpm locally in a clean ubuntu container -> ./dist
+# Build the application .deb and .rpm in a clean ubuntu container -> ./dist
 [group('packaging')]
-package-distro version='0.0.0':
+package-app version='0.0.0':
     bash packaging/build-in-docker.sh {{ version }}
+
+# Build language packs' .deb and .rpm; no code builds all, e.g. `just package-lang en`
+[group('packaging')]
+package-lang *codes:
+    bash packaging/build-lang-in-docker.sh {{ codes }}
+
+# Build every distro package (app + all language packs) locally -> ./dist
+[group('packaging')]
+package-distro version='0.0.0': (package-app version) (package-lang)

--- a/packaging/build-in-docker.sh
+++ b/packaging/build-in-docker.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Build the EasySpeak .deb and .rpm locally inside a clean ubuntu:24.04 container
-# (mirrors the GitHub `release.yml` runner). Handy on NixOS, where the bundle's
-# standalone CPython/manylinux wheels can't run on the host. Outputs to ./dist.
+# Build the EasySpeak application .deb and .rpm locally inside a clean
+# ubuntu:24.04 container (mirrors the GitHub `release.yml` runner). Handy on
+# NixOS, where the bundle's standalone CPython/manylinux wheels can't run on the
+# host. Language packs build separately, without a compiler or CPython bundle —
+# see packaging/build-lang-in-docker.sh. Outputs to ./dist.
 #
 #   packaging/build-in-docker.sh [VERSION]   (default VERSION: 0.0.0)
 set -euo pipefail
@@ -34,23 +36,14 @@ docker run --rm \
 
     cp -r /src /build && cd /build
 
-    # Application package (amd64).
+    # Application package (amd64). Speech models ship as separate noarch
+    # easyspeak-lang-* packages — see packaging/build-lang-in-docker.sh.
     PREFIX=/opt/easyspeak bash packaging/stage-bundle.sh
     nfpm package -f packaging/nfpm.yaml -p deb -t /out
     nfpm package -f packaging/nfpm.yaml -p rpm -t /out
 
-    # Language data packages (noarch). Add more languages here as they appear.
-    # Each pack carries its own version from pins.toml, independent of the app
-    # release VERSION above, so its content changes drive its version, not ours.
-    for lang in en; do
-      bash packaging/stage-lang.sh "$lang"
-      LANG_VERSION=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open(\"pins.toml\", \"rb\"))[\"lang\"][\"$lang\"][\"version\"])")
-      VERSION="$LANG_VERSION" nfpm package -f "packaging/nfpm-lang-$lang.yaml" -p deb -t /out
-      VERSION="$LANG_VERSION" nfpm package -f "packaging/nfpm-lang-$lang.yaml" -p rpm -t /out
-    done
-
-    chmod a+rw /out/*.deb /out/*.rpm
+    chmod a+rw /out/easyspeak_*_amd64.deb /out/easyspeak-*.x86_64.rpm
   '
 
 echo "built:"
-ls -lh "$REPO_ROOT"/dist/*.deb "$REPO_ROOT"/dist/*.rpm
+ls -lh "$REPO_ROOT"/dist/easyspeak_*_amd64.deb "$REPO_ROOT"/dist/easyspeak-*.x86_64.rpm

--- a/packaging/build-lang-in-docker.sh
+++ b/packaging/build-lang-in-docker.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Build EasySpeak language-data packages (easyspeak-lang-<code>, noarch) inside a
+# clean container. Unlike the application build, this needs no compiler and no
+# CPython bundle — just uv, curl and nfpm — because a language pack is nothing
+# but downloaded speech models. Each pack is versioned from pins.toml,
+# independent of the application release. Outputs to ./dist.
+#
+#   packaging/build-lang-in-docker.sh [<code> ...]   default: every language
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Grep, not a TOML parser: this host side runs with nothing but docker + git.
+IMAGE="${IMAGE:-$(grep -Po '^ubuntu_image = "\K[^"]+' "$REPO_ROOT/pins.toml")}"
+LANGS="$*"
+[ -n "$LANGS" ] || LANGS="$(grep -Po '^\[lang\.\K[^.\]]+(?=\]$)' "$REPO_ROOT/pins.toml" | tr '\n' ' ')"
+
+command -v docker >/dev/null || { echo "error: docker is required" >&2; exit 1; }
+mkdir -p "$REPO_ROOT/dist"
+
+docker run --rm \
+  -e LANGS="$LANGS" \
+  -v "$REPO_ROOT:/src:ro" \
+  -v "$REPO_ROOT/dist:/out" \
+  "$IMAGE" bash -euo pipefail -c '
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq curl ca-certificates xz-utils >/dev/null
+    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1
+    export PATH="$HOME/.local/bin:$PATH"
+
+    # Install nfpm (static Go binary) at the version pinned in pins.toml.
+    NFPM_VER=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open(\"/src/pins.toml\", \"rb\"))[\"toolchain\"][\"nfpm\"])")
+    curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VER}/nfpm_${NFPM_VER}_linux_x86_64.tar.gz" \
+      | tar -xz -C /usr/local/bin nfpm
+
+    cp -r /src /build && cd /build
+
+    # Each pack is stamped with its own pins.toml version, not the app release.
+    for lang in $LANGS; do
+      bash packaging/stage-lang.sh "$lang"
+      VERSION=$(uv run --no-project python -c "import tomllib; print(tomllib.load(open(\"pins.toml\", \"rb\"))[\"lang\"][\"$lang\"][\"version\"])")
+      export VERSION
+      nfpm package -f "packaging/nfpm-lang-$lang.yaml" -p deb -t /out
+      nfpm package -f "packaging/nfpm-lang-$lang.yaml" -p rpm -t /out
+    done
+
+    chmod a+rw /out/*-lang-*.deb /out/*-lang-*.rpm
+  '
+
+echo "built:"
+ls -lh "$REPO_ROOT"/dist/*-lang-*.deb "$REPO_ROOT"/dist/*-lang-*.rpm

--- a/tests/packaging/README.md
+++ b/tests/packaging/README.md
@@ -17,9 +17,10 @@ recipes that build, then verify. The distro packages build in a clean Ubuntu
 container (Docker required); the Python packages build with `uv`:
 
 ```sh
-just check-deb-package        # build-in-docker, then test_deb.sh
-just check-rpm-package        # build-in-docker, then test_rpm.sh
-just check-distro-packages    # both of the above, sharing one container build
+just check-deb-package        # build app in-docker, then test_deb.sh
+just check-rpm-package        # build app in-docker, then test_rpm.sh
+just check-lang-packages      # build lang in-docker, then test_lang.sh
+just check-distro-packages    # all of the above (app built once, each lang once)
 just check-python-packages    # uv build, then test_python_wheel.sh + test_python_sdist.sh
 ```
 
@@ -31,6 +32,7 @@ non-zero on the first missing (or forbidden) path.
 ```sh
 test_deb.sh            # dpkg-deb --contents: launcher, units, extension + schema present
 test_rpm.sh            # rpm --query --list: same contract for the .rpm
+test_lang.sh           # dpkg-deb + rpm: language pack ships the models, carries its own version
 test_python_wheel.sh   # unzip -Z1: core + plugins + extension present, docs/tests absent
 test_python_sdist.sh   # tar tzf: same contract for the source tarball
 ```

--- a/tests/packaging/test_lang.sh
+++ b/tests/packaging/test_lang.sh
@@ -1,33 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-code="${1:-en}"
+codes=("$@")
+[ "${#codes[@]}" -gt 0 ] || mapfile -t codes < <(grep -Po '^\[lang\.\K[^.\]]+(?=\]$)' pins.toml)
+[ "${#codes[@]}" -gt 0 ] || { echo "no languages defined in pins.toml" >&2; exit 1; }
 
-# The pack version lives in pins.toml, independent of the application's release
-# version — that independence is the whole point of a data package, so assert it.
-want=$(uv run --no-project python - "$code" <<'PY'
+want_version() {
+    uv run --no-project python - "$1" <<'PY'
 import sys
 import tomllib
 
 with open("pins.toml", "rb") as f:
     print(tomllib.load(f)["lang"][sys.argv[1]]["version"])
 PY
-)
+}
 
-deb=$(ls -t "dist/easyspeak-lang-${code}_"*.deb | head -1)
-rpm=$(ls -t "dist/easyspeak-lang-${code}-"*.rpm | head -1)
+check() {
+    local code="$1" want deb rpm deb_v rpm_v files
+    want=$(want_version "$code")
+    deb=$(ls -t "dist/easyspeak-lang-${code}_"*.deb | head -1)
+    rpm=$(ls -t "dist/easyspeak-lang-${code}-"*.rpm | head -1)
 
-echo "The language package carries its own version ($want), not the app's"
-deb_version=$(dpkg-deb --field "$deb" Version)
-rpm_version=$(rpm --query --package "$rpm" --queryformat '%{VERSION}' 2>/dev/null)
-[ "$deb_version" = "$want" ] || { echo "  .deb version $deb_version != $want" >&2; exit 1; }
-[ "$rpm_version" = "$want" ] || { echo "  .rpm version $rpm_version != $want" >&2; exit 1; }
+    # The pack version comes from pins.toml, independent of the app release —
+    # that independence is the whole point of a data package.
+    echo "[$code] carries its own version ($want), not the app's"
+    deb_v=$(dpkg-deb --field "$deb" Version)
+    rpm_v=$(rpm --query --package "$rpm" --queryformat '%{VERSION}' 2>/dev/null)
+    [ "$deb_v" = "$want" ] || { echo "  [$code] .deb version $deb_v != $want" >&2; exit 1; }
+    [ "$rpm_v" = "$want" ] || { echo "  [$code] .rpm version $rpm_v != $want" >&2; exit 1; }
 
-echo "The language package ships the Whisper model and the Piper voice"
-for files in "$(dpkg-deb --contents "$deb")" "$(rpm --query --list --package "$rpm" 2>/dev/null)"; do
-    has() { grep -q "$1" <<<"$files" || { echo "  MISSING: $1" >&2; exit 1; }; }
-    has /opt/easyspeak/models/whisper/
-    has /opt/easyspeak/models/piper/
+    echo "[$code] ships the Whisper model and the Piper voice"
+    for files in "$(dpkg-deb --contents "$deb")" "$(rpm --query --list --package "$rpm" 2>/dev/null)"; do
+        grep -q /opt/easyspeak/models/whisper/ <<<"$files" || { echo "  [$code] MISSING whisper" >&2; exit 1; }
+        grep -q /opt/easyspeak/models/piper/ <<<"$files" || { echo "  [$code] MISSING piper" >&2; exit 1; }
+    done
+}
+
+for code in "${codes[@]}"; do
+    check "$code"
 done
 
-echo "✔  Language package looks good."
+echo "✔  Language packages look good."


### PR DESCRIPTION
With each language pack now carrying its own version, the next step is to build it independently of the application. The two share nothing at build time: a pack is only downloaded speech models dropped under `/opt/easyspeak/models`, needing no compiler and no CPython bundle, while the app build needs both.

This extracts language packaging into its own `packaging/build-lang-in-docker.sh`, which builds the noarch `easyspeak-lang-*` packages in a lighter container — just `uv`, `curl`, and `nfpm`, without the `build-essential`/`portaudio` toolchain — and takes one or more language codes, stamping each pack with its own `pins.toml` version. `packaging/build-in-docker.sh` becomes application-only.

The `just` recipes split to match: `package-app` and `package-lang <code>` build each independently, and `package-distro` now delegates to both. `check-lang-packages` builds via the new script and runs `test_lang.sh`; `check-distro-packages` builds the app once and each language once (verified by `just -n`). The release workflow calls the two scripts separately, still attaching every package — a bridge kept intact until the release-trigger split (the third step) moves the language build onto its own trigger. The packaging guide and the `tests/packaging` README are updated.

Second of three steps toward building and releasing the language packs independently; a release-trigger split follows.