### PR TITLE
fix(dictation): backspace no longer cancels scratch that

### DIFF
--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -676,20 +676,28 @@ def press_backspace(count):
 
 
 def _handle_delete(core, text):
-    """Run "backspace"/"scratch that" if that is what was said; True when it was."""
+    """Run "backspace"/"scratch that" if that is what was said; True when it was.
+
+    A backspace shortens what "scratch that" still has to remove rather than
+    discarding it, so the two can be used in either order on one utterance.
+    """
     words = text.split()
     count = _backspace_count(words)
-    if count is None and text in UNDO_PHRASES:
+    scratching = count is None and text in UNDO_PHRASES
+    if scratching:
         count = core.dictation_last_length
         if not count:
             core.speak("Nothing to scratch")
             return True
     if count is None:
         return False
-    if press_backspace(count):
+    if not press_backspace(count):
+        core.speak("Dictation isn't set up on this system.")
+        return True
+    if scratching:
         core.dictation_last_length = 0
     else:
-        core.speak("Dictation isn't set up on this system.")
+        core.dictation_last_length = max(core.dictation_last_length - count, 0)
     return True
 
 

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -1344,3 +1344,19 @@ def test_handle_delete_ignores_ordinary_speech(mock_press, mock_core):
     """Dictated words that are not a delete command fall through to insertion."""
     assert dictation._handle_delete(mock_core, "hello world") is False
     assert not mock_press.called
+
+
+@patch.object(dictation, "press_backspace", return_value=True)
+def test_backspace_shortens_what_scratch_that_removes(mock_press, mock_core):
+    """Backspacing part of an utterance leaves the rest still scratchable."""
+    mock_core.dictation_last_length = 13
+
+    dictation._handle_delete(mock_core, "backspace")
+    dictation._handle_delete(mock_core, "backspace")
+
+    assert mock_core.dictation_last_length == 11
+
+    dictation._handle_delete(mock_core, "scratch that")
+
+    assert mock_press.call_args.args[0] == 11
+    assert mock_core.dictation_last_length == 0


### PR DESCRIPTION
_handle_delete zeroed the undo length after any deletion, so a single backspace left 'scratch that' with nothing to remove. A backspace now subtracts from the pending length instead, and only 'scratch that' clears it outright.