### PR TITLE
feat(dictation): backspace and scratch that

### DIFF
--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -22,7 +22,7 @@ SILENCE_DURATION = 0.7
 COMMANDS = [
     "notes - start dictation mode (say 'stop notes' to end)",
     "Punctuation: comma, period, question mark, exclamation mark, colon, semicolon",
-    "Editing: backspace, space, tab",
+    "Editing: backspace, backspace five, scratch that, space, tab",
     "Structure: new sentence, new line, new paragraph, enter",
     "Symbols: apostrophe, quote, dash, hyphen, at sign, hashtag, percent, asterisk",
 ]
@@ -32,8 +32,8 @@ core = None
 # Prompt to bias Whisper toward recognizing punctuation commands
 DICTATION_PROMPT = (
     "comma, period, new sentence, new paragraph, new line, question mark, "
-    "exclamation mark, colon, semicolon, stop notes, backspace, space, tab, "
-    "enter, apostrophe, quote, dash, hyphen, at sign, hashtag, percent"
+    "exclamation mark, colon, semicolon, stop notes, backspace, scratch that, "
+    "space, tab, enter, apostrophe, quote, dash, hyphen, at sign, hashtag, percent"
 )
 
 
@@ -81,6 +81,7 @@ def setup(c):
     """Store the core reference and enable the GNOME accessibility bridge."""
     global core
     core = c
+    c.dictation_last_length = 0
     ensure_gnome_accessibility()
     # Offer dictation to the keyboard (silent) activation path too: core runs
     # this while the hotkey combo is held, with no wake word spoken.
@@ -128,6 +129,7 @@ KEYCODES = {
     "super": 125,
     "insert": 110,
     "v": 47,
+    "backspace": 14,
 }
 
 DEFAULT_PASTE_CHORD = "ctrl+v"
