### PR TITLE
feat(browser): voice toggles for rendering and ad blocking

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,10 @@ Requires a webcam and additional dependencies — see [Installation](installatio
 | search [query] | Web search (DuckDuckGo) |
 | go to [url] | Navigate to URL |
 | open youtube | Open bookmark[^bookmarks] |
+| fix rendering | Switch the browser to software rendering[^rendering] |
+| restore rendering | Switch it back to hardware rendering |
+| allow ads | Turn ad blocking off[^adblock] |
+| block ads | Turn ad blocking back on |
 | enter | Press Enter (submit a form or search) |
 | press tab | Press Tab |
 | press escape | Press Escape in the page |
@@ -95,6 +99,18 @@ Requires a webcam and additional dependencies — see [Installation](installatio
     needed for link hints to appear as numbers. See
     [Troubleshooting](troubleshooting.md#browser-plugin-link-numbers-dont-work)
     if numbers don't show.
+
+[^rendering]:
+    Some graphics drivers render video sites badly under qutebrowser — smeared
+    text, stuttering icons, a player that flickers. This writes
+    `c.qt.args = ['disable-gpu-compositing']` to your qutebrowser config and
+    restarts the browser. Say "restore rendering" to undo it.
+
+[^adblock]:
+    Some sites detect element-level ad blocking and break on purpose. This writes
+    `c.content.blocking.enabled = False` and restarts the browser. Ad overlays
+    then take hint numbers away from the page underneath, so turn it back on when
+    you are done.
 
 [^bookmarks]:
     Built-in bookmarks: youtube, google, gmail, github, reddit, twitter,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -101,6 +101,33 @@ navigation, which costs your scroll position. You'll hear "Reloading" and see:
 ↻ Reloading: page scripts don't survive a history navigation
 ```
 
+## Browser renders badly
+
+On some graphics drivers qutebrowser renders video sites wrong: text smears over
+itself, icons stutter, the player flickers or disappears. YouTube is the usual
+place to notice it.
+
+Say **"fix rendering"** in browser mode. That writes the line below to your
+qutebrowser config and restarts the browser:
+
+```python
+c.qt.args = ['disable-gpu-compositing']
+```
+
+Say **"restore rendering"** to put it back, or delete the line by hand.
+
+This turns off GPU compositing for qutebrowser only, so video decoding is a
+little more expensive. Leave it off unless you see the problem.
+
+## A site breaks with ad blocking on
+
+EasySpeak turns on element-level ad blocking when `python3-adblock` is installed,
+because ad overlays are numbered like anything else and steal hint numbers from
+the page underneath. Some sites detect it and break on purpose.
+
+Say **"allow ads"** in browser mode to turn blocking off and restart the browser,
+and **"block ads"** to turn it back on.
+
 ## Wake word not detecting
 
 - Check the microphone: `arecord -d 3 test.wav && aplay test.wav`

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -226,6 +226,44 @@ def _setting_name(line):
     return match.group(1) if match else None
 
 
+SOFTWARE_RENDERING_LINE = "c.qt.args = ['disable-gpu-compositing']"
+
+ADBLOCK_OFF_LINE = "c.content.blocking.enabled = False"
+
+
+def set_config_line(line, *, wanted):
+    """Add or remove one line in qutebrowser's config.py, keyed on its setting.
+
+    Returns None when the config can't be written, so the caller can say why.
+    """
+    cfg = Path.home() / ".config" / "qutebrowser" / "config.py"
+    try:
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        existing = cfg.read_text() if cfg.exists() else ""
+        kept = [
+            text
+            for text in existing.splitlines()
+            if _setting_name(text) != _setting_name(line)
+        ]
+        if wanted:
+            kept.append(line)
+        cfg.write_text("\n".join(kept) + "\n")
+    except OSError as exc:
+        logger.warning("Could not write %s: %s", cfg, exc)
+        return None
+    return wanted
+
+
+def _apply_config_line(core, line, spoken, *, wanted):
+    """Write a config toggle and restart qutebrowser so it takes effect."""
+    if set_config_line(line, wanted=wanted) is None:
+        core.speak("Could not write the browser config.")
+        return True
+    core.speak(f"{spoken}. Restarting the browser.")
+    qb("restart")
+    return True
+
+
 def ensure_qutebrowser_config():
     """Bring qutebrowser's config.py in line with what EasySpeak needs.
 
@@ -905,6 +943,27 @@ def handle_browser_command(cmd_lower, core):
     if cmd_lower in ["escape", "cancel", "nevermind"]:
         qb("fake-key <Escape>")
         return True
+
+    # --- Browser config toggles ---
+    if cmd_lower in ["software rendering", "fix rendering", "fix the display"]:
+        return _apply_config_line(
+            core, SOFTWARE_RENDERING_LINE, "Software rendering on", wanted=True
+        )
+
+    if cmd_lower in ["hardware rendering", "restore rendering"]:
+        return _apply_config_line(
+            core, SOFTWARE_RENDERING_LINE, "Hardware rendering on", wanted=False
+        )
+
+    if cmd_lower in ["allow ads", "stop blocking ads", "disable ad blocking"]:
+        return _apply_config_line(
+            core, ADBLOCK_OFF_LINE, "Ad blocking off", wanted=True
+        )
+
+    if cmd_lower in ["block ads", "enable ad blocking"]:
+        return _apply_config_line(
+            core, ADBLOCK_OFF_LINE, "Ad blocking on", wanted=False
+        )
 
     # --- Keystrokes ---
     request = mediakeys.parse_key_request(cmd_lower.split(), BARE_KEYS)

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -1857,3 +1857,78 @@ def test_browser_words_keep_their_own_meaning(mock_press, command, mock_core):
     browser.handle_browser_command(command, mock_core)
 
     assert not mock_press.called
+
+
+def test_software_rendering_adds_the_line(tmp_path, monkeypatch):
+    """Turning it on appends the qt.args line to config.py."""
+    monkeypatch.setattr(browser.Path, "home", lambda: tmp_path)
+
+    assert browser.set_config_line(browser.SOFTWARE_RENDERING_LINE, wanted=True) is True
+
+    cfg = tmp_path / ".config" / "qutebrowser" / "config.py"
+    assert browser.SOFTWARE_RENDERING_LINE in cfg.read_text()
+
+
+def test_software_rendering_removes_the_line(tmp_path, monkeypatch):
+    """Turning it off takes the line back out and leaves the rest alone."""
+    monkeypatch.setattr(browser.Path, "home", lambda: tmp_path)
+    cfg = tmp_path / ".config" / "qutebrowser" / "config.py"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(f"c.hints.chars = '0123456789'\n{browser.SOFTWARE_RENDERING_LINE}\n")
+
+    assert (
+        browser.set_config_line(browser.SOFTWARE_RENDERING_LINE, wanted=False) is False
+    )
+
+    written = cfg.read_text()
+    assert browser.SOFTWARE_RENDERING_LINE not in written
+    assert "c.hints.chars" in written
+
+
+def test_software_rendering_is_not_added_twice(tmp_path, monkeypatch):
+    """Asking for it again replaces the line rather than appending another."""
+    monkeypatch.setattr(browser.Path, "home", lambda: tmp_path)
+
+    browser.set_config_line(browser.SOFTWARE_RENDERING_LINE, wanted=True)
+    browser.set_config_line(browser.SOFTWARE_RENDERING_LINE, wanted=True)
+
+    cfg = tmp_path / ".config" / "qutebrowser" / "config.py"
+    assert cfg.read_text().count(browser.SOFTWARE_RENDERING_LINE) == 1
+
+
+@patch.object(browser, "qb")
+@patch.object(browser, "set_config_line", return_value=True)
+def test_fix_rendering_restarts_the_browser(mock_set, mock_qb, mock_core):
+    """The setting only applies on a fresh qutebrowser process."""
+    assert browser.handle_browser_command("fix rendering", mock_core) is True
+    assert mock_set.call_args.args[0] == browser.SOFTWARE_RENDERING_LINE
+    assert mock_qb.call_args.args[0] == "restart"
+
+
+@patch.object(browser, "qb")
+@patch.object(browser, "set_config_line", return_value=None)
+def test_rendering_reports_an_unwritable_config(mock_set, mock_qb, mock_core):
+    """A read-only config is reported rather than silently ignored."""
+    browser.handle_browser_command("fix rendering", mock_core)
+
+    assert not mock_qb.called
+    assert "Could not write" in mock_core.speak.call_args.args[0]
+
+
+@pytest.mark.parametrize(
+    ["command", "wanted"],
+    [
+        ("allow ads", True),
+        ("stop blocking ads", True),
+        ("block ads", False),
+        ("enable ad blocking", False),
+    ],
+)
+@patch.object(browser, "qb")
+@patch.object(browser, "set_config_line", return_value=True)
+def test_adblock_toggle(mock_set, mock_qb, command, wanted, mock_core):
+    """Ad blocking can be turned off for sites that fight it, and back on."""
+    assert browser.handle_browser_command(command, mock_core) is True
+    assert mock_set.call_args.args[0] == browser.ADBLOCK_OFF_LINE
+    assert mock_set.call_args.kwargs["wanted"] is wanted
+    assert mock_qb.call_args.args[0] == "restart"


### PR DESCRIPTION
Adds 'fix rendering' and 'restore rendering', which toggle disable-gpu-compositing in the qutebrowser config and restart the browser. Some drivers render video sites wrong under QtWebEngine, with smeared text, stuttering icons and a flickering player, and the setting only applies to a fresh process. Opt-in, so machines that render correctly keep GPU compositing.

Adds 'allow ads' and 'block ads', since some sites detect element-level blocking and break on purpose. Turning blocking off means ad overlays start taking hint numbers from the page underneath, which is why it is on by default.

Both toggles share one config writer, keyed on the setting name so saying a command twice replaces the line rather than appending another.

Documented in commands.md and troubleshooting.md.