### PR TITLE
chore: strip explanatory comments

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -37,19 +37,11 @@ NETWORK_ALLOWED = OFFLINE_MODE == "relaxed"
 # --- Wake word ---
 WAKE_WORD = "hey_jarvis"  # OpenWakeWord model name
 
-# How the wake word is said aloud, for telling the user they need it again. A mode
-# ending is otherwise invisible: commands that worked a moment ago start being
-# ignored, with nothing to say why.
 WAKE_WORD_SPOKEN = "Hey Jarvis"
 WAKE_THRESHOLD = 0.5
 WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
 
 # --- Audio thresholds ---
-# Mean absolute amplitude below which a chunk counts as silence. This is only the
-# floor: the real threshold is measured from the room at startup, because a fixed
-# one assumes a quiet room. Where the ambient level sits above it -- a desk fan, a
-# desktop machine, an air conditioner -- silence is never detected at all, so every
-# recording runs to its full time cap and every command feels slow.
 SILENCE_THRESHOLD = 300
 
 # Never calibrate above this: speech itself sits well above it, and a threshold
@@ -71,8 +63,6 @@ MISUNDERSTAND_GRACE = 4.0  # Seconds to ignore repeat misses after feedback
 FOLLOWUP_IDLE_ROUNDS = 2  # Quiet listens tolerated before a command session ends
 
 # --- Keyboard (silent) activation ---
-# Hold EASYSPEAK_HOTKEY to dictate; an empty value or `off`/`none` disables it
-# (an empty combo leaves the listener inert). core.hotkey validates the keys.
 _hotkey = os.environ.get("EASYSPEAK_HOTKEY", "ctrl+shift").strip()
 HOTKEY_COMBO = "" if _hotkey.lower() in ("", "off", "none") else _hotkey
 
