### PR TITLE
fix(clipboard): drop the xclip fallback and require wl-clipboard

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -101,9 +101,9 @@ stripped before matching, since Whisper adds them.
 
 ## Dictation
 
-Dictation places text by pasting it, which needs `wl-clipboard` (Wayland) or
-`xclip` (X11) installed, and needs a text field focused. In the browser, use
-`numbers` and pick the hint on the field first.
+Dictation places text by pasting it, which needs `wl-clipboard` installed and a
+text field focused. In the browser, use `numbers` and pick the hint on the field
+first.
 
 | Command | Action |
 |---------|--------|

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,8 +68,8 @@ sudo dnf install \
 `wl-clipboard` is what dictation uses to place text. It types by putting the
 text on the clipboard and sending a paste keystroke, because accessibility-level
 insertion is silently ignored by Chromium-based applications — they accept the
-call, report success, and discard the text. Without `wl-clipboard` (or `xclip` on
-X11) dictation falls back to that path and quietly does nothing in a browser.
+call, report success, and discard the text. Without `wl-clipboard`, dictation
+falls back to that path and quietly does nothing in a browser.
 
 `python3-gobject` and `libadwaita` power the tray menu's **About EasySpeak**
 window. They ship with any GNOME desktop, so they're usually already present;

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -44,10 +44,9 @@ This is **fully offline** (assuming the system dependencies — GTK4, PortAudio,
 PyGObject, … — are already present, as on any GNOME desktop). Then launch
 **EasySpeak** from the applications menu, or run `easyspeak`.
 
-Dictation additionally needs a clipboard tool — `wl-clipboard` on Wayland,
-`xclip` on X11 — since it places text by pasting rather than through the
-accessibility bridge, which Chromium-based applications ignore. It is a
-`recommends`, so a minimal install may not pull it in.
+Dictation additionally needs `wl-clipboard`, since it places text by pasting
+rather than through the accessibility bridge, which Chromium-based applications
+ignore. It is a hard dependency, so it comes with the package.
 
 Installing the app **without** a language pack also works: the wake word is built
 in, the Whisper model then downloads automatically on first run, and voice feedback

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -41,10 +41,10 @@ gsettings set org.gnome.desktop.interface toolkit-accessibility true
 ## Dictation types nothing
 
 Dictation places text by putting it on the clipboard and sending a paste
-keystroke. Install the clipboard tool for your session:
+keystroke. Install `wl-clipboard`:
 
 ```bash
-sudo dnf install wl-clipboard   # Wayland; use xclip on X11
+sudo dnf install wl-clipboard
 ```
 
 Without it, insertion falls back to the accessibility bridge, which
@@ -52,7 +52,7 @@ Chromium-based applications (qutebrowser, Electron apps) accept and silently
 discard — the log says so:
 
 ```
-No clipboard tool found, so dictation is falling back to AT-SPI, ...
+wl-clipboard is not installed, so dictation is falling back to AT-SPI, ...
 ```
 
 If you hear **"No text field focused"**, click into a text field first, or use

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -57,6 +57,7 @@ overrides:
     - gir1.2-gtk-4.0
     - gir1.2-adw-1
     - adwaita-icon-theme     # provides the launcher icon
+    - wl-clipboard           # dictation places text by pasting
     recommends:
     - easyspeak-lang-en      # default language data; repo installs pull it automatically
     - gnome-shell            # provides `gnome-extensions` (mouse grid / indicator)
@@ -66,7 +67,6 @@ overrides:
     - wireplumber            # wpctl volume control
     - pulseaudio-utils       # paplay (chime + TTS fallback)
     - sound-theme-freedesktop  # wake/error chime sounds
-    - wl-clipboard           # dictation pastes text; xclip on X11
   rpm:
     depends:
     - portaudio
@@ -77,6 +77,7 @@ overrides:
     - gtk4
     - libadwaita
     - adwaita-icon-theme
