### PR TITLE
Adding environment variable for customizing the language of the Whisper model

### DIFF
--- a/src/core/config.py
+++ b/src/core/config.py
@@ -99,6 +99,7 @@ PIPER_BIN = os.environ.get("EASYSPEAK_PIPER_BIN") or _bundled_bin(
 WHISPER_MODEL = os.environ.get("EASYSPEAK_WHISPER_MODEL") or _bundled_model(
     "models", "whisper", "base.en", default="base.en"
 )
+WHISPER_LANG = os.environ.get("EASYSPEAK_WHISPER_LANG", "en")
 WHISPER_COMPUTE_TYPE = os.environ.get("EASYSPEAK_WHISPER_COMPUTE_TYPE", "int8")
 try:
     WHISPER_CPU_THREADS = max(

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -36,6 +36,7 @@ from .config import (
     WHISPER_COMPUTE_TYPE,
     WHISPER_CPU_THREADS,
     WHISPER_MODEL,
+    WHISPER_LANG,
     load_whisper_model,
 )
 from .gnome_extension import ensure_extension
@@ -512,7 +513,7 @@ class EasySpeak:
             initial_prompt=use_prompt,
             beam_size=1,
             vad_filter=True,
-            language="en",
+            language=WHISPER_LANG,
             # Nothing here reads timestamps, and generating them costs tokens.
             without_timestamps=True,
             condition_on_previous_text=False,
@@ -783,9 +784,10 @@ class EasySpeak:
         self.wakeword = WakeWordModel()
 
         logger.info(
-            "Loading Whisper (%s, %s, cpu_threads=%s)...",
+            "Loading Whisper (%s, %s, language=%s, cpu_threads=%s)...",
             WHISPER_MODEL,
             WHISPER_COMPUTE_TYPE,
+            WHISPER_LANG,
             WHISPER_CPU_THREADS or "auto",
         )
         try:


### PR DESCRIPTION
I've added the environment variable "EASYSPEAK_WHISPER_LANG" with default "en" for customizing the language of the Whisper model. Setting the right language improves the results of multilanguage models and reduces switching between several languages.