### PR TITLE
feat(dictation): send enter, tab, escape and arrow keys

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,13 +121,30 @@ first.
 | new line | Insert newline |
 | new paragraph | Insert double newline |
 | new sentence | Insert . and capitalize next |
-| backspace | Delete character |
 | space | Insert space |
-| tab | Insert tab |
 | at sign | Insert @ |
 | hashtag | Insert # |
 | percent | Insert % |
 | asterisk | Insert * |
+
+### Editing and keys
+
+These send real keystrokes rather than inserting text, so they work in browser
+fields and forms as well as editors. The arrows need `press` in front, since a
+bare "up" or "right" is ordinary dictated speech.
+
+| Command | Action |
+|---------|--------|
+| backspace | Delete one character |
+| backspace five | Delete five characters |
+| scratch that | Delete what the last utterance inserted |
+| enter | Press Enter |
+| tab | Press Tab |
+| escape | Press Escape |
+| page up | Press Page Up |
+| page down | Press Page Down |
+| press down | Press the Down arrow |
+| press down five | Press the Down arrow five times |
 
 ## Apps
 

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -22,8 +22,9 @@ SILENCE_DURATION = 0.7
 COMMANDS = [
     "notes - start dictation mode (say 'stop notes' to end)",
     "Punctuation: comma, period, question mark, exclamation mark, colon, semicolon",
-    "Editing: backspace, backspace five, scratch that, space, tab",
-    "Structure: new sentence, new line, new paragraph, enter",
+    "Editing: backspace, backspace five, scratch that",
+    "Keys: enter, tab, escape, page up, page down, press down five",
+    "Structure: new sentence, new line, new paragraph",
     "Symbols: apostrophe, quote, dash, hyphen, at sign, hashtag, percent, asterisk",
 ]
 
@@ -33,7 +34,8 @@ core = None
 DICTATION_PROMPT = (
     "comma, period, new sentence, new paragraph, new line, question mark, "
     "exclamation mark, colon, semicolon, stop notes, backspace, scratch that, "
-    "space, tab, enter, apostrophe, quote, dash, hyphen, at sign, hashtag, percent"
+    "enter, tab, escape, space, apostrophe, quote, dash, hyphen, at sign, "
+    "hashtag, percent"
 )
 
 
@@ -130,6 +132,17 @@ KEYCODES = {
     "insert": 110,
     "v": 47,
     "backspace": 14,
+    "enter": 28,
+    "tab": 15,
+    "escape": 1,
+    "up": 103,
+    "down": 108,
+    "left": 105,
+    "right": 106,
+    "home": 102,
+    "end": 107,
+    "page up": 104,
+    "page down": 109,
 }
 
 DEFAULT_PASTE_CHORD = "ctrl+v"
