### PR TITLE
Add prek pre-commit hooks for file hygiene and shellcheck

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,6 +17,7 @@ jobs:
         - format --diff
         - lint --diff
         - lint-yaml
+        - precommit
         - types
         - package
         - check-desktop-integration

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+exclude: ^docs/media/
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: mixed-line-ending
+  - id: check-merge-conflict
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.10.0.1
+  hooks:
+  - id: shellcheck

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+disable=SC2012,SC2001

--- a/justfile
+++ b/justfile
@@ -28,9 +28,9 @@ update-pins:
     uv run --no-project --with packaging python packaging/update_pins.py
     git diff --color --exit-code pins.toml
 
-# Run all code style checks (format, lint, js, yaml)
+# Run all code style checks (format, lint, js, yaml, pre-commit hooks)
 [group('codestyle')]
-codestyle: format lint lint-js lint-yaml
+codestyle: format lint lint-js lint-yaml precommit
 
 # Check Python code style (use -- to apply, --diff to preview)
 [group('codestyle')]
@@ -51,6 +51,11 @@ lint-js *args:
 [group('codestyle')]
 lint-yaml *args:
     git ls-files '*.yml' '*.yaml' | xargs uvx yamllint -s {{ args }}
+
+# Run the prek pre-commit hooks (file hygiene + shellcheck) over all files
+[group('codestyle')]
+precommit *args=('run --all-files'):
+    uvx prek {{ args }}
 
 # Static type checking (use --pretty for error details)
 [group('safety')]

--- a/src/gnome@easyspeak.dev/extension.js
+++ b/src/gnome@easyspeak.dev/extension.js
@@ -26,7 +26,7 @@ const DBUS_INTERFACE = `
       <arg type="i" direction="in" name="width"/>
       <arg type="i" direction="in" name="height"/>
     </method>
-    
+
     <!-- Mouse control -->
     <method name="Click">
       <arg type="i" direction="in" name="x"/>
@@ -62,12 +62,12 @@ const DBUS_INTERFACE = `
       <arg type="s" direction="in" name="direction"/>
       <arg type="i" direction="in" name="clicks"/>
     </method>
-    
+
     <!-- Screenshot for OCR -->
     <method name="TakeScreenshot">
       <arg type="s" direction="out" name="path"/>
     </method>
-    
+
     <!-- Window management (focused window) -->
     <method name="CloseWindow"/>
     <method name="MinimizeWindow"/>
@@ -77,7 +77,7 @@ const DBUS_INTERFACE = `
     <method name="UnfullscreenWindow"/>
     <method name="TileLeft"/>
     <method name="TileRight"/>
-    
+
     <!-- Window queries and focus -->
     <method name="GetWindows">
       <arg type="s" direction="out" name="json"/>
@@ -86,7 +86,7 @@ const DBUS_INTERFACE = `
       <arg type="s" direction="in" name="title"/>
       <arg type="b" direction="out" name="success"/>
     </method>
-    
+
     <!-- Workspace control -->
     <method name="SwitchWorkspace">
       <arg type="i" direction="in" name="index"/>
@@ -99,7 +99,7 @@ const DBUS_INTERFACE = `
     <method name="GetCurrentWorkspace">
       <arg type="i" direction="out" name="index"/>
     </method>
-    
+
     <!-- Screen info -->
     <method name="GetScreenSize">
       <arg type="i" direction="out" name="width"/>
@@ -165,7 +165,7 @@ export default class EasySpeakGridExtension extends Extension {
             Show: () => this._grid.show(),
             Hide: () => this._grid.hide(),
             Update: (x, y, width, height) => this._grid.update(x, y, width, height),
-            
+
             // Mouse
             Click: (x, y) => this._grid.click(x, y),
             DoubleClick: (x, y) => this._grid.doubleClick(x, y),
@@ -175,10 +175,10 @@ export default class EasySpeakGridExtension extends Extension {
             StartDrag: (x, y) => this._grid.startDrag(x, y),
             EndDrag: (x, y) => this._grid.endDrag(x, y),
             Scroll: (x, y, direction, clicks) => this._grid.scroll(x, y, direction, clicks),
-            
+
             // Screenshot
             TakeScreenshot: () => this._screenMgr.takeScreenshotSync(),
-            
+
             // Window management
             CloseWindow: () => this._winMgr.closeWindow(),
             MinimizeWindow: () => this._winMgr.minimizeWindow(),
@@ -188,18 +188,18 @@ export default class EasySpeakGridExtension extends Extension {
             UnfullscreenWindow: () => this._winMgr.unfullscreenWindow(),
             TileLeft: () => this._winMgr.tileLeft(),
             TileRight: () => this._winMgr.tileRight(),
-            
+
             // Window queries
             GetWindows: () => this._winMgr.getWindows(),
             FocusWindow: (title) => this._winMgr.focusWindow(title),
-            
+
             // Workspaces
             SwitchWorkspace: (index) => this._winMgr.switchWorkspace(index),
             NextWorkspace: () => this._winMgr.nextWorkspace(),
             PrevWorkspace: () => this._winMgr.prevWorkspace(),
             GetWorkspaceCount: () => this._winMgr.getWorkspaceCount(),
             GetCurrentWorkspace: () => this._winMgr.getCurrentWorkspace(),
-            
+
             // Screen info
             GetScreenSize: () => this._grid.getScreenSize(),
 

--- a/tests/packaging/test_rpm.sh
+++ b/tests/packaging/test_rpm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-rpm=$(ls -t dist/easyspeak-*.rpm | grep -v -- '-lang-' | head -1)
+rpm=$(ls -t dist/easyspeak-*.x86_64.rpm | head -1)
 files=$(rpm --query --list --package "$rpm" 2>/dev/null)
 
 has() { grep -q "$1" <<<"$files" || { echo "  MISSING: $1" >&2; exit 1; }; }


### PR DESCRIPTION
A missing final newline in a shell script recently slipped through, because nothing lints shell scripts or enforces whitespace hygiene outside the Python/JS/YAML tools (each of which happens to enforce a final newline for its own language). This closes that gap for every file type.

Adds a [prek](https://github.com/j178/prek)-run pre-commit configuration:

- `end-of-file-fixer`, `trailing-whitespace`, `mixed-line-ending`, `check-merge-conflict` — file hygiene across all tracked files (binaries auto-skipped).
- `shellcheck` — static analysis for the shell scripts that had no linter at all.

It runs via a new `just precommit` recipe (`uvx prek run --all-files`), folded into `codestyle` and added to the CI check matrix. Developers can also `uvx prek install` to run it on commit.

`.shellcheckrc` disables `SC2012` and `SC2001`: the packaging tests select the newest artifact with `ls -t … | head` and the scripts use `sed 's/^/…/'` for per-line prefixing, both deliberate idioms. `docs/media/` is excluded as captured artifacts (e.g. a sample log we don't want rewritten).

Fixes the two violations the hooks surfaced: trailing whitespace on blank lines inside `extension.js`'s D-Bus XML template literal (inter-element whitespace, semantically inert), and `test_rpm.sh`'s `ls | grep -v -- '-lang-'` rewritten to select the app package by its `x86_64` arch (language packs are noarch) — which also clears `SC2010`.