### PR TITLE
fix(nix): supply the runtime tools the code actually invokes

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,6 +35,18 @@ the first launch so GNOME loads the bundled extension. See the
 [Packaging guide](packaging.md#install) for offline notes, more languages, and
 hold-to-dictate setup.
 
+## NixOS
+
+The flake carries the runtime tools, the Piper voice and the sound theme, so
+there is no system-package step:
+
+```bash
+nix run github:ctsdownloads/easyspeak
+```
+
+Log out and back in once after the first launch so GNOME loads the bundled
+Shell extension. See [Contributing](contributing.md#nixos) for the dev shell.
+
 ## Install from source
 
 For development, or to run the latest unreleased code, install from the repository.

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,13 @@
           piper-tts # TTS engine
           qutebrowser # browser plugin + "open browser" / help page
           sound-theme-freedesktop # /usr/share/sounds/freedesktop/...
+          wl-clipboard # wl-copy/wl-paste: dictation places text by pasting
+          wireplumber # wpctl: absolute volume levels
+          glib # gsettings for the AT-SPI bridge, gdbus for the Shell extension
+          dbus # dbus-send: MPRIS media player detection
+          pipewire # pw-play, preferred over paplay when present
+          xdg-utils # xdg-open: the files plugin
+          procps # pgrep/pkill: the browser and apps plugins
         ];
 
         # Native toolchain needed when uv compiles wheels from source


### PR DESCRIPTION
runtimeTools carried five entries while the code shells out to seventeen binaries. Dictation could not paste without wl-clipboard, volume levels had no wpctl, the AT-SPI bridge had no gsettings, the Shell extension had no gdbus, and media player detection had no dbus-send, which is why 'play' reported no player while one was running.

gnome-shell and flatpak stay out: both are guarded by shutil.which, and pulling GNOME Shell into the closure is a lot for something a GNOME system already has.

installation.md gains a NixOS section. It claimed NixOS was tested while the only instructions lived under a contributor heading in contributing.md.