### PR TITLE
Detect ad blocking by asking qutebrowser, not a stray python3

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
           ffmpeg # ffplay for TTS playback (NOT -headless; that strips SDL)
           pulseaudio # paplay for the wake-word chime
           piper-tts # TTS engine
-          qutebrowser # browser plugin + "open browser" / help page
+          qutebrowser # browser plugin + "open browser" / help page (bundles python-adblock)
           sound-theme-freedesktop # /usr/share/sounds/freedesktop/...
           wl-clipboard # wl-copy/wl-paste: dictation places text by pasting
           wireplumber # wpctl: absolute volume levels

--- a/src/plugins/browser.py
+++ b/src/plugins/browser.py
@@ -179,32 +179,39 @@ REQUIRED_QUTEBROWSER_LINES = [
 ]
 
 
-ADBLOCK_CANDIDATES = ("python3", "/usr/bin/python3", "/usr/bin/python")
-
-
 def adblock_method():
-    """Return the strongest ad-blocking method this system can actually run.
+    """Return the strongest ad-blocking method qutebrowser can actually run.
 
     Ad overlays and newsletter interstitials are numbered like anything else, so
     they take hint numbers away from the page underneath and a spoken hint lands
     on a popup instead of the link the user meant. "both" adds Brave's ABP engine,
-    which is what catches those overlays -- but it needs python-adblock, and
+    which is what catches those overlays -- but it needs the `adblock` module, and
     without it qutebrowser complains on every single page load, which is worse
     than the ads. Host blocking is built in and needs nothing.
 
-    Probed rather than assumed, so installing python-adblock later is picked up on
-    the next start with nothing for the user to edit.
+    The module has to be importable by the interpreter that *runs* qutebrowser,
+    which is often not the `python3` on `PATH`: a virtualenv, a distro package, a
+    Flatpak or a Nix build each ship their own. So this asks qutebrowser itself
+    rather than probing a stray interpreter, which answered correctly only when
+    the two happened to coincide. `--version` lists each optional module as
+    `adblock: <version>` when present and `adblock: no` when not, so a leading
+    digit means "both"; installing the module later is still picked up on the
+    next start. That call imports Qt and so is slow rather than instant, so the
+    15-second timeout is a ceiling for a wedged process, not an expected wait --
+    past it, host blocking (which always works) is assumed.
     """
-    for candidate in ADBLOCK_CANDIDATES:
-        try:
-            probe = subprocess.run(
-                [candidate, "-c", "import adblock"], capture_output=True, check=False
-            )
-        except OSError:
-            continue  # no such interpreter; try the next
-        if probe.returncode == 0:
-            return "both"
-    return "hosts"
+    try:
+        version = subprocess.run(
+            ["qutebrowser", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,  # seconds
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "hosts"  # no qutebrowser, or it hung: host blocking always works
+    available = re.search(r"^\s*adblock:\s*\d", version.stdout, re.MULTILINE)
+    return "both" if available else "hosts"
 
 
 def required_qutebrowser_lines():

--- a/tests/unit/plugins/test_browser.py
+++ b/tests/unit/plugins/test_browser.py
@@ -1,5 +1,6 @@
 """Tests for the browser plugin module."""
 
+import subprocess
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1420,25 +1421,39 @@ def test_listen_for_hint_gives_up_on_a_page_without_hints(
 
 
 @pytest.mark.parametrize(
-    ["probe_result", "expected"],
-    [(Mock(returncode=0), "both"), (Mock(returncode=1), "hosts")],
+    ["adblock_line", "expected"],
+    [("adblock: 0.6.0", "both"), ("adblock: no", "hosts")],
 )
 @patch("subprocess.run")
-def test_adblock_method_follows_what_is_installed(mock_run, probe_result, expected):
-    """ "both" catches ad overlays, but only when python-adblock is there.
+def test_adblock_method_follows_what_qutebrowser_reports(
+    mock_run, adblock_line, expected
+):
+    """ "both" catches ad overlays, but only when qutebrowser has the module.
 
     Without it qutebrowser complains on every page load, which is worse than the
-    ads. Probing means installing it later is picked up on the next start with
-    nothing for the user to edit.
+    ads. `--version` lists `adblock: <version>` when present and `adblock: no`
+    when not, so reading it picks up an install on the next start with nothing for
+    the user to edit.
     """
