### PR TITLE
fix(browser): stop hint mode hearing its own prompt

### DIFF
--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -1,6 +1,5 @@
 """Browser Plugin - Qutebrowser voice control via IPC."""
 
-import contextlib
 import logging
 import re
 import subprocess
@@ -509,9 +508,8 @@ def listen_for_hint(core, retries_left=3):
     # Small delay to let hints render
     time.sleep(0.3)
 
-    # Clear audio buffer
-    with contextlib.suppress(Exception):
-        core.stream.read(core.stream.get_read_available(), exception_on_overflow=False)
+    core.speech.drain()
+    core.flush_stream()
 
     # Wait for speech
     first = core.wait_for_speech(timeout=10)


### PR DESCRIPTION
listen_for_hint cleared the mic buffer 0.3s after speaking 'Ready', but speak() is non-blocking and the phrase takes longer than that, so the tail landed in the buffer after the flush and came back as the hint number. The log shows it as 'Heard ready, which isn't a hint number', and the real answer is lost.

Waits for playback to finish before flushing, which is what listen_modal already does everywhere else.