### PR TITLE
feat: keystroke commands in dictation and browser mode

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,10 @@ Requires a webcam and additional dependencies — see [Installation](installatio
 | search [query] | Web search (DuckDuckGo) |
 | go to [url] | Navigate to URL |
 | open youtube | Open bookmark[^bookmarks] |
+| enter | Press Enter (submit a form or search) |
+| press tab | Press Tab |
+| press escape | Press Escape in the page |
+| press down five | Press the Down arrow five times |
 | exit browser | Leave browser mode |
 
 [^hints]:
@@ -98,6 +102,9 @@ Requires a webcam and additional dependencies — see [Installation](installatio
 
 Commands may start with a filler word — "and scroll down", "so back" — which is
 stripped before matching, since Whisper adds them.
+
+Keystrokes need `press` in front here, apart from `enter`: `down`, `up`, `tab` and
+`escape` already mean something else in this mode.
 
 ## Dictation
 

--- a/src/core/mediakeys.py
+++ b/src/core/mediakeys.py
@@ -9,8 +9,12 @@ as the D-Bus connection that created it, so the whole CreateSession -> Start ->
 NotifyKeyboardKeycode -> Stop sequence runs on one connection.
 """
 
+import logging
+
 from jeepney import DBusAddress, new_method_call
 from jeepney.io.blocking import open_dbus_connection
+
+logger = logging.getLogger(__name__)
 
 _BUS = "org.gnome.Mutter.RemoteDesktop"
 
@@ -67,3 +71,82 @@ def tap_chord(keycodes):
         conn.send_and_get_reply(new_method_call(session, "Stop"))
     finally:
         conn.close()
+
+
+KEYS = {
+    "enter": 28,
+    "tab": 15,
+    "escape": 1,
+    "backspace": 14,
+    "up": 103,
+    "down": 108,
+    "left": 105,
+    "right": 106,
+    "home": 102,
+    "end": 107,
+    "page up": 104,
+    "page down": 109,
+}
+
+KEY_ALIASES = {
+    "delete": "backspace",
+    "return": "enter",
+    "escape key": "escape",
+}
+
+SPOKEN_COUNTS = {
+    "one": 1,
+    "two": 2,
+    "three": 3,
+    "four": 4,
+    "five": 5,
+    "six": 6,
+    "seven": 7,
+    "eight": 8,
+    "nine": 9,
+    "ten": 10,
+}
+
+MAX_KEY_REPEATS = 200
+
+
+def parse_key_request(words, bare_allowed):
+    """Return (keycode, repeats) for a spoken keystroke command, else None.
+
+    Accepts an optional "press" prefix, one- or two-word key names, and a trailing
+    count as digits or a number word. `bare_allowed` names the keys a caller will
+    accept without the prefix; every other key needs it, so that words already
+    meaning something else in that mode are left alone.
+    """
+    explicit = bool(words) and words[0] == "press"
+    if explicit:
+        words = words[1:]
+    if not words:
+        return None
+
+    for length in (2, 1):
+        name = " ".join(words[:length])
+        name = KEY_ALIASES.get(name, name)
+        if name not in KEYS or (not explicit and name not in bare_allowed):
+            continue
+        tail = words[length:]
+        if not tail:
+            return KEYS[name], 1
+        if len(tail) > 1:
+            return None
+        count = int(tail[0]) if tail[0].isdigit() else SPOKEN_COUNTS.get(tail[0])
+        if count is None:
+            return None
+        return KEYS[name], min(count, MAX_KEY_REPEATS)
+    return None
+
+
+def press_key(keycode, repeats=1):
+    """Tap `keycode` `repeats` times; True when the keystrokes were delivered."""
+    try:
+        for _ in range(repeats):
+            tap_chord([keycode])
+    except (RuntimeError, OSError) as exc:
+        logger.warning("Keystrokes need GNOME's RemoteDesktop interface: %s", exc)
+        return False
+    return True

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -6,7 +6,13 @@ import subprocess
 import time
 from pathlib import Path
 
+from easyspeak.core import mediakeys
+
 logger = logging.getLogger(__name__)
+
+# down, up, tab and escape already mean something in this mode, so every key but
+# enter needs the "press" prefix.
+BARE_KEYS = frozenset({"enter"})
 
 NAME = "browser"
 DESCRIPTION = "Qutebrowser voice control"
@@ -898,6 +904,13 @@ def handle_browser_command(cmd_lower, core):
     # --- Escape ---
     if cmd_lower in ["escape", "cancel", "nevermind"]:
         qb("fake-key <Escape>")
+        return True
+
+    # --- Keystrokes ---
+    request = mediakeys.parse_key_request(cmd_lower.split(), BARE_KEYS)
+    if request is not None:
+        if not mediakeys.press_key(*request):
+            core.speak("Keystrokes need GNOME.")
         return True
 
     # --- Bookmarks ---

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -11,6 +11,8 @@ import threading
 import time
 from pathlib import Path
 
+from easyspeak.core import mediakeys
+
 logger = logging.getLogger(__name__)
 
 NAME = "dictation"
@@ -131,18 +133,6 @@ KEYCODES = {
     "super": 125,
     "insert": 110,
     "v": 47,
-    "backspace": 14,
-    "enter": 28,
-    "tab": 15,
-    "escape": 1,
-    "up": 103,
-    "down": 108,
-    "left": 105,
-    "right": 106,
-    "home": 102,
-    "end": 107,
-    "page up": 104,
-    "page down": 109,
 }
 
 DEFAULT_PASTE_CHORD = "ctrl+v"
@@ -434,8 +424,6 @@ def insert_text(text):
     )
 
     try:
-        from easyspeak.core import mediakeys
-
         mediakeys.tap_chord(chord)
     except Exception:
         logger.warning(
@@ -638,77 +626,10 @@ def format_text(text):
     return text.strip()
 
 
-SPOKEN_COUNTS = {
-    "one": 1,
-    "two": 2,
-    "three": 3,
-    "four": 4,
-    "five": 5,
-    "six": 6,
-    "seven": 7,
-    "eight": 8,
-    "nine": 9,
-    "ten": 10,
-}
-
-MAX_KEY_REPEATS = 200
-
 UNDO_PHRASES = frozenset({"scratch that", "scratch this", "undo that", "undo this"})
 
-KEY_ALIASES = {
-    "delete": "backspace",
-    "return": "enter",
-    "escape key": "escape",
-}
-
 # Bare "up" or "right" is ordinary speech, so the arrows need "press" in front.
-ARROW_KEYS = frozenset({"up", "down", "left", "right"})
-
-
-def _key_request(words):
-    """Return (keycode, repeats) for a keystroke command, or None if it isn't one.
-
-    Accepts an optional "press" prefix, one- or two-word key names, and a trailing
-    count as digits or a number word.
-    """
-    if words and words[0] == "press":
-        words = words[1:]
-        explicit = True
-    else:
-        explicit = False
-    if not words:
-        return None
-
-    for length in (2, 1):
-        name = " ".join(words[:length])
-        name = KEY_ALIASES.get(name, name)
-        if name not in KEYCODES or name in {"ctrl", "shift", "alt", "super", "v"}:
-            continue
-        if name in ARROW_KEYS and not explicit:
-            return None
-        tail = words[length:]
-        if not tail:
-            return KEYCODES[name], 1
-        if len(tail) > 1:
-            return None
-        count = int(tail[0]) if tail[0].isdigit() else SPOKEN_COUNTS.get(tail[0])
-        if count is None:
-            return None
-        return KEYCODES[name], min(count, MAX_KEY_REPEATS)
-    return None
-
-
-def press_key(keycode, repeats=1):
-    """Tap `keycode` `repeats` times; True when the keystrokes were delivered."""
-    try:
-        from easyspeak.core import mediakeys
-
-        for _ in range(repeats):
-            mediakeys.tap_chord([keycode])
-    except (ImportError, RuntimeError, OSError) as exc:
-        logger.warning("Keystrokes need GNOME's RemoteDesktop interface: %s", exc)
-        return False
-    return True
+BARE_KEYS = frozenset(mediakeys.KEYS) - {"up", "down", "left", "right"}
 
 
 def _handle_keystroke(core, text):
@@ -717,23 +638,23 @@ def _handle_keystroke(core, text):
     A backspace shortens what "scratch that" still has to remove rather than
     discarding it, so the two can be used in either order on one utterance.
     """
-    request = _key_request(text.split())
+    request = mediakeys.parse_key_request(text.split(), BARE_KEYS)
     scratching = request is None and text in UNDO_PHRASES
     if scratching:
         pending = core.dictation_last_length
         if not pending:
             core.speak("Nothing to scratch")
             return True
-        request = (KEYCODES["backspace"], pending)
+        request = (mediakeys.KEYS["backspace"], pending)
     if request is None:
         return False
     keycode, repeats = request
-    if not press_key(keycode, repeats):
+    if not mediakeys.press_key(keycode, repeats):
         core.speak("Dictation isn't set up on this system.")
         return True
     if scratching:
         core.dictation_last_length = 0
-    elif keycode == KEYCODES["backspace"]:
+    elif keycode == mediakeys.KEYS["backspace"]:
         core.dictation_last_length = max(core.dictation_last_length - repeats, 0)
     else:
         core.dictation_last_length = 0

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from easyspeak.core import mediakeys
 from easyspeak.plugins import browser
 
 # Tests for parse_hint_numbers function.
@@ -1830,3 +1831,29 @@ def test_page_state_belongs_to_the_session(
 
     assert "reload" not in [call.args[0] for call in mock_qb.call_args_list]
     assert first.browser_page_js_stale is True
+
+
+@pytest.mark.parametrize(
+    ["command", "key"],
+    [
+        ("enter", "enter"),
+        ("press enter", "enter"),
+        ("press tab", "tab"),
+        ("press escape", "escape"),
+        ("press down", "down"),
+    ],
+)
+@patch.object(mediakeys, "press_key", return_value=True)
+def test_browser_sends_keystrokes(mock_press, command, key, mock_core):
+    """Keystroke commands reach the page rather than qutebrowser's command line."""
+    assert browser.handle_browser_command(command, mock_core) is True
+    assert mock_press.call_args.args[0] == mediakeys.KEYS[key]
+
+
+@pytest.mark.parametrize("command", ["down", "up", "tab", "escape"])
+@patch.object(mediakeys, "press_key")
+def test_browser_words_keep_their_own_meaning(mock_press, command, mock_core):
+    """Words that already mean something in this mode are not treated as keys."""
+    browser.handle_browser_command(command, mock_core)
+
+    assert not mock_press.called

--- a/tests/unit/plugins/test_dictation.py
+++ b/tests/unit/plugins/test_dictation.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import Mock, patch
 
 import pytest
+from easyspeak.core import mediakeys
 from easyspeak.plugins import dictation
 
 
@@ -1300,7 +1301,7 @@ def test_the_browser_is_handed_back_even_after_a_failure(mock_qb, mock_core_with
         ("backspace five", ("backspace", 5)),
         ("backspace 5", ("backspace", 5)),
         ("delete three", ("backspace", 3)),
-        ("backspace 999", ("backspace", dictation.MAX_KEY_REPEATS)),
+        ("backspace 999", ("backspace", mediakeys.MAX_KEY_REPEATS)),
         ("enter", ("enter", 1)),
         ("press enter", ("enter", 1)),
         ("return", ("enter", 1)),
@@ -1318,33 +1319,33 @@ def test_the_browser_is_handed_back_even_after_a_failure(mock_qb, mock_core_with
 )
 def test_key_request(spoken, expected):
     """Key commands take an optional press prefix and an optional repeat count."""
-    request = dictation._key_request(spoken.split())
+    request = mediakeys.parse_key_request(spoken.split(), dictation.BARE_KEYS)
     if expected is None:
         assert request is None
     else:
-        assert request == (dictation.KEYCODES[expected[0]], expected[1])
+        assert request == (mediakeys.KEYS[expected[0]], expected[1])
 
 
-@patch.object(dictation, "press_key", return_value=True)
+@patch.object(mediakeys, "press_key", return_value=True)
 def test_handle_delete_sends_the_requested_count(mock_press, mock_core):
     """ "backspace five" removes five characters."""
     mock_core.dictation_last_length = 13
 
     assert dictation._handle_keystroke(mock_core, "backspace five") is True
-    assert mock_press.call_args.args == (dictation.KEYCODES["backspace"], 5)
+    assert mock_press.call_args.args == (mediakeys.KEYS["backspace"], 5)
 
 
-@patch.object(dictation, "press_key", return_value=True)
+@patch.object(mediakeys, "press_key", return_value=True)
 def test_scratch_that_removes_the_last_insertion(mock_press, mock_core):
     """The undo phrase removes exactly what the previous utterance inserted."""
     mock_core.dictation_last_length = 13
 
     assert dictation._handle_keystroke(mock_core, "scratch that") is True
-    assert mock_press.call_args.args == (dictation.KEYCODES["backspace"], 13)
+    assert mock_press.call_args.args == (mediakeys.KEYS["backspace"], 13)
     assert mock_core.dictation_last_length == 0
 
 
-@patch.object(dictation, "press_key")
+@patch.object(mediakeys, "press_key")
 def test_scratch_that_with_nothing_inserted(mock_press, mock_core):
     """With no previous insertion the user is told, and no keys are sent."""
     mock_core.dictation_last_length = 0
@@ -1354,14 +1355,14 @@ def test_scratch_that_with_nothing_inserted(mock_press, mock_core):
     assert mock_core.speak.call_args.args[0] == "Nothing to scratch"
 
 
-@patch.object(dictation, "press_key")
+@patch.object(mediakeys, "press_key")
 def test_handle_delete_ignores_ordinary_speech(mock_press, mock_core):
     """Dictated words that are not a delete command fall through to insertion."""
     assert dictation._handle_keystroke(mock_core, "hello world") is False
     assert not mock_press.called
 
 
-@patch.object(dictation, "press_key", return_value=True)
+@patch.object(mediakeys, "press_key", return_value=True)
 def test_backspace_shortens_what_scratch_that_removes(mock_press, mock_core):
     """Backspacing part of an utterance leaves the rest still scratchable."""
     mock_core.dictation_last_length = 13
@@ -1373,5 +1374,5 @@ def test_backspace_shortens_what_scratch_that_removes(mock_press, mock_core):
 
     dictation._handle_keystroke(mock_core, "scratch that")
 
-    assert mock_press.call_args.args == (dictation.KEYCODES["backspace"], 11)
+    assert mock_press.call_args.args == (mediakeys.KEYS["backspace"], 11)
     assert mock_core.dictation_last_length == 0


### PR DESCRIPTION
Adds enter, tab, escape, page up, page down and the arrows as spoken keystrokes. All take an optional 'press' prefix and a repeat count, so 'press down five' works like 'backspace five'.

Each mode declares which keys it accepts without the prefix. Dictation takes everything but the arrows, since a bare 'up' or 'right' is ordinary speech. Browser mode takes only enter, since down, up, tab and escape already mean scroll, browser tabs and cancel there.

The key table, parser and sender live in core.mediakeys rather than the dictation plugin, so browser.py does not have to import another plugin.

enter and tab previously mapped to the newline and tab characters in format_text and were pasted as text, so neither submitted a form nor moved focus.