-    mock_run.return_value = probe_result
+    mock_run.return_value = Mock(
+        stdout=f"qutebrowser v3.7.0\nBackend: QtWebEngine\n{adblock_line}\n"
+    )
 
     assert browser.adblock_method() == expected
+    # The question is whether qutebrowser's own interpreter has the module, so
+    # ask qutebrowser -- not a stray python3 that only coincidentally matches.
+    assert mock_run.call_args.args[0] == ["qutebrowser", "--version"]
 
 
-@patch("subprocess.run", side_effect=OSError("no python3"))
-def test_adblock_method_without_an_interpreter(mock_run):
-    """No way to probe means assume the dependency isn't there."""
+@patch("subprocess.run", side_effect=OSError("no qutebrowser"))
+def test_adblock_method_without_qutebrowser(mock_run):
+    """No qutebrowser to ask means fall back to built-in host blocking."""
+    assert browser.adblock_method() == "hosts"
+
+
+@patch("subprocess.run", side_effect=subprocess.TimeoutExpired("qutebrowser", 15))
+def test_adblock_method_when_version_hangs(mock_run):
+    """A wedged `--version` falls back rather than stalling startup forever."""
     assert browser.adblock_method() == "hosts"
 
 
@@ -1750,22 +1765,16 @@ def test_digit_homophones(spoken, digit):
 
 
 @patch("subprocess.run")
-def test_adblock_probe_falls_through_to_the_system_interpreter(mock_run):
-    """A bare `python3` is the venv's own, which never has a distro package.
+def test_adblock_method_ignores_a_python3_that_is_not_qutebrowsers(mock_run):
+    """The old probe asked whatever `python3` was on PATH and got it wrong.
 
-    Probing only that concludes python-adblock is missing on exactly the setup
-    most likely to have it installed system-wide.
+    Under a virtualenv or Nix, that interpreter is not the one that runs
+    qutebrowser: it can lack the module while qutebrowser bundles it, or carry it
+    while qutebrowser was built without. Only qutebrowser's own `--version` answer
+    counts, so a report that omits an `adblock` version means host blocking.
     """
-    mock_run.side_effect = lambda cmd, **_kw: Mock(
-        returncode=0 if cmd[0] == "/usr/bin/python3" else 1
-    )
+    mock_run.return_value = Mock(stdout="qutebrowser v3.7.0\nBackend: QtWebEngine\n")
 
-    assert browser.adblock_method() == "both"
-
-
-@patch("subprocess.run", side_effect=OSError("no such interpreter"))
-def test_adblock_probe_skips_interpreters_that_are_not_there(mock_run):
-    """A candidate that isn't installed is skipped, not raised."""
     assert browser.adblock_method() == "hosts"
 
 


### PR DESCRIPTION
`adblock_method()` decides whether qutebrowser can run Brave's ABP engine (`both`) or must fall back to built-in host blocking (`hosts`). It ran that check by probing `python3`, `/usr/bin/python3` and `/usr/bin/python` for `import adblock` — but the module has to be importable by the interpreter that actually *runs* qutebrowser, and that is often not the `python3` on `PATH`.

A virtualenv, a distro package, a Flatpak or a Nix build each ship their own interpreter, so the probe answered correctly only when the two happened to coincide, and concluded the module was missing on exactly the packaged installs most likely to have it. Detection runs at daemon startup (`setup()` → `ensure_qutebrowser_config()`), so a wrong answer silently downgrades ad blocking on every launch.

## What changed

`adblock_method()` now reads `qutebrowser --version`, which lists each optional module as `adblock: <version>` when present and `adblock: no` when not, and asks the one interpreter whose answer counts. It falls back to `hosts` when qutebrowser is absent or its version call hangs — the latter bounded by a 15-second ceiling, since `--version` imports Qt and is slow rather than instant. `flake.nix` notes that its bundled qutebrowser carries python-adblock.

This is a portability fix, not a platform patch: it makes ad-block detection correct across virtualenvs and every packaging format that runs qutebrowser under its own interpreter, of which the dev flake is just one.

## Note for review

The current probe wasn't accidental — commit `d28b78e` ("Address review: probe interpreters…") adopted it in response to earlier review feedback, and this reverses that direction. If that thread rejected `--version` for a reason worth keeping, let me know.