### PR TITLE
feat: option to require the wake word inside modes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,6 +223,19 @@ Folders open in whatever file manager your desktop is configured for (via
 Volume changes are silent — GNOME's own on-screen display and chime acknowledge
 them.
 
+## Speakers playing audio
+
+Modes normally take a command on their own, with no wake word. That is faster, but
+a video playing through speakers reaches the microphone too, and its speech is
+transcribed like anything else.
+
+Say **"require wake word"** and modes stop accepting bare commands: say
+"Hey Jarvis, numbers" rather than "numbers". Page audio never says the wake word,
+so it can no longer trigger anything. Say **"free listening"** to go back.
+
+Set `EASYSPEAK_REQUIRE_WAKE_WORD=1` to start that way every time. Headphones or
+PipeWire echo cancellation solve the same problem at the audio level.
+
 ## Knowing which mode is listening
 
 Modes announce themselves, so you don't need a terminal to follow along:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -103,7 +103,7 @@ Requires a webcam and additional dependencies — see [Installation](installatio
 [^rendering]:
     Some graphics drivers render video sites badly under qutebrowser — smeared
     text, stuttering icons, a player that flickers. This writes
-    `c.qt.args = ['disable-gpu-compositing']` to your qutebrowser config and
+    `c.qt.args = ["disable-gpu-compositing"]` to your qutebrowser config and
     restarts the browser. Say "restore rendering" to undo it.
 
 [^adblock]:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -111,7 +111,7 @@ Say **"fix rendering"** in browser mode. That writes the line below to your
 qutebrowser config and restarts the browser:
 
 ```python
-c.qt.args = ['disable-gpu-compositing']
+c.qt.args = ["disable-gpu-compositing"]
 ```
 
 Say **"restore rendering"** to put it back, or delete the line by hand.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,6 +47,7 @@ the module that reads each (linked to its API reference).
 | `EASYSPEAK_HOTKEY`               | `ctrl+shift`                           | Keys held to dictate without the wake word |
 | `EASYSPEAK_OFFLINE`              | `strict`                               | Stay offline; `relaxed` downloads models   |
 | `EASYSPEAK_PIPER_BIN`            | `piper`                                | Piper TTS binary                           |
+| `EASYSPEAK_REQUIRE_WAKE_WORD`    | unset                                  | Modes need the wake word on every command  |
 | `EASYSPEAK_PIPER_MODEL`          | bundled Amy voice                      | Piper voice `.onnx` for speech output      |
 | `EASYSPEAK_SOUNDS_DIR`           | `/usr/share/sounds/freedesktop/stereo` | Directory of the wake chime and error bell |
 | `EASYSPEAK_WHISPER_COMPUTE_TYPE` | `int8`                                 | CTranslate2 compute type                   |

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -41,6 +41,11 @@ WAKE_WORD_SPOKEN = "Hey Jarvis"
 WAKE_THRESHOLD = 0.5
 WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
 
+# Modes normally accept a bare command. With this on they need the wake word too,
+# which keeps a speaker playing video from being transcribed as commands.
+_require_wake = os.environ.get("EASYSPEAK_REQUIRE_WAKE_WORD", "").strip().lower()
+REQUIRE_WAKE_WORD = _require_wake in {"1", "true", "yes", "on"}
+
 # --- Audio thresholds ---
 SILENCE_THRESHOLD = 300
 

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -23,6 +23,7 @@ from .config import (
     HOTKEY_COMBO,
     MAX_RECORD_SECONDS,
     MISUNDERSTAND_GRACE,
+    REQUIRE_WAKE_WORD,
     SILENCE_CALIBRATION_SECONDS,
     SILENCE_DURATION,
     SILENCE_NOISE_MARGIN,
@@ -57,6 +58,15 @@ WAKE_PREFIXES = (
     "jarvis",
     "jarvis,",
 )
+
+
+def has_wake_prefix(cmd):
+    """True when a spoken command starts with the wake word."""
+    cmd = cmd.lower().strip()
+    return any(
+        cmd == wake or (cmd.startswith(wake) and cmd[len(wake) :][:1] in " ,.!?")
+        for wake in WAKE_PREFIXES
+    )
 
 
 def strip_wake_words(cmd):
@@ -113,6 +123,7 @@ class EasySpeak:
         # modal mode, so the request survives the unwind back to the main loop.
         self.exit_requested = False
         self.last_misunderstand_time = 0
+        self.require_wake_word = REQUIRE_WAKE_WORD
         # Persistent text-to-speech pipeline (piper -> audio player) so the
         # voice model is loaded only once.
         self.speech = SpeechPipeline()
@@ -603,6 +614,10 @@ class EasySpeak:
             if not text:
                 # Noise, or an echo of our own prompt. Not a command, so the
                 # deadline stands.
+                continue
+
+            if self.require_wake_word and not has_wake_prefix(text):
+                logger.debug("  no wake word, ignoring: %s", text)
                 continue
 
             spoken = strip_wake_words(text)

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -226,7 +226,7 @@ def _setting_name(line):
     return match.group(1) if match else None
 
 
-SOFTWARE_RENDERING_LINE = "c.qt.args = ['disable-gpu-compositing']"
+SOFTWARE_RENDERING_LINE = 'c.qt.args = ["disable-gpu-compositing"]'
 
 ADBLOCK_OFF_LINE = "c.content.blocking.enabled = False"
 

--- a/src/plugins/zz_base.py
+++ b/src/plugins/zz_base.py
@@ -5,6 +5,8 @@ DESCRIPTION = "Help and exit commands"
 
 COMMANDS = [
     "help - list all commands",
+    "require wake word - modes stop accepting bare commands",
+    "free listening - modes accept bare commands again",
     "quit/exit/goodbye - exit EasySpeak",
 ]
 
@@ -24,6 +26,16 @@ def handle(cmd, core):
     command is for another plugin.
     """
     cmd_lower = cmd.lower().strip()
+
+    if cmd_lower in ["require wake word", "require the wake word"]:
+        core.require_wake_word = True
+        core.speak("Modes now need the wake word.")
+        return True
+
+    if cmd_lower in ["free listening", "stop requiring wake word"]:
+        core.require_wake_word = False
+        core.speak("Modes now take commands on their own.")
+        return True
 
     # Exit - but NOT if it's "quit tracking" etc
     if "tracking" not in cmd_lower:

--- a/tests/unit/core/test_listen_modal.py
+++ b/tests/unit/core/test_listen_modal.py
@@ -666,3 +666,37 @@ class TestWakeWordStripping:
         itself.
         """
         assert main.strip_wake_words(spoken) == spoken
+
+
+class TestRequireWakeWord:
+    """Modes can be told to accept only commands that carry the wake word."""
+
+    @pytest.mark.parametrize(
+        ["spoken", "expected"],
+        [
+            ("hey jarvis, numbers", True),
+            ("hey jarvis numbers", True),
+            ("jarvis, back", True),
+            ("Hey Jarvis", True),
+            ("numbers", False),
+            ("and now the weather forecast", False),
+        ],
+    )
+    def test_has_wake_prefix(self, spoken, expected):
+        """Only a leading wake word counts, so page audio cannot pass as a command."""
+        assert main.has_wake_prefix(spoken) is expected
+
+    def test_bare_commands_are_ignored_when_required(self, easy):
+        """With the flag on, an utterance without the wake word is not a command."""
+        easy.require_wake_word = True
+        drive(easy, [b"a", b"b"], ["scroll down", "hey jarvis, back"])
+
+        with clock():
+            assert list(easy.listen_modal("browser")) == ["back"]
+
+    def test_bare_commands_pass_by_default(self, easy):
+        """The flag is off by default, so modes still take a bare command."""
+        drive(easy, [b"a"], ["scroll down"])
+
+        with clock():
+            assert list(easy.listen_modal("browser")) == ["scroll down"]

--- a/tests/unit/plugins/test_zz_base.py
+++ b/tests/unit/plugins/test_zz_base.py
@@ -174,3 +174,18 @@ def test_show_help_with_plugins_without_commands_attribute(mock_print, mock_core
         call.args[0] if call.args else "" for call in mock_print.call_args_list
     ]
     assert "\n=== Available Commands ===" in print_calls
+
+
+@pytest.mark.parametrize(
+    ["command", "expected"],
+    [
+        ("require wake word", True),
+        ("require the wake word", True),
+        ("free listening", False),
+        ("stop requiring wake word", False),
+    ],
+)
+def test_wake_word_requirement_toggle(command, expected, mock_core):
+    """The requirement can be turned on and off by voice, in any mode."""
+    assert zz_base.handle(command, mock_core) is True
+    assert mock_core.require_wake_word is expected


### PR DESCRIPTION
listen_modal strips a leading wake word but does not require one, so every utterance the microphone picks up is a command candidate. With a video playing through speakers, its speech is transcribed and acted on.

Adds core.require_wake_word, off by default. With it on, listen_modal drops any utterance that does not start with the wake word, which page audio never does. Toggled by voice with 'require wake word' and 'free listening', or defaulted with EASYSPEAK_REQUIRE_WAKE_WORD=1.