@@ -545,9 +547,6 @@ def format_text(text):
     # Punctuation replacements - order matters!
     replacements = [
         # Editing commands
-        (r"\s*\bbackspace\b\s*", "\b"),
-        (r"\s*\bback space\b\s*", "\b"),
-        (r"\s*\bdelete\b\s*", "\b"),
         (r"\s*\bspace\b\s*", " "),
         (r"\s*\btab\b\s*", "\t"),
         # Sentence breaks - add space after
@@ -628,6 +627,72 @@ def format_text(text):
     return text.strip()
 
 
+SPOKEN_COUNTS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+
+MAX_BACKSPACES = 200
+
+UNDO_PHRASES = frozenset({"scratch that", "scratch this", "undo that", "undo this"})
+
+
+def _backspace_count(words):
+    """Return how many characters "backspace ..." asks for, or None if it isn't that.
+
+    A bare "backspace" is one; a trailing digit or number word is the count.
+    """
+    if not words or words[0] not in {"backspace", "delete"}:
+        return None
+    if len(words) == 1:
+        return 1
+    if len(words) > 2:
+        return None
+    tail = words[1]
+    if tail.isdigit():
+        return min(int(tail), MAX_BACKSPACES)
+    return SPOKEN_COUNTS.get(tail)
+
+
+def press_backspace(count):
+    """Send `count` backspace keystrokes; True when they were delivered."""
+    try:
+        from easyspeak.core import mediakeys
+
+        for _ in range(count):
+            mediakeys.tap_chord([KEYCODES["backspace"]])
+    except (ImportError, RuntimeError, OSError) as exc:
+        logger.warning("Backspace needs GNOME's RemoteDesktop interface: %s", exc)
+        return False
+    return True
+
+
+def _handle_delete(core, text):
+    """Run "backspace"/"scratch that" if that is what was said; True when it was."""
+    words = text.split()
+    count = _backspace_count(words)
+    if count is None and text in UNDO_PHRASES:
+        count = core.dictation_last_length
+        if not count:
+            core.speak("Nothing to scratch")
+            return True
+    if count is None:
+        return False
+    if press_backspace(count):
+        core.dictation_last_length = 0
+    else:
+        core.speak("Dictation isn't set up on this system.")
+    return True
+
+
 def _dictate_utterance(core, text):
     """Format one transcribed utterance, insert it, and give error feedback.
 
@@ -644,6 +709,8 @@ def _dictate_utterance(core, text):
     if formatted[0].isalpha():
         formatted = " " + formatted
     status = insert_text(formatted)
+    if status == INSERTED:
+        core.dictation_last_length = len(formatted)
     if status == NO_FOCUS:
         core.speak("No text field focused.")
         return True
@@ -727,6 +794,9 @@ def _dictation_session(core):
         if is_exit_phrase(text):
             core.speak("Done")
             return True
+
+        if _handle_delete(core, text):
+            continue
 
         if _dictate_utterance(core, text):
             return True

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -147,10 +147,9 @@ def test_ensure_gnome_accessibility_oserror(mock_which, mock_run, readlog):
         ("hello you line world", "Hello\nworld"),
         ("hello line break world", "Hello\nworld"),
         ("hello enter world", "Hello\nworld"),
-        # Backspace command
-        ("hello backspace world", "Hello\bworld"),
-        ("hello back space world", "Hello\bworld"),
-        ("hello delete world", "Hello\bworld"),
+        # Backspace is a keystroke command, not text: it must survive as words
+        ("hello backspace world", "Hello backspace world"),
+        ("hello delete world", "Hello delete world"),
         # Space command
         ("hello space world", "Hello world"),
         # Tab command
@@ -1291,3 +1290,57 @@ def test_the_browser_is_handed_back_even_after_a_failure(mock_qb, mock_core_with
         dictation.handle("notes", mock_core_with_audio)
 
     assert mock_qb.call_args.args[0] == "mode-leave"
+
+
+@pytest.mark.parametrize(
+    ["spoken", "expected"],
+    [
+        ("backspace", 1),
+        ("delete", 1),
+        ("backspace five", 5),
+        ("backspace 5", 5),
+        ("delete three", 3),
+        ("backspace 999", dictation.MAX_BACKSPACES),
+        ("backspace the file", None),
+        ("hello world", None),
+    ],
+)
+def test_backspace_count(spoken, expected):
+    """A bare backspace is one character; a trailing count asks for more."""
+    assert dictation._backspace_count(spoken.split()) == expected
+
+
+@patch.object(dictation, "press_backspace", return_value=True)
+def test_handle_delete_sends_the_requested_count(mock_press, mock_core):
+    """ "backspace five" removes five characters."""
+    mock_core.dictation_last_length = 13
+
+    assert dictation._handle_delete(mock_core, "backspace five") is True
+    assert mock_press.call_args.args[0] == 5
+
+
+@patch.object(dictation, "press_backspace", return_value=True)
+def test_scratch_that_removes_the_last_insertion(mock_press, mock_core):
+    """The undo phrase removes exactly what the previous utterance inserted."""
+    mock_core.dictation_last_length = 13
+
+    assert dictation._handle_delete(mock_core, "scratch that") is True
+    assert mock_press.call_args.args[0] == 13
+    assert mock_core.dictation_last_length == 0
+
+
+@patch.object(dictation, "press_backspace")
+def test_scratch_that_with_nothing_inserted(mock_press, mock_core):
+    """With no previous insertion the user is told, and no keys are sent."""
+    mock_core.dictation_last_length = 0
+
+    assert dictation._handle_delete(mock_core, "scratch that") is True
+    assert not mock_press.called
+    assert mock_core.speak.call_args.args[0] == "Nothing to scratch"
+
+
+@patch.object(dictation, "press_backspace")
+def test_handle_delete_ignores_ordinary_speech(mock_press, mock_core):
+    """Dictated words that are not a delete command fall through to insertion."""
+    assert dictation._handle_delete(mock_core, "hello world") is False
+    assert not mock_press.called


### PR DESCRIPTION
Adds three ways to remove text without leaving dictation: 'backspace' for one character, 'backspace five' or 'backspace 5' for a count, and 'scratch that' to remove exactly what the previous utterance inserted.

Deletion sends real backspace keystrokes through the same Mutter RemoteDesktop path the paste chord already uses.

The existing 'backspace' and 'delete' words in format_text mapped to the 0x08 character, which was then pasted as text: saying backspace inserted an invisible control character rather than deleting anything. Those replacements are removed, so both words now dictate as ordinary text, and the three tests asserting the old output are corrected.