### PR TITLE
Add a CLI option to print version information

### DIFF
--- a/src/core/cli.py
+++ b/src/core/cli.py
@@ -10,6 +10,7 @@ files and exit. All `EASYSPEAK_*` variables are listed in [`core.config`][core.c
 import argparse
 
 from . import log
+from .about import app_version
 
 
 def parse_args(argv=None):
@@ -40,6 +41,12 @@ def parse_args(argv=None):
         "--preview",
         choices=config_items,
         help="print the file content that would be configured and exit",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {app_version()}",
+        help="show the installed version and exit",
     )
     args = parser.parse_args(argv)
 

--- a/tests/unit/core/test_cli.py
+++ b/tests/unit/core/test_cli.py
@@ -51,6 +51,16 @@ def test_parse_args_verbose_and_quiet_are_mutually_exclusive():
         cli.parse_args(["-v", "-q"])
 
 
+def test_version_prints_program_and_version_then_exits(capsys):
+    """--version prints "easyspeak <version>" and exits without running the app."""
+    with pytest.raises(SystemExit) as exc:
+        cli.parse_args(["--version"])
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert out == f"easyspeak {cli.app_version()}\n"
+
+
 def _run_then_log(argv, capsys, level, message):
     """Run the CLI with argv, emit one log record, return its formatted stderr.
 


### PR DESCRIPTION
We show version information in the About dialog, but the CLI should also have a way to display it.