+    - wl-clipboard           # dictation places text by pasting
     recommends:
     - easyspeak-lang-en
     - gnome-shell
@@ -86,4 +87,3 @@ overrides:
     - wireplumber
     - pulseaudio-utils
     - sound-theme-freedesktop
-    - wl-clipboard           # dictation pastes text; xclip on X11

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -269,18 +269,13 @@ def paste_chord(wm_class=UNKNOWN):
 
 
 def clipboard_tools():
-    """Return the (copy, paste) commands for this session, or (None, None).
+    """Return the (copy, paste) commands, or (None, None) if wl-clipboard is absent.
 
-    wl-clipboard on Wayland, xclip on X11. Both are ordinary desktop packages;
-    without either there is no way to put text on the clipboard.
+    EasySpeak targets Wayland, so wl-clipboard is the only supported tool. Without
+    it there is no way to put text on the clipboard.
     """
     if shutil.which("wl-copy") and shutil.which("wl-paste"):
         return ["wl-copy"], ["wl-paste", "--no-newline"]
-    if shutil.which("xclip"):
-        return (
-            ["xclip", "-selection", "clipboard"],
-            ["xclip", "-selection", "clipboard", "-o"],
-        )
     return None, None
 
 
@@ -422,9 +417,9 @@ def insert_text(text):
     copy_cmd, paste_cmd = clipboard_tools()
     if copy_cmd is None:
         logger.warning(
-            "No clipboard tool found, so dictation is falling back to AT-SPI, "
-            "which Chromium-based apps accept and ignore. Install wl-clipboard "
-            "(Wayland) or xclip (X11) for text to reach the browser."
+            "wl-clipboard is not installed, so dictation is falling back to "
+            "AT-SPI, which Chromium-based apps accept and ignore. Install "
+            "wl-clipboard for text to reach the browser."
         )
         return insert_via_atspi(text)
 

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -814,7 +814,7 @@ def test_insert_text_reports_a_failed_copy(monkeypatch, readlog):
 def test_insert_text_falls_back_without_a_clipboard_tool(
     mock_atspi, mock_focus, monkeypatch
 ):
-    """With no wl-clipboard or xclip, the old accessibility path is all there is."""
+    """With no wl-clipboard, the old accessibility path is all there is."""
     monkeypatch.setattr(dictation.shutil, "which", lambda _name: None)
 
     assert dictation.insert_text("hello") == dictation.INSERTED
@@ -831,18 +831,11 @@ def test_clipboard_tools_prefers_wayland(monkeypatch):
     assert paste_cmd[0] == "wl-paste"
 
 
-def test_clipboard_tools_falls_back_to_xclip(monkeypatch):
-    """On X11 there is no wl-clipboard, but xclip does the same job."""
-    monkeypatch.setattr(
-        dictation.shutil,
-        "which",
-        lambda name: "/usr/bin/xclip" if name == "xclip" else None,
-    )
+def test_clipboard_tools_without_wl_clipboard(monkeypatch):
+    """EasySpeak targets Wayland, so wl-clipboard is the only supported tool."""
+    monkeypatch.setattr(dictation.shutil, "which", lambda _name: None)
 
-    copy_cmd, paste_cmd = dictation.clipboard_tools()
-
-    assert copy_cmd[0] == "xclip"
-    assert "-o" in paste_cmd
+    assert dictation.clipboard_tools() == (None, None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The paste keystroke goes exclusively through Mutter's RemoteDesktop interface, so the xclip half of clipboard_tools could populate a clipboard whose paste could never fire. EasySpeak targets Wayland; wl-clipboard is the only supported tool.

wl-clipboard moves from recommends to depends in both the deb and rpm blocks: dictation is a core feature, so an installed package should not need a follow-up install to make it work.

Removes the X11 and xclip references from installation.md, packaging.md, troubleshooting.md and commands.md, and corrects the log line troubleshooting.md tells users to look for.