### PR TITLE
fix: wait for the real wake word in modes, not a text prefix

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -229,9 +229,10 @@ Modes normally take a command on their own, with no wake word. That is faster, b
 a video playing through speakers reaches the microphone too, and its speech is
 transcribed like anything else.
 
-Say **"require wake word"** and modes stop accepting bare commands: say
-"Hey Jarvis, numbers" rather than "numbers". Page audio never says the wake word,
-so it can no longer trigger anything. Say **"free listening"** to go back.
+Say **"require wake word"** and modes wait for the wake word before every
+command, exactly like the main loop: say "Hey Jarvis", wait for the chime, then
+say the command. Page audio never says the wake word, so it can no longer trigger
+anything. Say **"free listening"** to go back.
 
 Set `EASYSPEAK_REQUIRE_WAKE_WORD=1` to start that way every time. Headphones or
 PipeWire echo cancellation solve the same problem at the audio level.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,7 +47,7 @@ the module that reads each (linked to its API reference).
 | `EASYSPEAK_HOTKEY`               | `ctrl+shift`                           | Keys held to dictate without the wake word |
 | `EASYSPEAK_OFFLINE`              | `strict`                               | Stay offline; `relaxed` downloads models   |
 | `EASYSPEAK_PIPER_BIN`            | `piper`                                | Piper TTS binary                           |
-| `EASYSPEAK_REQUIRE_WAKE_WORD`    | unset                                  | Modes need the wake word on every command  |
+| `EASYSPEAK_REQUIRE_WAKE_WORD`    | unset                                  | Modes wait for the wake word each command  |
 | `EASYSPEAK_PIPER_MODEL`          | bundled Amy voice                      | Piper voice `.onnx` for speech output      |
 | `EASYSPEAK_SOUNDS_DIR`           | `/usr/share/sounds/freedesktop/stereo` | Directory of the wake chime and error bell |
 | `EASYSPEAK_WHISPER_COMPUTE_TYPE` | `int8`                                 | CTranslate2 compute type                   |

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -41,8 +41,8 @@ WAKE_WORD_SPOKEN = "Hey Jarvis"
 WAKE_THRESHOLD = 0.5
 WAKE_COOLDOWN = 3.0  # Seconds to ignore wake word after trigger
 
-# Modes normally accept a bare command. With this on they need the wake word too,
-# which keeps a speaker playing video from being transcribed as commands.
+# Modes normally accept a bare command. With this on they wait for the wake word
+# first, which keeps a speaker playing video from being transcribed as commands.
 _require_wake = os.environ.get("EASYSPEAK_REQUIRE_WAKE_WORD", "").strip().lower()
 REQUIRE_WAKE_WORD = _require_wake in {"1", "true", "yes", "on"}
 

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -60,15 +60,6 @@ WAKE_PREFIXES = (
 )
 
 
