### PR TITLE
Release language packs on their own trigger

### DIFF
--- a/.github/workflows/release-lang.yml
+++ b/.github/workflows/release-lang.yml
@@ -1,0 +1,68 @@
+name: Release language packs
+
+# Language data packages release on their own cadence, not with the application:
+# their content changes only when pins.toml does. Push a `lang-<code>-<version>`
+# tag (e.g. `lang-en-1.0.0`) to build and publish that pack — the version
+# segment must match the pack's version in pins.toml. A manual run
+# (workflow_dispatch) builds the named packs — or all of them by default — and
+# uploads them as artifacts.
+#
+# The `plan` job resolves which language codes to build; the `build` job fans
+# them out over a matrix so several packs build in parallel.
+
+on:
+  push:
+    tags:
+    - 'lang-*'
+  workflow_dispatch:
+    inputs:
+      codes:
+        description: Language codes to build, space-separated; empty builds all
+        default: ''
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+      release: ${{ steps.resolve.outputs.release }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Resolve language codes and release tag
+      id: resolve
+      env:
+        EVENT: ${{ github.event_name }}
+        REF_NAME: ${{ github.ref_name }}
+        INPUT_CODES: ${{ github.event.inputs.codes }}
+      run: python3 packaging/plan_lang_release.py
+
+  build:
+    needs: plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create the language release and upload its assets
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build the language pack
+      env:
+        CODE: ${{ matrix.code }}
+      run: bash packaging/build-lang-in-docker.sh "$CODE"
+    - name: Publish to the language release
+      if: needs.plan.outputs.release != ''
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG: ${{ needs.plan.outputs.release }}
+      run: |
+        gh release create "$TAG" dist/*-lang-*.deb dist/*-lang-*.rpm \
+          --title "$TAG" \
+          --notes 'EasySpeak language data package, versioned independently of the application (see pins.toml).' \
+        || gh release upload "$TAG" dist/*-lang-*.deb dist/*-lang-*.rpm --clobber
+    - name: Upload build artifacts
+      if: needs.plan.outputs.release == ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: language-pack-${{ matrix.code }}
+        path: dist/*-lang-*.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
       run: |
         tag='${{ github.event.release.tag_name }}'
         bash packaging/build-in-docker.sh "${tag#v}"
-    - name: Build language packs
-      run: bash packaging/build-lang-in-docker.sh
     - name: Attach packages to the release
       env:
         GH_TOKEN: ${{ github.token }}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -103,6 +103,26 @@ We create releases by drafting a new release from the
    message.
 8. Finally, press <kbd>Publish Release</kbd> (release label "Latest").
 
+Publishing a release builds the `easyspeak` application packages and attaches
+them; the `easyspeak-lang-*` data packages release separately, on their own
+cadence.
+
+### Language packs
+
+A language pack changes only when its models in `pins.toml` do, so it is
+versioned and released independently of the application. Its `[lang.<code>]`
+`version` reflects that pack's pinned content and is bumped by `just update-pins`
+whenever the models change (review it in `git diff pins.toml`). To release the
+pack, push a matching `lang-<code>-<version>` tag:
+
+```console
+git tag lang-en-1.0.0
+git push origin lang-en-1.0.0
+```
+
+This runs `release-lang.yml`, which verifies the tag's version against
+`pins.toml`, builds the pack, and publishes it to a `lang-en-1.0.0` release.
+
 [gh:source]: https://github.com/ctsdownloads/easyspeak
 [gh:releases]: https://github.com/ctsdownloads/easyspeak/releases
 [gh:issues]: https://github.com/ctsdownloads/easyspeak/issues

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -96,9 +96,12 @@ just package-distro           # both of the above (every distro package)
 The app and the language packs build independently. The app build needs a
 compiler and the standalone CPython bundle; a language pack is only downloaded
 speech models, so it builds in a lighter container with no compiler and carries
-its own version from `pins.toml`, independent of the app release. CI builds all
-of them on every published GitHub Release (`.github/workflows/release.yml`) and
-attaches the archives to it.
+its own version from `pins.toml`, independent of the app release. They release
+on separate triggers too: a published GitHub Release builds and attaches the app
+packages (`.github/workflows/release.yml`), while pushing a
+`lang-<code>-<version>` tag builds that language pack and publishes it to its own
+release (`.github/workflows/release-lang.yml`, which fans the codes out over a
+matrix).
 
 ## Other distributions
 

--- a/packaging/plan_lang_release.py
+++ b/packaging/plan_lang_release.py
@@ -1,0 +1,56 @@
+"""Resolve which language packs the release-lang workflow should build.
+
+Reads the triggering event from the environment and writes two GitHub Actions
+outputs: `matrix` (an Actions `{"include": [...]}` object of language codes to
+fan out over) and `release` (the tag to publish to, empty for a manual run).
+
+- A `lang-<code>-<version>` tag push builds that one pack and publishes it to a
+  release named for the tag; the version segment must match pins.toml.
+- A manual `workflow_dispatch` builds the named codes — or every language in
+  pins.toml when none are given — and uploads artifacts instead of publishing a
+  release.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import tomllib
+
+
+def resolve(event, ref, inputs, pins):
+    """Return `(matrix, release)` for the given trigger.
+
+    `matrix` is the Actions matrix object; `release` is the tag to publish to,
+    or `""` for a manual run. Raises `SystemExit` if a tag's version segment
+    does not match the pack's `version` in `pins`.
+    """
+    if event == "push":
+        code, _, want = ref.removeprefix("lang-").rpartition("-")
+        have = pins.get(code, {}).get("version")
+        if want != have:
+            msg = f"::error::tag {ref} says {want}, pins.toml has {code}={have}"
+            raise SystemExit(msg)
+        codes, release = [code], ref
+    else:
+        codes, release = inputs.split() or list(pins), ""
+    return {"include": [{"code": code} for code in codes]}, release
+
+
+def main():
+    """Resolve from the environment and write the GitHub Actions outputs."""
+    pins = tomllib.loads(Path("pins.toml").read_text(encoding="utf-8"))["lang"]
+    matrix, release = resolve(
+        os.environ["EVENT"],
+        os.environ["REF_NAME"],
+        os.environ.get("INPUT_CODES", ""),
+        pins,
+    )
+    output = Path(os.environ["GITHUB_OUTPUT"])
+    with output.open("a", encoding="utf-8") as out:
+        out.write(f"matrix={json.dumps(matrix)}\n")
+        out.write(f"release={release}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The final step of decoupling the language packs: they now release on their own cadence, not with the application.

The on-release job in `release.yml` builds and attaches **only the app packages** — the language build is gone from it. Language packs move to a dedicated `release-lang.yml`:

- **`lang-<code>-<version>` tag** → builds that one pack and publishes it to a release named for the tag. The version segment is validated against `pins.toml` (a mismatch fails the run), so a pack can only be tagged at the version its models actually are.
- **manual `workflow_dispatch`** → builds the named codes, or **every language by default**, and uploads them as artifacts (no release).

A `plan` job resolves which codes to build (from the tag, or the dispatch input, or all of `pins.toml`) and a `build` job fans them out over a **matrix**, so multiple packs build in parallel, each publishing independently. The resolver lives in `packaging/plan_lang_release.py` (ruff-linted, unit-testable) rather than inline YAML.

Docs updated: the packaging guide describes the split triggers, and the contributing guide gains a "Language packs" section on cutting a `lang-<code>-<version>` release.

Third of three steps, following #123 (independent versioning) and #124 (build split). With this, adding or updating a language is fully self-contained: bump it in `pins.toml` (its version auto-bumps), and tag `lang-<code>-<version>` to ship it — no app release involved.