### PR TITLE
refactor(browser): hold session state on core, not module globals

### DIFF
--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -37,7 +37,6 @@ core = None
 # back to the daemon, and "browser" is one it does own -- so without this guard,
 # saying it inside browser mode routed straight back into handle() and opened a
 # second, nested mode on top of the first.
-in_browser_mode = False
 
 # Number words for hint selection
 HINT_NUMBERS = {
@@ -316,6 +315,8 @@ def setup(c):
     """Store the core reference and write the required qutebrowser config."""
     global core
     core = c
+    c.browser_page_js_stale = False
+    c.in_browser_mode = False
     ensure_qutebrowser_config()
 
 
@@ -491,18 +492,15 @@ HINT_RETRY_DELAY = 0.6
 # getting elements" and scrolling silently does nothing. Reloading is the only
 # thing that reliably brings either back, and it is paid for when one of them is
 # next used rather than on every navigation.
-_needs_reload_before_page_js = False
 
 
-def _reload_if_page_js_is_stale(core=None):
+def _reload_if_page_js_is_stale(core):
     """Reload when a history navigation has left the page's JS unusable."""
-    global _needs_reload_before_page_js
-    if not _needs_reload_before_page_js:
+    if not core.browser_page_js_stale:
         return
-    _needs_reload_before_page_js = False
+    core.browser_page_js_stale = False
     logger.debug("  ↻ Reloading: page scripts don't survive a history navigation")
-    if core is not None:
-        core.speak("Reloading")
+    core.speak("Reloading")
     qb("reload")
     time.sleep(RELOAD_SETTLE)
 
@@ -511,7 +509,7 @@ def _reload_if_page_js_is_stale(core=None):
 RELOAD_SETTLE = 0.8
 
 
-def show_hints(core=None):
+def show_hints(core):
     """Show the numbered hints, reloading first if history navigation broke them."""
     _reload_if_page_js_is_stale(core)
     qb("hint")
@@ -729,7 +727,7 @@ def handle(cmd, core):
 
     # --- Enter browser mode (explicit) ---
     if cmd_lower in ["browser", "browser mode", "open browser", "launch browser"]:
-        if in_browser_mode:
+        if core.in_browser_mode:
             return True  # already there; don't stack a second one
         # Only launch when there is nothing to talk to. Running `qutebrowser`
         # again while an instance is up doesn't start a second browser -- it
@@ -768,17 +766,15 @@ def browser_mode(core):
     browser mode holds the microphone, and an
     unattended session ends on its own instead of leaving the wake word unreachable.
     """
-    global in_browser_mode
-
     core.speak("Browser")
     logger.info("=== BROWSER MODE ACTIVE ===")
     logger.info("Say commands directly. 'exit browser' to leave.")
 
-    in_browser_mode = True
+    core.in_browser_mode = True
     try:
         _run_browser_mode(core)
     finally:
-        in_browser_mode = False
+        core.in_browser_mode = False
 
 
 def _run_browser_mode(core):
@@ -839,8 +835,6 @@ def strip_filler(cmd_lower):
 
 def handle_browser_command(cmd_lower, core):
     """Execute a single in-browser command; None if it isn't recognised."""
-    global _needs_reload_before_page_js
-
     cmd_lower = strip_filler(cmd_lower)
 
     # Said a beat after hint mode already closed; absorbing it beats answering
@@ -887,12 +881,12 @@ def handle_browser_command(cmd_lower, core):
     # --- Navigation ---
     if cmd_lower in ["back", "go back", "previous page"]:
         qb("back")
-        _needs_reload_before_page_js = True
+        core.browser_page_js_stale = True
         return True
 
     if cmd_lower in ["forward", "go forward", "next page"]:
         qb("forward")
-        _needs_reload_before_page_js = True
+        core.browser_page_js_stale = True
         return True
 
     if cmd_lower in ["reload", "refresh", "reload page"]:

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -44,10 +44,17 @@ def attach_listen_modal(core):
 
 @pytest.fixture
 def mock_core():
-    """Create a mock core object for testing plugins."""
+    """Create a mock core object for testing plugins.
+
+    Session flags a plugin's setup() would set are set here too. A bare Mock
+    invents any attribute asked of it and every invented one is truthy, so
+    without this a flag meaning "already in browser mode" reads as True.
+    """
     core = Mock()
     core.stream.read = Mock()
     core.stream.get_read_available = Mock(return_value=1024)
+    core.browser_page_js_stale = False
+    core.in_browser_mode = False
     return attach_listen_modal(core)
 
 
@@ -123,6 +130,9 @@ def mock_core_factory():
         core = Mock()
         core.stream.read = Mock()
         core.stream.get_read_available = Mock(return_value=1024)
+        # Session flags a plugin's setup() would set; see mock_core.
+        core.browser_page_js_stale = False
+        core.in_browser_mode = False
 
         if wait_for_speech_values is not None:
             core.wait_for_speech = Mock(side_effect=wait_for_speech_values)

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -1343,11 +1343,9 @@ def test_handle_does_not_nest_browser_mode(mock_browser_mode, command, mock_core
     is one it does own -- so it routed straight back into handle() and opened a
     second mode on top of the first, relaunching the browser on the way.
     """
-    browser.in_browser_mode = True
-    try:
-        assert browser.handle(command, mock_core) is True
-    finally:
-        browser.in_browser_mode = False
+    mock_core.in_browser_mode = True
+
+    assert browser.handle(command, mock_core) is True
 
     assert not mock_browser_mode.called
     assert not mock_core.host_run.called
@@ -1360,7 +1358,7 @@ def test_browser_mode_flag_is_cleared_on_exit(mock_handle_cmd, mock_core_factory
 
     browser.browser_mode(mock_core)
 
-    assert browser.in_browser_mode is False
+    assert mock_core.in_browser_mode is False
 
 
 @patch.object(browser, "handle_browser_command", side_effect=RuntimeError("boom"))
@@ -1373,7 +1371,7 @@ def test_browser_mode_flag_is_cleared_after_a_failure(
     with pytest.raises(RuntimeError):
         browser.browser_mode(mock_core)
 
-    assert browser.in_browser_mode is False
+    assert mock_core.in_browser_mode is False
 
 
 @pytest.mark.parametrize("misheard", ["number", "numbers", "links"])
@@ -1485,11 +1483,9 @@ def test_config_is_left_alone_when_already_right(mock_method, tmp_path, monkeypa
 
 
 @pytest.fixture(autouse=True)
-def _forget_navigation():
-    """Start each test with no pending reload."""
-    browser._needs_reload_before_page_js = False
-    yield
-    browser._needs_reload_before_page_js = False
+def _forget_navigation(mock_core):
+    """Start each test with no pending reload, as setup() leaves it."""
+    mock_core.browser_page_js_stale = False
 
 
 @pytest.mark.parametrize("command", ["back", "go back", "forward", "next page"])
@@ -1541,11 +1537,11 @@ def test_the_reload_happens_only_once(mock_qb, mock_listen, mock_sleep, mock_cor
 
 @patch("time.sleep")
 @patch.object(browser, "qb")
-def test_show_hints_settles_before_hinting(mock_qb, mock_sleep):
+def test_show_hints_settles_before_hinting(mock_qb, mock_sleep, mock_core):
     """A reloaded page needs a moment before its elements can be walked."""
-    browser._needs_reload_before_page_js = True
+    mock_core.browser_page_js_stale = True
 
-    browser.show_hints()
+    browser.show_hints(mock_core)
 
     assert mock_sleep.called
     sent = [call.args[0] for call in mock_qb.call_args_list]
@@ -1804,3 +1800,33 @@ def test_config_updates_settings_written_with_other_spacing(
     text = cfg.read_text()
     assert text.count("c.hints.chars") == 1
     assert text.count("c.content.autoplay") == 1
+
+
+@patch.object(browser, "ensure_qutebrowser_config")
+def test_setup_declares_the_page_state(mock_config, mock_core):
+    """The session carries this, so setup is where it starts out false."""
+    browser.setup(mock_core)
+
+    assert mock_core.browser_page_js_stale is False
+
+
+@patch("time.sleep")
+@patch.object(browser, "listen_for_hint")
+@patch.object(browser, "qb")
+def test_page_state_belongs_to_the_session(
+    mock_qb, mock_listen, mock_sleep, mock_core_factory
+):
+    """One session navigating must not make another session reload.
+
+    This used to be a module-level flag, so it was shared by everything.
+    """
+    first, second = mock_core_factory(), mock_core_factory()
+    first.browser_page_js_stale = False
+    second.browser_page_js_stale = False
+
+    browser.handle_browser_command("back", first)
+    mock_qb.reset_mock()
+    browser.handle_browser_command("numbers", second)
+
+    assert "reload" not in [call.args[0] for call in mock_qb.call_args_list]
+    assert first.browser_page_js_stale is True


### PR DESCRIPTION
in_browser_mode and _needs_reload_before_page_js were module-level globals. Both are session state, so they move to core.in_browser_mode and core.browser_page_js_stale, declared in setup().

_reload_if_page_js_is_stale and show_hints lose their core=None defaults, since core is now required. The plugin conftest sets both flags explicitly: a bare Mock invents any attribute asked of it and every invented one is truthy, so a flag meaning 'already in browser mode' would otherwise read as True.