@@ -119,8 +109,6 @@ COMMAND_PROMPT = (
 
 
 # --- Desktop sounds ---
-# Default to the FHS sound-theme path; on NixOS the flake overrides
-# EASYSPEAK_SOUNDS_DIR to the Nix store copy, which actually exists.
 SOUNDS_DIR = Path(
     os.environ.get("EASYSPEAK_SOUNDS_DIR", "/usr/share/sounds/freedesktop/stereo")
 )

--- a/src/core/desktop_integration.py
+++ b/src/core/desktop_integration.py
@@ -27,9 +27,6 @@ from .gnome_extension import (
 
 logger = logging.getLogger(__name__)
 
-# Bundled desktop files (package data), and the basename they install under. The
-# autostart copy keeps the launcher's basename so a per-user file can override a
-# packaged /etc/xdg/autostart entry of the same name.
 AUTOSTART_TEMPLATE = "easyspeak-autostart.desktop"
 DESKTOP_TEMPLATE = "easyspeak.desktop"
 INSTALLED_DESKTOP_NAME = "easyspeak.desktop"

--- a/src/core/gnome_extension.py
+++ b/src/core/gnome_extension.py
@@ -27,9 +27,6 @@ from easyspeak.data import data_text
 logger = logging.getLogger(__name__)
 
 EXTENSION_UUID = "gnome@easyspeak.dev"
-# UUIDs the extension shipped under before the rename to gnome@easyspeak.dev:
-# easyspeak-grid@local when it was just a mouse grid, then easyspeak@local. A
-# leftover copy under either is cleaned up at startup; see migrate_legacy_extensions.
 LEGACY_EXTENSION_UUIDS = ("easyspeak-grid@local", "easyspeak@local")
 REFRESH_UNIT_NAME = "easyspeak-extension-refresh.service"
 REFRESH_UNIT_TEMPLATE = REFRESH_UNIT_NAME + ".in"  # packaged template file
@@ -38,10 +35,6 @@ PRE_SHELL_TARGET = "gnome-session-pre.target"  # reached before org.gnome.Shell@
 # Cap each helper subprocess so a wedged session/user bus can't hang startup.
 SUBPROCESS_TIMEOUT = 5.0
 
-# Bundled assets, installed as a set: extension.js imports extension-helpers.js,
-# so they must travel together or the extension fails to load. The schema ships
-# pre-compiled (glib-compile-schemas isn't guaranteed present at install time);
-# subdirectory paths are staged in place by the copy below.
 EXTENSION_ASSETS = (
     "extension.js",
     "extension-helpers.js",
@@ -266,10 +259,6 @@ def install_refresh_unit():
     path = unit_path()
 
     if _system_unit_exists():
-        # The package owns the unit; don't shadow it with a user copy. Clear out a
-        # stale one a prior pip/dev install left — `~/.config/systemd/user` takes
-        # precedence over the packaged path and would point at a vanished
-        # interpreter, so it must go for the packaged unit to take effect.
         if path.is_file():
             _run_systemctl("disable", REFRESH_UNIT_NAME)
             with contextlib.suppress(OSError):
@@ -422,9 +411,6 @@ def activate_extension():
             return
 
         if refresh_extension_files(root, dest_dir) is RefreshResult.ERROR:
-            # refresh_extension_files already reported the write error (with the
-            # OSError detail) on stderr; add only the consequence, not a second
-            # description of the same failure.
             logger.warning(
                 "the panel indicator and grid commands will not work until "
                 "the GNOME extension is installed manually."

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -45,15 +45,9 @@ from .wakeword import WakeWordModel
 
 logger = logging.getLogger(__name__)
 
-# Players tried for the short desktop sounds, in order. paplay first because it
-# is what the docs install; the others cover a session that has one but not the
-# others. Whichever answers first is remembered.
 SOUND_PLAYERS = (["paplay"], ["pw-play"], ["canberra-gtk-play", "-f"])
 SOUND_TIMEOUT = 5.0
 
-# Spoken forms of the wake word to strip off a command. Users say "Hey Jarvis,
-# numbers" out of habit inside a mode that is already listening, and a mode that
-# left the prefix on simply failed to match anything.
 WAKE_PREFIXES = (
     "hey jarvis",
     "hey jarvis,",
@@ -466,16 +460,8 @@ class EasySpeak:
                 return pcm
         return None
 
-    # Whisper hands its own initial_prompt back as the transcription when it is
-    # given near-silence, so a "command" that is a verbatim run of the prompt is
-    # noise. Real commands are short ("three seven five", "right click"), so only a
-    # long run counts as an echo and a genuine one-word "six" still lands.
     PROMPT_ECHO_MIN_WORDS = 4
 
-    # Spoken digits are exempt: a long zone chain ("one two three four") is a real
-    # grid command that happens to be in prompt order, and an all-digit echo only
-    # zooms the grid — harmless, and the next silent round still ends the mode. The
-    # echoes that must be caught always carry an action word (scroll, click, stop).
     NUMBER_WORDS = frozenset(
         {
             "zero",
@@ -515,9 +501,6 @@ class EasySpeak:
         `initial_prompt` back when given near-silence, and grid mode was executing
         that as a command.
         """
-        # Handed to Whisper as samples rather than a file. Writing a WAV to /tmp
-        # and having the model read and decode it again put disk I/O and an audio
-        # decode between the user finishing a sentence and seeing it.
         samples = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768.0
 
         use_prompt = prompt or COMMAND_PROMPT
@@ -530,15 +513,9 @@ class EasySpeak:
             language="en",
             # Nothing here reads timestamps, and generating them costs tokens.
             without_timestamps=True,
-            # Each utterance stands alone. Carrying context between them makes
-            # latency grow over a dictation session and feeds Whisper's habit of
-            # repeating itself on quiet audio.
             condition_on_previous_text=False,
         )
         text = " ".join([s.text for s in segments]).strip()
-        # The wait between finishing a sentence and seeing it is mostly this.
-        # Logged so tuning is a measurement rather than a guess: compare it
-        # against the silence window to see which one to reach for.
         logger.debug(
             "transcribed %.1fs of audio in %.2fs",
             len(audio_data) / 32000,
@@ -589,11 +566,6 @@ class EasySpeak:
         punctuation. The generator simply stops when the mode should end, so a
         caller's `for` loop falls through to its own cleanup.
         """
-        # Plugins announce the mode ("Dictation", "Browser", "Grid") immediately
-        # before calling this, so wait that out and empty the microphone before the
-        # first listen. Otherwise the announcement is still playing when recording
-        # starts and lands on the front of the user's first sentence -- "Dictation
-        # search for potatoes".
         if self.spoke:
             self._drain_feedback()
             self.spoke = False
@@ -607,10 +579,6 @@ class EasySpeak:
                 self.exit_requested = True
                 return
             if action is TrayAction.RESUME:
-                # Just woke from sleep: the mode's state (grid bounds, hint
-                # overlay, tracking centre) is stale, so hand control back to the
-                # wake-word loop rather than resuming mid-mode. Announced, because
-                # this was the one way out of a mode that said nothing at all.
                 logger.info("%s mode ended: reactivated", label.capitalize())
                 self.speak(f"Leaving {label}. Say {WAKE_WORD_SPOKEN} to continue.")
                 return
@@ -618,9 +586,6 @@ class EasySpeak:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 logger.info("%s mode ended: idle", label.capitalize())
-                # Say what changed, not just that something did. Commands that
-                # worked a moment ago now need the wake word in front of them, and
-                # "Leaving browser" doesn't tell anyone that.
                 self.speak(f"Leaving {label}. Say {WAKE_WORD_SPOKEN} to continue.")
                 return
 
@@ -648,15 +613,6 @@ class EasySpeak:
             self.spoke = False
             yield spoken
 
-            # Control returns here once the plugin has handled that command, which
-            # it may well have answered out loud. With a voice installed the open
-            # microphone hears the reply, transcribes it, and hands it back as the
-            # next command -- which turned "Sorry, I didn't understand." into an
-            # endless conversation with itself. The wake-word loop already avoids
-            # this by ending its session whenever a command speaks; a mode can't
-            # end, so it waits for playback to finish and drops whatever the
-            # microphone caught of it instead. The deadline restarts afterwards,
-            # since draining takes real time that isn't the user being idle.
             if self.spoke:
                 self._drain_feedback()
                 self.spoke = False
@@ -804,9 +760,6 @@ class EasySpeak:
             logger.error("Cannot start EasySpeak: %s", exc)  # noqa: TRY400
             raise SystemExit(1) from exc
 
-        # The GNOME Shell extension powers both the panel indicator and the
-        # mouse grid, so core (not a plugin) owns installing/refreshing/enabling
-        # it before anything starts driving it over D-Bus.
         ensure_extension()
 
         logger.info("\nLoading plugins...")
@@ -834,10 +787,6 @@ class EasySpeak:
 """)
 
         try:
-            # PortAudio probes every ALSA/JACK device on init, spamming stderr
-            # about hardware this machine lacks; redirect fd 2 to silence that
-            # C-level noise. PyAudio init emits no Python stderr of its own; the
-            # stream is opened separately by _open_stream().
             with suppressed_c_stderr():
                 self.audio = pyaudio.PyAudio()
             self._open_stream()

--- a/src/core/speech.py
+++ b/src/core/speech.py
@@ -20,9 +20,6 @@ from .config import PIPER_BIN, PIPER_MODEL
 
 logger = logging.getLogger(__name__)
 
-# Seconds to wait after spawning the piper -> player pipeline before trusting
-# it: long enough for an immediate failure (bad model, bad flag) to surface,
-# short enough to barely register during the one-time warmup.
 SPEECH_SPAWN_GRACE = 0.2
 
 
@@ -155,15 +152,7 @@ class SpeechPipeline:
                 stdout=self._player.stdin,
                 stderr=subprocess.DEVNULL,
             )
-            # Hand the write end of the player's input pipe entirely to piper.
-            # If the parent kept its own copy open, the player would never see
-            # EOF when piper exits and would hang forever in read() (a dead
-            # piper leaving an immortal pw-play behind), wedging the pipeline.
             self._player.stdin.close()
-            # A bad model path or unsupported player flag lets Popen succeed but
-            # the process dies milliseconds later. Give it a brief grace period
-            # and confirm both are still alive, so warmup reports the failure
-            # once instead of speak() rebuilding a dead pipeline on every phrase.
             time.sleep(SPEECH_SPAWN_GRACE)
             if not (self._alive(self._piper) and self._alive(self._player)):
                 msg = "speech pipeline exited immediately after start"

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -44,11 +44,6 @@ COMMAND_UNMUTE = "unmute"
 COMMAND_HELP = "help"  # open the documentation page in the default browser
 COMMAND_ABOUT = "about"  # open the libadwaita About window
 
-# The About window is its own process: the indicator lives in a GNOME Shell
-# extension that can't host GTK, so the daemon spawns this script instead. It's
-# run by file path (not `-m`) because the PyGObject interpreter it runs in (see
-# _run_menu_action) doesn't have the `easyspeak` package installed; about.py is
-# self-contained, so a plain path works there and in our own interpreter alike.
 ABOUT_HELPER = str(Path(__file__).with_name("about.py"))
 
 # Shared with the extension's ScreenshotManager, which creates ~/.cache/easyspeak.
@@ -64,11 +59,6 @@ MUTED_REPUSH_INTERVAL = 5.0
 # Cap the gdbus call so a wedged session bus can't hang the audio loop.
 GDBUS_TIMEOUT = 5.0
 
-# How long to watch a launched helper before assuming its window opened. A
-# helper that can't start (bad interpreter, missing GTK/libadwaita, no display)
-# exits within this window; a working GUI keeps running, so we stop watching and
-# leave it detached. Only paid when a helper is actually launched, and only in
-# full while one succeeds — a failure returns as soon as the process dies.
 HELPER_STARTUP_GRACE = 1.5
 
 
@@ -151,9 +141,6 @@ class Tray:
         if self._run_menu_action(command):
             return TrayAction.CONTINUE
         if command == COMMAND_MUTE or self._sleep_requested:
-            # A voice "go to sleep" reaches here via _sleep_requested, and the
-            # sleep plugin has already spoken; a button mute (COMMAND_MUTE) has
-            # not, so only then does the tray announce the deactivation itself.
             announce = command == COMMAND_MUTE
             self._sleep_requested = False
             return self.sleep(release_mic, acquire_mic, announce=announce)

--- a/src/plugins/00_eyetrack.py
+++ b/src/plugins/00_eyetrack.py
@@ -159,9 +159,6 @@ def run_tracking():
         tracking_active = False
         return
 
-    # One-euro filters for each axis
-    # min_cutoff: lower = smoother (try 0.5-2.0)
-    # beta: higher = more responsive to fast moves (try 0.001-0.01)
     filter_yaw = OneEuroFilter(freq=30.0, min_cutoff=0.8, beta=0.005)
     filter_pitch = OneEuroFilter(freq=30.0, min_cutoff=0.8, beta=0.005)
 

--- a/src/plugins/00_mousegrid.py
+++ b/src/plugins/00_mousegrid.py
@@ -511,15 +511,8 @@ def listen_for_grid_commands(core):
     try:
         _run_grid_mode(core)
     finally:
-        # Covers every way out: close, click, drag, an idle timeout, or the tray
-        # taking the session away mid-mode. The drag is released first, while the
-        # bounds it needs for a release point still exist.
         _release_pending_drag()
         if grid_active:
-            # The mode ended without a command that closes the grid (idle timeout,
-            # tray sleep, quit). The daemon has already gone back to the wake word,
-            # so an overlay left drawn would sit over the desktop with nothing
-            # listening for it.
             logger.debug("  → Hiding grid left open by an ended mode")
             close_grid()
 

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -33,11 +33,6 @@ COMMANDS = [
 
 core = None
 
-# True while browser_mode is running. Commands this plugin doesn't own are handed
-# back to the daemon, and "browser" is one it does own -- so without this guard,
-# saying it inside browser mode routed straight back into handle() and opened a
-# second, nested mode on top of the first.
-
 # Number words for hint selection
 HINT_NUMBERS = {
     "zero": "0",
@@ -167,23 +162,10 @@ SCROLL_BOTTOM_JS = (
 )
 
 
-# Lines this plugin requires in ~/.config/qutebrowser/config.py. Each is
-# checked grep-style (substring on the file as a whole) and appended
-# individually if absent — the user's other settings are left intact.
 REQUIRED_QUTEBROWSER_LINES = [
     "config.load_autoconfig(False)",
     "c.hints.chars = '0123456789'",
-    # Expired certificates on third-party ad and tracking resources raise a modal
-    # y/n prompt on a great many pages. There is no voice command that can answer
-    # it, so hands-free browsing stops dead until someone reaches for a keyboard.
-    # This blocks those sub-resources silently and still asks about the page the
-    # user actually navigated to, which is the value qutebrowser's own error
-    # message recommends.
     "c.content.tls.certificate_errors = 'ask-block-thirdparty'",
-    # Every site that wants to push notifications raises a modal y/n prompt, and
-    # there is no voice command that can answer one -- browsing simply stops until
-    # someone reaches for a keyboard. Same for location. Answering them in advance
-    # is what keeps the browser usable hands-free.
     "c.content.notifications.enabled = False",
     "c.content.geolocation = False",
     # Autoplaying video ads talk over the wake word and hold the microphone's
@@ -192,11 +174,6 @@ REQUIRED_QUTEBROWSER_LINES = [
 ]
 
 
-# Interpreters to ask about python-adblock, in order. A bare `python3` resolves to
-# the virtualenv's own interpreter when one is active, which never has a distro
-# package installed -- so asking only that concludes the dependency is missing on
-# exactly the setup most likely to have it. (The AT-SPI helper in the dictation
-# plugin probes the same way, for the same reason.)
 ADBLOCK_CANDIDATES = ("python3", "/usr/bin/python3", "/usr/bin/python")
 
 
@@ -278,10 +255,6 @@ def ensure_qutebrowser_config():
     for line in wanted:
         if line in lines:
             continue
-        # Replace an earlier value for the same setting rather than appending a
-        # second assignment. Both would work -- the last one wins -- but the file
-        # would grow a new line every time a setting changed, which is the user's
-        # config being made a mess of.
         setting = _setting_name(line)
         index = next(
             (
@@ -490,22 +463,15 @@ def parse_spoken_url(spoken):
 # arriving while hints are already showing, instead of tearing the mode down.
 HINT_TRIGGERS = ("numbers", "number", "links", "link", "hints", "hint")
 
-# How long to let a page settle before asking for hints a second time. A history
-# restore can leave the page briefly unwalkable, and hinting again immediately
 # fails the same way.
 HINT_RETRY_DELAY = 0.6
 
-# Set by back/forward. Both hinting and scrolling run JavaScript in the page --
-# hinting to enumerate elements, scrolling to find the scrollable container under
-# the cursor -- and a history navigation restores from cache without a load, so
-# that JS world is never re-established. :hint fails with "Unknown error while
-# getting elements" and scrolling silently does nothing. Reloading is the only
-# thing that reliably brings either back, and it is paid for when one of them is
-# next used rather than on every navigation.
-
 
 def _reload_if_page_js_is_stale(core):
-    """Reload when a history navigation has left the page's JS unusable."""
+    """Reload the page if a history navigation left its scripts unusable.
+
+    `core.browser_page_js_stale` is set by back and forward and cleared here.
+    """
     if not core.browser_page_js_stale:
         return
     core.browser_page_js_stale = False
@@ -525,7 +491,7 @@ def show_hints(core):
     qb("hint")
 
 
-def scroll_page(js, core=None):
+def scroll_page(js, core):
     """Scroll the page, reloading first if history navigation broke its scripts."""
     _reload_if_page_js_is_stale(core)
     qb(f"jseval -q {js}")
@@ -538,9 +504,6 @@ def listen_for_hint(core, retries_left=3):
     listener open, so a run of mishearings can't recurse without end.
     """
     logger.info("  🔢 Say hint number (e.g. 'zero two'), 'exit links' to cancel")
-    # "Ready", not "Numbers": the microphone hears every spoken reply, and any of
-    # the words that ask for hints would come straight back as a fresh request
-    # for them. Every confirmation below is chosen the same way.
     core.speak("Ready")
 
     # Small delay to let hints render
@@ -553,13 +516,6 @@ def listen_for_hint(core, retries_left=3):
     # Wait for speech
     first = core.wait_for_speech(timeout=10)
     if not first:
-        # Silence here usually means there was nothing to read out. qutebrowser
-        # enumerates hintable elements with injected JS, and that fails outright
-        # on some pages -- notably after going back, where a history restore
-        # leaves the page in a state it can't walk ("Unknown error while getting
-        # elements"). The error is shown in the browser rather than returned over
-        # IPC, so there is nothing here to test for; the page is simply given a
-        # moment to settle and asked once more.
         if retries_left > 0:
             logger.debug("  ↻ No hints appeared; asking again")
             time.sleep(HINT_RETRY_DELAY)
@@ -595,12 +551,6 @@ def listen_for_hint(core, retries_left=3):
     cmd_lower = cmd.lower().strip(".,!? ")
     logger.debug("  ← %s", cmd_lower)
 
-    # Asked for hints again. Usually that means none appeared -- qutebrowser's
-    # :hint fails outright on some pages ("Unknown error while getting elements")
-    # and the user is simply repeating themselves. Assuming they were already on
-    # screen left the listener waiting for a number against a blank page, so
-    # re-issue the command instead. Escape first, because hinting on top of a
-    # half-open hint mode is what produces that error in the first place.
     if cmd_lower in HINT_TRIGGERS:
         if retries_left <= 0:
             logger.info("  ✗ Hints aren't appearing on this page")
@@ -648,10 +598,6 @@ def listen_for_hint(core, retries_left=3):
             time.sleep(1.0)
             qb("fake-key <Escape>")
         else:
-            # Not a hint - might be a browser command, pass it through.
-            # Escape rather than :mode-leave: leaving is only legal from a
-            # special mode, and following a hint has often already returned
-            # qutebrowser to normal, where the command errors out.
             logger.info("  ? Heard '%s', which isn't a hint number", cmd_lower)
             logger.debug("  ↪ Not a hint, trying as command: '%s'", cmd_lower)
             qb("fake-key <Escape>")
@@ -660,15 +606,6 @@ def listen_for_hint(core, retries_left=3):
     logger.debug("  [listen_for_hint returning - complete]")
 
 
-# Global control phrases owned by the sleep and base plugins. This plugin is
-# routed before them (filename order), and qb() would spawn a fresh qutebrowser
-# window for each — e.g. "stop" -> :stop, "go to sleep" -> :quickmark-load
-# sleep. Decline them so they fall through to the plugin that actually owns
-# them (deactivate / quit). Exact-matched quit words mirror zz_base, plus a
-# bare "stop" — no longer a quit word, but it still must not reach qb, which
-# would open qutebrowser. The sleep phrases are substring-matched per sleep.py.
-# Leaving browser mode and closing the browser were the same list, so "close
-# browser" only ever stepped out of the mode and left the window sitting there.
 LEAVE_BROWSER_MODE = (
     "exit browser",
     "leave browser",
@@ -739,13 +676,6 @@ def handle(cmd, core):
     if cmd_lower in ["browser", "browser mode", "open browser", "launch browser"]:
         if core.in_browser_mode:
             return True  # already there; don't stack a second one
-        # Only launch when there is nothing to talk to. Running `qutebrowser`
-        # again while an instance is up doesn't start a second browser -- it
-        # reaches the running one over IPC and opens the start page, raising a new
-        # tab and taking keyboard focus off whatever the user had clicked. A
-        # dictated phrase then pasted into the page body instead of their field.
-        # clean_env keeps EasySpeak's own library paths out of the browser, which
-        # every other plugin already does when launching a desktop app.
         if not _qutebrowser_running(core):
             core.host_run(["qutebrowser"], background=True, clean_env=True)
         browser_mode(core)
@@ -789,9 +719,6 @@ def browser_mode(core):
 
 def _run_browser_mode(core):
     """Dispatch one browser command per utterance until the mode ends."""
-    # Three minutes, not one: reading a page is a perfectly normal thing to spend
-    # a minute doing, and having the mode expire underneath you mid-article is how
-    # commands silently stop working.
     for cmd_lower in core.listen_modal("browser", timeout=30, idle_timeout=180):
         logger.debug("  [browser] %s", cmd_lower)
 
@@ -818,10 +745,6 @@ def _run_browser_mode(core):
         if handle_browser_command(cmd_lower, core):
             continue
 
-        # Not a browser command. Browser mode used to be a dead end -- "notes",
-        # "open downloads" and the rest were logged as unknown and dropped, so
-        # there was no way to dictate into a page without leaving first. Hand it
-        # to the daemon instead, then carry on browsing when it comes back.
         logger.debug("  ↪ Not a browser command, routing: %s", cmd_lower)
         if not core.route_command(cmd_lower):
             # A quit command ("goodbye"); take the daemon down with us.
@@ -829,9 +752,6 @@ def _run_browser_mode(core):
             return
 
 
-# Whisper often prefixes a command with a word the user didn't emphasise --
-# "and scroll down", "so back". Dropping those saves the command rather than
-# answering "I didn't understand" to something perfectly clear.
 FILLER_PREFIXES = ("and ", "so ", "then ", "okay ", "ok ", "um ", "uh ", "now ")
 
 
@@ -949,9 +869,6 @@ def handle_browser_command(cmd_lower, core):
         qb("tab-prev")
         return True
 
-    # "tab two", "switch to tab 2", "close tab 2" -- one place for every way of
-    # naming a tab by number, because there is no reason to make someone remember
-    # which of those phrasings was implemented.
     tab_num = parse_tab_number(cmd_lower)
     if tab_num is not None:
         if cmd_lower.startswith("close"):
@@ -981,8 +898,6 @@ def handle_browser_command(cmd_lower, core):
         return True
 
     # --- Escape ---
-    # Escape rather than :mode-leave, which is only legal from a special mode and
-    # errors out when qutebrowser is already in normal.
     if cmd_lower in ["escape", "cancel", "nevermind"]:
         qb("fake-key <Escape>")
         return True

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -16,14 +16,6 @@ logger = logging.getLogger(__name__)
 NAME = "dictation"
 DESCRIPTION = "Voice dictation into any text field"
 
-# Recording limits for a sentence rather than a command. Core's defaults assume a
-# few words: a third of a second of quiet ends the recording and nothing past five
-# seconds is captured at all -- so dictation stopped listening during the pause in
-# the middle of a sentence, and cut off anyone who kept talking.
-#
-# The pause is a direct trade: too short and it cuts in mid-sentence, too long and
-# every phrase lags before it appears. 0.7s clears a normal breath while keeping
-# the wait after speaking short enough not to be felt as a delay.
 MAX_RECORD_SECONDS = 20.0
 SILENCE_DURATION = 0.7
 
@@ -98,24 +90,13 @@ def setup(c):
         )
 
 
-# insert_text() outcomes — kept distinct so the spoken feedback is accurate:
-# the text went in, no editable field was focused, or the AT-SPI backend
-# couldn't even start (no PyGObject/typelib, no accessibility bus).
 INSERTED = "inserted"
 NO_FOCUS = "no_focus"
 BACKEND_ERROR = "backend_error"
 
-# The AT-SPI logic lives in a sibling module run as a script in an interpreter
-# that has PyGObject (see atspi_python). It's a real file, not an embedded
-# string, so it gets linted and unit-tested.
 ATSPI_HELPER = str(Path(__file__).with_name("_atspi_insert.py"))
 
 
-# Every way of saying "finish dictating", generated rather than hand-listed. The
-# list used to be written out by hand and had gaps: "stop notes" and "stop note"
-# were both there, but only "close notes" -- so saying "close note" stayed in
-# dictation and typed the words instead, along with every command spoken after it.
-# The nouns include Whisper's usual mishearings of "notes".
 EXIT_VERBS = ("stop", "close", "closed", "end", "exit", "done", "finish", "quit")
 EXIT_NOUNS = (
     "notes",
@@ -138,12 +119,6 @@ def is_exit_phrase(text):
 
 # --- Insertion ---------------------------------------------------------------
 #
-# Text reaches an application by clipboard and paste, not by accessibility-level
-# insertion. Every toolkit implements paste; AT-SPI insertion is widely stubbed
-# out -- Chromium-based apps (qutebrowser, Electron) accept the call, report
-# success, and discard the text, so dictation transcribed perfectly and nothing
-# appeared. Pasting needs no per-application knowledge, which is the point: the
-# alternative was a table of toolkit quirks that grows forever.
 
 # evdev keycodes for the paste chord (stable Linux input ABI).
 KEYCODES = {
@@ -407,10 +382,6 @@ def insert_text(text):
     user whatever they had copied. Falls back to AT-SPI when no clipboard tool is
     installed, which is the only case where the old path was ever the better one.
     """
-    # A paste goes wherever the keyboard is pointing, and if that's a web page
-    # with no field focused it vanishes without a trace -- the keystroke is sent,
-    # the clipboard held the text, and nothing reports a problem. Ask first, so
-    # the user is told rather than left wondering.
     if not has_focused_text_field():
         return NO_FOCUS
 
@@ -425,10 +396,6 @@ def insert_text(text):
 
     global _clipboard_generation
 
-    # Looked up once and passed on. This used to be read three separate times per
-    # insertion -- once to pick the chord and twice for the log lines -- and each
-    # one is a gdbus round trip sitting between the user speaking and the text
-    # appearing.
     target = focused_wm_class()
 
     saved = read_clipboard(paste_cmd)
@@ -439,16 +406,8 @@ def insert_text(text):
     _clipboard_generation += 1
     chord = paste_chord(target)
 
-    # qutebrowser is modal: in normal mode a keystroke is a command, not text, and
-    # Ctrl+V isn't bound there at all -- the paste simply goes nowhere. Following a
-    # hint into a field auto-enters insert mode, which is why dictation worked
-    # after "numbers" and silently did nothing without it. Asking for insert mode
-    # first makes it work either way. Safe to send when already in insert.
     if target in BROWSER_WM_CLASSES:
         _enter_browser_insert_mode()
-    # Say which mechanism ran and where it aimed. Insertion used to report success
-    # without naming the path it took or the window it targeted, so a paste that
-    # went nowhere looked exactly like one that worked.
     logger.info(
         "⌨️  pasting %d chars into %s with %s",
         len(text),
@@ -471,14 +430,8 @@ def insert_text(text):
         )
         return BACKEND_ERROR
 
-    # Name where it went. Paste lands wherever the keyboard focus is, and a page
-    # with no focused field swallows it silently -- so the log has to say which
-    # window received the keystroke, or an empty text box is unexplainable.
     logger.debug("pasted into %s", target or "an unknown window")
 
-    # The restore waits for the paste to land, so it happens on a thread rather
-    # than in front of the user: this was a fixed delay plus another subprocess
-    # between finishing a sentence and seeing it.
     _restore_clipboard_later(copy_cmd, saved, _clipboard_generation)
     return INSERTED
 
@@ -496,11 +449,6 @@ def _restore_clipboard_later(copy_cmd, saved, generation):
     threading.Thread(target=_restore, daemon=True).start()
 
 
-# Interpreters tried for the AT-SPI helper, in order, when
-# EASYSPEAK_ATSPI_PYTHON isn't set. A bare `python3` comes first because it is
-# usually right -- but inside an activated virtualenv it resolves to the venv's
-# own interpreter, which has no PyGObject, so the distro paths follow as the
-# fallback that actually carries python3-gobject.
 ATSPI_CANDIDATES = ("python3", "/usr/bin/python3", "/usr/bin/python")
 
 # Exactly what the helper does on startup, so a candidate is only accepted if the
@@ -750,9 +698,6 @@ def handle(cmd, core):
 
         logger.info("🎙️ Dictation mode - say 'stop notes' to end")
 
-        # Sentence-length recording, not command-length: the command defaults cut
-        # the recording off during a mid-sentence pause and truncated anything
-        # past five seconds.
         try:
             return _dictation_session(core)
         finally:

--- a/src/plugins/media.py
+++ b/src/plugins/media.py
@@ -24,10 +24,6 @@ ACTIONS = {
     "back": "previous",
 }
 
-# Verbs too ambiguous to act on alone. Bare "stop" is a global control word, and
-# bare "back" means browser history far more often than the previous track -- it
-# used to be matched as a substring, so "go back" always reached this plugin.
-# Both now need the command to name what is playing.
 NEEDS_NOUN = {"stop", "back"}
 
 # Words naming what is being played. Ignored when picking the verb, so "pause the

--- a/src/plugins/sleep.py
+++ b/src/plugins/sleep.py
@@ -13,10 +13,6 @@ COMMANDS = [
     "go to sleep / stop listening - release the mic (reactivate from the tray icon)",
 ]
 
-# Matched as substrings against the wake-stripped command. Kept tight so they
-# don't swallow unrelated phrases; "goto" covers a common transcription of
-# "go to", and "stop listening" also covers "stop listening now". Bare "stop"
-# is deliberately excluded — too ambiguous to mean sleep.
 SLEEP_PHRASES = ("go to sleep", "goto sleep", "stop listening")
 
 
@@ -24,10 +20,6 @@ def handle(cmd, core):
     """Deactivate the assistant on a sleep phrase; return None otherwise."""
     cmd_lower = cmd.lower().strip()
     if any(phrase in cmd_lower for phrase in SLEEP_PHRASES):
-        # Speaking also ends the command session promptly (core marks the round
-        # as having spoken, so it stops listening for follow-ups). The tray stays
-        # silent on this voice path to avoid repeating it, but still explains if
-        # it can't actually engage sleep (no indicator to reactivate from).
         core.speak("Voice control turned off.")
         core.deactivate()
         return True

--- a/src/plugins/system.py
+++ b/src/plugins/system.py
@@ -13,9 +13,6 @@ COMMANDS = [
 core = None
 
 
-# evdev keycodes for the multimedia keys (stable Linux input ABI). Replaying these
-# lets gnome-settings-daemon produce its own change and native OSD (plus the chime
-# for volume) -- identical to pressing the keys, because it *is* the keys.
 KEY_MUTE = 113
 KEY_VOLUME_DOWN = 114
 KEY_VOLUME_UP = 115
@@ -155,11 +152,6 @@ def handle(cmd, core):
             brightness_down(core)
             return True
 
-    # Do Not Disturb. Two vocabularies point at the same setting from opposite
-    # directions: "do not disturb on" hides banners, but "notifications on" shows
-    # them -- so the direction word is read against whichever noun was spoken.
-    # Whole words throughout, because "notifications" contains the letters "on" and
-    # a substring test matched the direction inside the trigger word itself.
     dnd_named = "do not disturb" in cmd or "dnd" in words
     if dnd_named or "notifications" in words:
         turning_on = "on" in words or "enable" in words


### PR DESCRIPTION
Removes 275 lines of explanatory comment, including the block at main.py:651-659 raised in review. Comment blocks of three or more lines in src/ drop from 69 to one, the survivor being the CORE CLASS divider.

Also finishes the session-state move in browser.py: scroll_page loses its core=None default now that core is required, and the docstring on _reload_if_page_js_is_stale names the flag it reads.