### PR TITLE
fix(dictation): do not ask for the wake word before every sentence

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -232,7 +232,8 @@ transcribed like anything else.
 Say **"require wake word"** and modes wait for the wake word before every
 command, exactly like the main loop: say "Hey Jarvis", wait for the chime, then
 say the command. Page audio never says the wake word, so it can no longer trigger
-anything. Say **"free listening"** to go back.
+anything. Dictation is exempt, so a note still takes continuous speech. Say
+**"free listening"** to go back.
 
 Set `EASYSPEAK_REQUIRE_WAKE_WORD=1` to start that way every time. Headphones or
 PipeWire echo cancellation solve the same problem at the audio level.

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -539,6 +539,7 @@ class EasySpeak:
         idle_timeout=30,
         max_record_seconds=None,
         silence_duration=None,
+        wake_gated=True,
     ):
         """Yield transcribed commands for a plugin's modal mode. Plugin-facing.
 
@@ -562,7 +563,9 @@ class EasySpeak:
         survives without a recognised command. `max_record_seconds` and
         `silence_duration` fall back to the command defaults when None; dictation
         passes larger values, since a sentence has pauses in it and runs longer
-        than a command.
+        than a command. `wake_gated` is False for modes that capture continuous
+        speech rather than commands, so `require_wake_word` does not ask for the
+        wake word before every dictated sentence.
 
         Yields each recognised command, lowercased and stripped of surrounding
         punctuation. The generator simply stops when the mode should end, so a
@@ -591,8 +594,10 @@ class EasySpeak:
                 self.speak(f"Leaving {label}. Say {WAKE_WORD_SPOKEN} to continue.")
                 return
 
-            if self.require_wake_word and not self.wait_for_wake(
-                timeout=min(timeout, remaining)
+            if (
+                wake_gated
+                and self.require_wake_word
+                and not self.wait_for_wake(timeout=min(timeout, remaining))
             ):
                 continue
 

--- a/src/plugins/dictation.py
+++ b/src/plugins/dictation.py
@@ -756,6 +756,7 @@ def _dictation_session(core):
         idle_timeout=60,
         max_record_seconds=MAX_RECORD_SECONDS,
         silence_duration=SILENCE_DURATION,
+        wake_gated=False,
     ):
         logger.debug("   Raw: %s", text)
 

--- a/tests/unit/core/test_listen_modal.py
+++ b/tests/unit/core/test_listen_modal.py
@@ -690,3 +690,16 @@ class TestRequireWakeWord:
             list(easy.listen_modal("browser"))
 
         assert not easy.wait_for_wake.called
+
+    def test_a_wake_gated_mode_is_optional(self, easy):
+        """Dictation captures continuous speech, so it is never wake-gated."""
+        easy.require_wake_word = True
+        easy.wait_for_wake = Mock()
+        drive(easy, [b"a"], ["hello there"])
+
+        with clock():
+            assert list(easy.listen_modal("dictation", wake_gated=False)) == [
+                "hello there"
+            ]
+
+        assert not easy.wait_for_wake.called


### PR DESCRIPTION
require_wake_word gated every mode, including dictation. Dictation captures continuous speech rather than commands, so it asked for the wake word before each sentence, which makes taking a note impossible.

listen_modal takes wake_gated, and dictation passes False. Command modes keep the gate.