### PR TITLE
Fix flaky link check on freedesktop's WAF (418)

### DIFF
--- a/justfile
+++ b/justfile
@@ -122,25 +122,11 @@ check-docs: lint-docstrings lint-md check-links
 # Check built docs and README/CONTRIBUTING for dead external links (network)
 [group('docs')]
 check-links *args: docs
-    # README/CONTRIBUTING are GitHub-facing; render to HTML (linkchecker can't parse
-    # Markdown) so their links are checked too. Outside site/ so a deploy ignores them.
+    # linkchecker can't parse Markdown, so render README/CONTRIBUTING to HTML.
     mkdir -p build/linkcheck
     uvx --from markdown markdown_py README.md > build/linkcheck/readme.html
     uvx --from markdown markdown_py CONTRIBUTING.md > build/linkcheck/contributing.html
-    # No flag drops linkchecker's copyright banner; omit the 'intro' output part instead.
-    printf '[text]\nparts=url,parenturl,realurl,result,warning,info,stats,outro\n' > build/.linkcheckrc
-    # Skips: 404 page (absolute site_url links 404 on disk), the site's own /latest/
-    # pages (the local build IS /latest/, checked on disk; canonicals of new pages
-    # 404 online until the next deploy), bencher.dev (bot 403s), GitHub /compare
-    # (404s until the just-pushed tag propagates) and /pull links (permanent, never
-    # outdate); custom UA dodges freedesktop's WAF (418 to "Mozilla").
-    uvx linkchecker --config build/.linkcheckrc --check-extern --no-warnings \
-        --ignore-url '/404\.html' \
-        --ignore-url 'easyspeak\.dev/latest/' \
-        --ignore-url 'bencher\.dev' \
-        --ignore-url 'github\.com/.*/compare/' \
-        --ignore-url 'github\.com/.*/pull/' \
-        --user-agent LinkChecker {{ args }} \
+    uvx linkchecker --config linkcheckerrc {{ args }} \
         site/index.html build/linkcheck/readme.html build/linkcheck/contributing.html
 
 # Guard docstrings against reST markup (mkdocstrings renders Markdown, not reST)

--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -1,0 +1,19 @@
+[checking]
+useragent=LinkChecker
+
+[filtering]
+checkextern=1
+ignore=
+  /404\.html
+  easyspeak\.dev/latest/
+  bencher\.dev
+  github\.com/.*/compare/
+  github\.com/.*/pull/
+
+[output]
+warnings=0
+ignoreerrors=
+  ^https://www\.freedesktop\.org/ ^418
+
+[text]
+parts=url,parenturl,realurl,result,warning,info,stats,outro


### PR DESCRIPTION
`check-links` has been intermittently failing on a single URL:

```
URL     https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html
Result  Error: 418 I'm a teapot
```

It's the systemd.service reference from `src/core/gnome_extension.py`'s docstring. freedesktop sits behind a bot-hostile WAF that answers **418** to the shared GitHub-runner IPs — intermittently, which is why it passes locally and `main` passed 10 minutes before a PR run failed on the identical link. The old `--user-agent LinkChecker` dodge no longer placates it, and LinkChecker treats every 4xx except 429 as a hard error with **no** option to accept a status code (verified in `checker/httpurl.py`).

Rather than blanket-ignore the URL (which would also hide a real future 404), this uses LinkChecker's `ignoreerrors` — a `(url-regex, message-regex)` pair that downgrades a matching error **while still fetching the URL**:

```
[output]
ignoreerrors=
  ^https://www\.freedesktop\.org/ ^418
```

Verified against a local server returning a genuine 418: with the rule → 0 errors; with the wrong code (`^404`) → the 418 still errors. So real breakage on that host is still caught.

While here — and answering "can we drive linkchecker from a config file?" — all the settings the recipe passed as flags move into the committed `linkcheckerrc` (extern checking, warnings off, user agent, the banner-dropping output parts, and the ignore list). `check-links` collapses to `linkchecker --config linkcheckerrc <files>`.

This flakes on `main` too, so it's its own PR; #126 will go green once it rebases on top.