### PR TITLE
Link the language pack to its filtered Releases view

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,8 @@ Tested on Fedora and NixOS.
 The easiest path. Download the latest **app** package and a
 **[language pack](https://github.com/ctsdownloads/easyspeak/releases?q=lang)**
 from the [Releases page](https://github.com/ctsdownloads/easyspeak/releases)
-and install them together:
+and install them together — just take the latest of each; the app and
+language-pack version numbers are independent and need not match:
 
 === "Debian / Ubuntu"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,8 @@ Tested on Fedora and NixOS.
 
 ## Quick install (prebuilt packages)
 
-The easiest path. Download the latest **app** package and a **language pack**
+The easiest path. Download the latest **app** package and a
+**[language pack](https://github.com/ctsdownloads/easyspeak/releases?q=lang)**
 from the [Releases page](https://github.com/ctsdownloads/easyspeak/releases)
 and install them together:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,10 +13,9 @@ Tested on Fedora and NixOS.
 ## Quick install (prebuilt packages)
 
 The easiest path. Download the latest **app** package and a
-**[language pack](https://github.com/ctsdownloads/easyspeak/releases?q=lang)**
-from the [Releases page](https://github.com/ctsdownloads/easyspeak/releases)
-and install them together — just take the latest of each; the app and
-language-pack version numbers are independent and need not match:
+**[language pack][gh:releases:lang]** from the [Releases page][gh:releases] and
+install them together — just take the latest of each; the app and language-pack
+version numbers are independent and need not match:
 
 === "Debian / Ubuntu"
 
@@ -134,3 +133,6 @@ uv run --extra head-tracking easyspeak
 ```
 
 The `head-tracking` extra pulls in `sixdrepnet` and `opencv-python`.
+
+[gh:releases]: https://github.com/ctsdownloads/easyspeak/releases
+[gh:releases:lang]: https://github.com/ctsdownloads/easyspeak/releases?q=lang

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -24,8 +24,9 @@ without re-downloading the runtime. See [Language](#language).
 
 Download the latest packages from the
 [Releases page](https://github.com/ctsdownloads/easyspeak/releases) — grab **both**
-the app and a language pack — and install them **together** (the language pack is a
-separate file, not auto-fetched from GitHub):
+the app and a [language pack](https://github.com/ctsdownloads/easyspeak/releases?q=lang) —
+and install them **together** (the language pack is a separate file, not
+auto-fetched from GitHub):
 
 === "Debian / Ubuntu"
 

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -22,11 +22,10 @@ without re-downloading the runtime. See [Language](#language).
 
 ## Install
 
-Download the latest packages from the
-[Releases page](https://github.com/ctsdownloads/easyspeak/releases) — grab **both**
-the app and a [language pack](https://github.com/ctsdownloads/easyspeak/releases?q=lang) —
-and install them **together**. Just take the latest of each: a pack is a separate
-file (not auto-fetched from GitHub) and is versioned by its models, so the app and
+Download the latest packages from the [Releases page][gh:releases] — grab
+**both** the app and a [language pack][gh:releases:lang] — and install them
+**together**. Just take the latest of each: a pack is a separate file (not
+auto-fetched from GitHub) and is versioned by its models, so the app and
 language-pack version numbers are independent and need not match:
 
 === "Debian / Ubuntu"
@@ -144,3 +143,6 @@ to install a GNOME Shell extension into your home directory, and to spawn host
 binaries (`piper`, `qutebrowser`, `gnome-extensions`, `gsettings`, …). Granting all
 of that to a sandbox removes the confinement that is the whole point of those
 formats.
+
+[gh:releases]: https://github.com/ctsdownloads/easyspeak/releases
+[gh:releases:lang]: https://github.com/ctsdownloads/easyspeak/releases?q=lang

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -25,8 +25,9 @@ without re-downloading the runtime. See [Language](#language).
 Download the latest packages from the
 [Releases page](https://github.com/ctsdownloads/easyspeak/releases) — grab **both**
 the app and a [language pack](https://github.com/ctsdownloads/easyspeak/releases?q=lang) —
-and install them **together** (the language pack is a separate file, not
-auto-fetched from GitHub):
+and install them **together**. Just take the latest of each: a pack is a separate
+file (not auto-fetched from GitHub) and is versioned by its models, so the app and
+language-pack version numbers are independent and need not match:
 
 === "Debian / Ubuntu"
 


### PR DESCRIPTION
The install instructions pointed the whole "app and language pack" line at the general Releases page, mixing application and pack releases together. Links the "language pack" phrase to [`releases?q=lang`](https://github.com/ctsdownloads/easyspeak/releases?q=lang) so a reader lands on just the `easyspeak-lang-*` releases.

Also spells out, right at the download step in both the installation and packaging guides, that a pack is versioned by its models rather than the app — so the application and language-pack version numbers are independent and need not match; just take the latest of each.