-def has_wake_prefix(cmd):
-    """True when a spoken command starts with the wake word."""
-    cmd = cmd.lower().strip()
-    return any(
-        cmd == wake or (cmd.startswith(wake) and cmd[len(wake) :][:1] in " ,.!?")
-        for wake in WAKE_PREFIXES
-    )
-
-
 def strip_wake_words(cmd):
     """Remove a leading spoken wake word and surrounding punctuation.
 
@@ -600,6 +591,11 @@ class EasySpeak:
                 self.speak(f"Leaving {label}. Say {WAKE_WORD_SPOKEN} to continue.")
                 return
 
+            if self.require_wake_word and not self.wait_for_wake(
+                timeout=min(timeout, remaining)
+            ):
+                continue
+
             self.flush_stream()
             # Never wait past the deadline, so the mode ends on time even when the
             # room is quiet enough that every listen runs its full length.
@@ -616,10 +612,6 @@ class EasySpeak:
                 # deadline stands.
                 continue
 
-            if self.require_wake_word and not has_wake_prefix(text):
-                logger.debug("  no wake word, ignoring: %s", text)
-                continue
-
             spoken = strip_wake_words(text)
             if not spoken:
                 continue  # the wake word on its own is not a command
@@ -634,6 +626,28 @@ class EasySpeak:
                 deadline = time.monotonic() + idle_timeout
 
     # --- Main loop ---
+
+    def wait_for_wake(self, timeout):
+        """Block until the wake word is heard, then chime. False on timeout.
+
+        The same detector, cooldown and chime the main loop uses, so a mode that
+        asks for the wake word behaves exactly like the wake-word loop does.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            pcm = self.stream.read(1280, exception_on_overflow=False)
+            score = self.wakeword.predict(pcm)
+            if score <= WAKE_THRESHOLD:
+                continue
+            now = time.time()
+            if now - self.last_wake_time < WAKE_COOLDOWN:
+                continue
+            self.last_wake_time = now
+            logger.info("🎤 Wake! (confidence: %.2f)", score)
+            self._reset_detector()
+            self._play_wake_chime()
+            return True
+        return False
 
     def _reset_detector(self):
         """Reset the wake detector and drop buffered mic audio.

--- a/src/plugins/zz_base.py
+++ b/src/plugins/zz_base.py
@@ -5,7 +5,7 @@ DESCRIPTION = "Help and exit commands"
 
 COMMANDS = [
     "help - list all commands",
-    "require wake word - modes stop accepting bare commands",
+    "require wake word - modes wait for the wake word each command",
     "free listening - modes accept bare commands again",
     "quit/exit/goodbye - exit EasySpeak",
 ]
@@ -29,7 +29,7 @@ def handle(cmd, core):
 
     if cmd_lower in ["require wake word", "require the wake word"]:
         core.require_wake_word = True
-        core.speak("Modes now need the wake word.")
+        core.speak("Modes now wait for the wake word.")
         return True
 
     if cmd_lower in ["free listening", "stop requiring wake word"]:

--- a/tests/unit/core/test_listen_modal.py
+++ b/tests/unit/core/test_listen_modal.py
@@ -669,34 +669,24 @@ class TestWakeWordStripping:
 
 
 class TestRequireWakeWord:
-    """Modes can be told to accept only commands that carry the wake word."""
+    """Modes can be told to wait for the wake word before every command."""
 
-    @pytest.mark.parametrize(
-        ["spoken", "expected"],
-        [
-            ("hey jarvis, numbers", True),
-            ("hey jarvis numbers", True),
-            ("jarvis, back", True),
-            ("Hey Jarvis", True),
-            ("numbers", False),
-            ("and now the weather forecast", False),
-        ],
-    )
-    def test_has_wake_prefix(self, spoken, expected):
-        """Only a leading wake word counts, so page audio cannot pass as a command."""
-        assert main.has_wake_prefix(spoken) is expected
-
-    def test_bare_commands_are_ignored_when_required(self, easy):
-        """With the flag on, an utterance without the wake word is not a command."""
+    def test_the_mode_waits_for_the_wake_word(self, easy):
+        """With the flag on, nothing is heard until the wake word fires."""
         easy.require_wake_word = True
-        drive(easy, [b"a", b"b"], ["scroll down", "hey jarvis, back"])
+        misses, hit = [False], [True]
+        easy.wait_for_wake = Mock(side_effect=misses + hit + misses * 20)
+        drive(easy, [b"a"], ["back"])
 
         with clock():
             assert list(easy.listen_modal("browser")) == ["back"]
 
-    def test_bare_commands_pass_by_default(self, easy):
-        """The flag is off by default, so modes still take a bare command."""
+    def test_a_mode_does_not_wait_by_default(self, easy):
+        """The flag is off by default, so the wake word is never waited on."""
+        easy.wait_for_wake = Mock()
         drive(easy, [b"a"], ["scroll down"])
 
         with clock():
-            assert list(easy.listen_modal("browser")) == ["scroll down"]
+            list(easy.listen_modal("browser"))
+
+        assert not easy.wait_for_wake.called


### PR DESCRIPTION
The first version only checked whether the transcript happened to start with the wake word. That meant no chime, and the whole phrase had to land in one recording — the natural pause after 'Hey Jarvis' ended it early, so the utterance transcribed to the wake word alone and was dropped in silence.

listen_modal now calls wait_for_wake, which runs the same detector, cooldown and chime as the main loop. Say 'Hey Jarvis', hear the pop, then say the command, exactly as at the top level.