### PR TITLE
Fix benchmark job by allowing Whisper model downloads

### DIFF
--- a/.github/actions/benchmark/action.yml
+++ b/.github/actions/benchmark/action.yml
@@ -35,6 +35,7 @@ runs:
   - name: Track benchmarks with Bencher
     shell: bash
     env:
+      EASYSPEAK_OFFLINE: relaxed
       FORCE_COLOR: '1'
       PY_COLORS: '1'
     run: |


### PR DESCRIPTION
The benchmark suite loads the base.en and tiny.en Whisper models, but since gating downloads behind `EASYSPEAK_OFFLINE` (strict by default), load_whisper_model refuses to fetch a missing model and raises instead. The runner's Hugging Face cache is never actually primed, so every benchmark run fails with "speech model 'base.en' is not installed".

Sets `EASYSPEAK_OFFLINE=relaxed` for the bencher run so the models download on demand and populate the cache. The composite action is shared by the baseline and preview jobs, so this covers both.

Related: d75bf79 (make model download opt-in via `EASYSPEAK_OFFLINE`)