@@ -548,7 +561,6 @@ def format_text(text):
     replacements = [
         # Editing commands
         (r"\s*\bspace\b\s*", " "),
-        (r"\s*\btab\b\s*", "\t"),
         # Sentence breaks - add space after
         (r"\s*,?\s*\bnew sentence\b\s*", ". "),
         (r"\s*,?\s*\bnext sentence\b\s*", ". "),
@@ -559,7 +571,6 @@ def format_text(text):
         (r"\s*,?\s*\bnewline\b\s*", "\n"),
         (r"\s*,?\s*\byou line\b\s*", "\n"),
         (r"\s*,?\s*\bline break\b\s*", "\n"),
-        (r"\s*,?\s*\benter\b\s*", "\n"),
         # Punctuation - include common mishearings
         (r"\s*,?\s*\bcomma\b\s*", ", "),
         (r"\s*,?\s*\bkarma\b\s*", ", "),
@@ -640,64 +651,92 @@ SPOKEN_COUNTS = {
     "ten": 10,
 }
 
-MAX_BACKSPACES = 200
+MAX_KEY_REPEATS = 200
 
 UNDO_PHRASES = frozenset({"scratch that", "scratch this", "undo that", "undo this"})
 
+KEY_ALIASES = {
+    "delete": "backspace",
+    "return": "enter",
+    "escape key": "escape",
+}
 
-def _backspace_count(words):
-    """Return how many characters "backspace ..." asks for, or None if it isn't that.
+# Bare "up" or "right" is ordinary speech, so the arrows need "press" in front.
+ARROW_KEYS = frozenset({"up", "down", "left", "right"})
 
-    A bare "backspace" is one; a trailing digit or number word is the count.
+
+def _key_request(words):
+    """Return (keycode, repeats) for a keystroke command, or None if it isn't one.
+
+    Accepts an optional "press" prefix, one- or two-word key names, and a trailing
+    count as digits or a number word.
     """
-    if not words or words[0] not in {"backspace", "delete"}:
+    if words and words[0] == "press":
+        words = words[1:]
+        explicit = True
+    else:
+        explicit = False
+    if not words:
         return None
-    if len(words) == 1:
-        return 1
-    if len(words) > 2:
-        return None
-    tail = words[1]
-    if tail.isdigit():
-        return min(int(tail), MAX_BACKSPACES)
-    return SPOKEN_COUNTS.get(tail)
+
+    for length in (2, 1):
+        name = " ".join(words[:length])
+        name = KEY_ALIASES.get(name, name)
+        if name not in KEYCODES or name in {"ctrl", "shift", "alt", "super", "v"}:
+            continue
+        if name in ARROW_KEYS and not explicit:
+            return None
+        tail = words[length:]
+        if not tail:
+            return KEYCODES[name], 1
+        if len(tail) > 1:
+            return None
+        count = int(tail[0]) if tail[0].isdigit() else SPOKEN_COUNTS.get(tail[0])
+        if count is None:
+            return None
+        return KEYCODES[name], min(count, MAX_KEY_REPEATS)
+    return None
 
 
-def press_backspace(count):
-    """Send `count` backspace keystrokes; True when they were delivered."""
+def press_key(keycode, repeats=1):
+    """Tap `keycode` `repeats` times; True when the keystrokes were delivered."""
     try:
         from easyspeak.core import mediakeys
 
-        for _ in range(count):
-            mediakeys.tap_chord([KEYCODES["backspace"]])
+        for _ in range(repeats):
+            mediakeys.tap_chord([keycode])
     except (ImportError, RuntimeError, OSError) as exc:
-        logger.warning("Backspace needs GNOME's RemoteDesktop interface: %s", exc)
+        logger.warning("Keystrokes need GNOME's RemoteDesktop interface: %s", exc)
         return False
     return True
 
 
-def _handle_delete(core, text):
-    """Run "backspace"/"scratch that" if that is what was said; True when it was.
+def _handle_keystroke(core, text):
+    """Run a keystroke command if that is what was said; True when it was.
 
     A backspace shortens what "scratch that" still has to remove rather than
     discarding it, so the two can be used in either order on one utterance.
     """
-    words = text.split()
-    count = _backspace_count(words)
-    scratching = count is None and text in UNDO_PHRASES
+    request = _key_request(text.split())
+    scratching = request is None and text in UNDO_PHRASES
     if scratching:
-        count = core.dictation_last_length
-        if not count:
+        pending = core.dictation_last_length
+        if not pending:
             core.speak("Nothing to scratch")
             return True
-    if count is None:
+        request = (KEYCODES["backspace"], pending)
+    if request is None:
         return False
-    if not press_backspace(count):
+    keycode, repeats = request
+    if not press_key(keycode, repeats):
         core.speak("Dictation isn't set up on this system.")
         return True
     if scratching:
         core.dictation_last_length = 0
+    elif keycode == KEYCODES["backspace"]:
+        core.dictation_last_length = max(core.dictation_last_length - repeats, 0)
     else:
-        core.dictation_last_length = max(core.dictation_last_length - count, 0)
+        core.dictation_last_length = 0
     return True
 
 
@@ -803,7 +842,7 @@ def _dictation_session(core):
             core.speak("Done")
             return True
 
-        if _handle_delete(core, text):
+        if _handle_keystroke(core, text):
             continue
 
         if _dictate_utterance(core, text):

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -146,14 +146,14 @@ def test_ensure_gnome_accessibility_oserror(mock_which, mock_run, readlog):
         ("hello newline world", "Hello\nworld"),
         ("hello you line world", "Hello\nworld"),
         ("hello line break world", "Hello\nworld"),
-        ("hello enter world", "Hello\nworld"),
+        ("hello enter world", "Hello enter world"),
         # Backspace is a keystroke command, not text: it must survive as words
         ("hello backspace world", "Hello backspace world"),
         ("hello delete world", "Hello delete world"),
         # Space command
         ("hello space world", "Hello world"),
-        # Tab command
-        ("hello tab world", "Hello\tworld"),
+        # Tab and enter are keystroke commands, not text
+        ("hello tab world", "Hello tab world"),
         # Dash and hyphen
         ("hello dash world", "Hello - world"),
         ("hello hyphen world", "Hello-world"),
@@ -1295,68 +1295,83 @@ def test_the_browser_is_handed_back_even_after_a_failure(mock_qb, mock_core_with
 @pytest.mark.parametrize(
     ["spoken", "expected"],
     [
-        ("backspace", 1),
-        ("delete", 1),
-        ("backspace five", 5),
-        ("backspace 5", 5),
-        ("delete three", 3),
-        ("backspace 999", dictation.MAX_BACKSPACES),
+        ("backspace", ("backspace", 1)),
+        ("delete", ("backspace", 1)),
+        ("backspace five", ("backspace", 5)),
+        ("backspace 5", ("backspace", 5)),
+        ("delete three", ("backspace", 3)),
+        ("backspace 999", ("backspace", dictation.MAX_KEY_REPEATS)),
+        ("enter", ("enter", 1)),
+        ("press enter", ("enter", 1)),
+        ("return", ("enter", 1)),
+        ("tab", ("tab", 1)),
+        ("escape", ("escape", 1)),
+        ("page down", ("page down", 1)),
+        ("press down five", ("down", 5)),
+        ("press left 3", ("left", 3)),
+        ("down", None),
+        ("right", None),
         ("backspace the file", None),
         ("hello world", None),
+        ("enter the room", None),
     ],
 )
-def test_backspace_count(spoken, expected):
-    """A bare backspace is one character; a trailing count asks for more."""
-    assert dictation._backspace_count(spoken.split()) == expected
+def test_key_request(spoken, expected):
+    """Key commands take an optional press prefix and an optional repeat count."""
+    request = dictation._key_request(spoken.split())
+    if expected is None:
+        assert request is None
+    else:
+        assert request == (dictation.KEYCODES[expected[0]], expected[1])
 
 
-@patch.object(dictation, "press_backspace", return_value=True)
+@patch.object(dictation, "press_key", return_value=True)
 def test_handle_delete_sends_the_requested_count(mock_press, mock_core):
     """ "backspace five" removes five characters."""
     mock_core.dictation_last_length = 13
 
-    assert dictation._handle_delete(mock_core, "backspace five") is True
-    assert mock_press.call_args.args[0] == 5
+    assert dictation._handle_keystroke(mock_core, "backspace five") is True
+    assert mock_press.call_args.args == (dictation.KEYCODES["backspace"], 5)
 
 
-@patch.object(dictation, "press_backspace", return_value=True)
+@patch.object(dictation, "press_key", return_value=True)
 def test_scratch_that_removes_the_last_insertion(mock_press, mock_core):
     """The undo phrase removes exactly what the previous utterance inserted."""
     mock_core.dictation_last_length = 13
 
-    assert dictation._handle_delete(mock_core, "scratch that") is True
-    assert mock_press.call_args.args[0] == 13
+    assert dictation._handle_keystroke(mock_core, "scratch that") is True
+    assert mock_press.call_args.args == (dictation.KEYCODES["backspace"], 13)
     assert mock_core.dictation_last_length == 0
 
 
-@patch.object(dictation, "press_backspace")
+@patch.object(dictation, "press_key")
 def test_scratch_that_with_nothing_inserted(mock_press, mock_core):
     """With no previous insertion the user is told, and no keys are sent."""
     mock_core.dictation_last_length = 0
 
-    assert dictation._handle_delete(mock_core, "scratch that") is True
+    assert dictation._handle_keystroke(mock_core, "scratch that") is True
     assert not mock_press.called
     assert mock_core.speak.call_args.args[0] == "Nothing to scratch"
 
 
-@patch.object(dictation, "press_backspace")
+@patch.object(dictation, "press_key")
 def test_handle_delete_ignores_ordinary_speech(mock_press, mock_core):
     """Dictated words that are not a delete command fall through to insertion."""
-    assert dictation._handle_delete(mock_core, "hello world") is False
+    assert dictation._handle_keystroke(mock_core, "hello world") is False
     assert not mock_press.called
 
 
-@patch.object(dictation, "press_backspace", return_value=True)
+@patch.object(dictation, "press_key", return_value=True)
 def test_backspace_shortens_what_scratch_that_removes(mock_press, mock_core):
     """Backspacing part of an utterance leaves the rest still scratchable."""
     mock_core.dictation_last_length = 13
 
-    dictation._handle_delete(mock_core, "backspace")
-    dictation._handle_delete(mock_core, "backspace")
+    dictation._handle_keystroke(mock_core, "backspace")
+    dictation._handle_keystroke(mock_core, "backspace")
 
     assert mock_core.dictation_last_length == 11
 
-    dictation._handle_delete(mock_core, "scratch that")
+    dictation._handle_keystroke(mock_core, "scratch that")
 
-    assert mock_press.call_args.args[0] == 11
+    assert mock_press.call_args.args == (dictation.KEYCODES["backspace"], 11)
     assert mock_core.dictation_last_length == 0


### PR DESCRIPTION
Adds keystroke commands to dictation: enter, tab, escape, page up, page down, and the arrows. All take an optional 'press' prefix and a repeat count, so 'press down five' works the same way 'backspace five' does. The arrows require the prefix, since a bare 'up' or 'right' is ordinary speech.

enter and tab previously mapped to the newline and tab characters in format_text and were pasted as text, so neither submitted a form nor moved focus. Both now send the key, and both words dictate as ordinary text mid-sentence. 'new line' still inserts a newline character.

press_backspace becomes press_key and _handle_delete becomes _handle_keystroke, since neither is backspace-specific now.

commands.md drops the backspace and tab rows, which described insertion that never worked, and gains a table for the keystroke commands.