### PR TITLE
Skip the Docs workflow for language-pack tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
     - main
     tags:
     - '*'
+    - '!lang-*'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
The Docs workflow ran on every pushed tag, so a language-pack release (a `lang-<code>-<version>` tag, e.g. `lang-en-1.0.0`) triggered it too. Beyond the wasted lint run, the `deploy` job runs on any tag and archived a versioned docs site named for the pack tag, then moved the `stable` alias onto it — see [this run](https://github.com/ctsdownloads/easyspeak/actions/runs/28682870716).

Application release tags are bare semver (`0.7.0`), so excluding `lang-*` from the tag trigger keeps docs publishing on the application cadence and leaves language-pack releases to `release.yml` alone.